### PR TITLE
Add @Proxy interface wrapping

### DIFF
--- a/praxiscore-api/src/main/java/org/praxislive/core/ExecutionContext.java
+++ b/praxiscore-api/src/main/java/org/praxislive/core/ExecutionContext.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright 2018 Neil C Smith.
+ * Copyright 2021 Neil C Smith.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3 only, as
@@ -19,45 +19,138 @@
  * Please visit https://www.praxislive.org if you need additional information or
  * have any questions.
  */
-
 package org.praxislive.core;
 
 import java.util.OptionalLong;
 
 /**
- *
- * 
+ * An optional context available from the {@link Root} lookup providing the
+ * ability to query and listen for changes in root state or clock time.
+ * <p>
+ * A Root will be initialized with {@link State#NEW}, move to / between
+ * {@link State#ACTIVE} and {@link State#IDLE}, then move to
+ * {@link State#TERMINATED}. A Root will not return to the NEW state, or any
+ * other state once terminated.
+ * <p>
+ * Time is the local Root time relative to {@link RootHub#getClock()}. Clock
+ * listeners are called whenever the Root's local time changes - the frequency
+ * of changes, and whether the frequency is fixed or variable, is Root
+ * implementation specific.
  */
 public interface ExecutionContext {
 
-    public static enum State {NEW, ACTIVE, IDLE, TERMINATED};
+    /**
+     * Possible states of a Root.
+     */
+    public static enum State {
 
+        /**
+         * Newly created.
+         */
+        NEW,
+        /**
+         * Actively running.
+         */
+        ACTIVE,
+        /**
+         * Idle (optional state). Clock listeners will not be fired when idle,
+         * and other specific root behaviour (eg. display) may be switched off.
+         */
+        IDLE,
+        /**
+         * Terminated.
+         */
+        TERMINATED
+    };
+
+    /**
+     * Add a listener for state changes.
+     *
+     * @param listener state listener, may not be null
+     */
     public void addStateListener(StateListener listener);
 
+    /**
+     * Remove an existing state listener.
+     *
+     * @param listener state listener to remove
+     */
     public void removeStateListener(StateListener listener);
 
+    /**
+     * Add a listener for clock changes. Listeners will be called every time the
+     * Root is active and its local time changes - the frequency of changes, and
+     * whether the frequency is fixed or variable, is Root implementation
+     * specific.
+     *
+     * @param listener clock listener, may not be null
+     */
     public void addClockListener(ClockListener listener);
 
+    /**
+     * Remove an existing clock listener.
+     *
+     * @param listener clock listener to remove
+     */
     public void removeClockListener(ClockListener listener);
 
+    /**
+     * Get the current Root local time in nanoseconds, relative to the RootHub
+     * clock.
+     *
+     * @return time in nanoseconds
+     */
     public long getTime();
-    
+
+    /**
+     * Get the clock time in nanoseconds when the Root last became active. If
+     * the current state is not active, the return value is not valid.
+     *
+     * @return clock time became active
+     */
     public long getStartTime();
-    
+
+    /**
+     * Get the current state of the Root.
+     *
+     * @return current state
+     */
     public State getState();
 
+    /**
+     * Get the optional update period, if the Root implementation guarantees to
+     * update clock time at a fixed frequency.
+     *
+     * @return optional update period
+     */
     public default OptionalLong getPeriod() {
         return OptionalLong.empty();
     }
 
+    /**
+     * Listener called on state changes.
+     */
     public static interface StateListener {
 
+        /**
+         * State changed.
+         * 
+         * @param source execution context
+         */
         public void stateChanged(ExecutionContext source);
 
     }
 
+    /**
+     * Listener called on clock time updates.
+     */
     public static interface ClockListener {
 
+        /**
+         * Called on clock time update.
+         * 
+         * @param source execution context
+         */
         public void tick(ExecutionContext source);
 
     }

--- a/praxiscore-api/src/main/java/org/praxislive/core/ThreadContext.java
+++ b/praxiscore-api/src/main/java/org/praxislive/core/ThreadContext.java
@@ -1,0 +1,61 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright 2021 Neil C Smith.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License version 3 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * version 3 for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License version 3
+ * along with this work; if not, see http://www.gnu.org/licenses/
+ * 
+ *
+ * Please visit https://www.praxislive.org if you need additional information or
+ * have any questions.
+ */
+package org.praxislive.core;
+
+/**
+ * An optional context available from the {@link Root} lookup, providing the
+ * ability to query whether code is running on the Root thread, and to pass
+ * tasks to invoke on the Root thread.
+ */
+public interface ThreadContext {
+
+    /**
+     * Check whether the current thread is the active thread executing inside a
+     * Root update.
+     *
+     * @return current thread is in Root update
+     */
+    public boolean isInUpdate();
+
+    /**
+     * Check whether the current thread is the thread currently driving a Root
+     * implementation. This is a looser check than {@link #isInUpdate()} where a
+     * Root implementation may be driven by an external context - eg. UI event
+     * thread. It will always return true when isInUpdate() returns true. This
+     * method does not return true if a thread has been returned to a pool. As a
+     * guide, it will return true if blocking the current thread would block the
+     * Root from executing.
+     *
+     * @return current thread is Root executing thread
+     */
+    public boolean isRootThread();
+
+    /**
+     * Execute a task on the Root thread. The task should carefully check that
+     * its state is still valid - eg. a component should check that it has not
+     * been removed from the Root hierarchy.
+     *
+     * @param task task to be executed
+     */
+    public void invokeLater(Runnable task);
+
+}

--- a/praxiscore-code/src/main/java/org/praxislive/code/CodeComponent.java
+++ b/praxiscore-code/src/main/java/org/praxislive/code/CodeComponent.java
@@ -135,6 +135,10 @@ public final class CodeComponent<D extends CodeDelegate> implements Component {
         codeCtxt.handleHierarchyChanged();
     }
 
+    CodeContext<D> getCodeContext() {
+        return codeCtxt;
+    }
+    
     ComponentAddress getAddress() {
         return address;
     }

--- a/praxiscore-code/src/main/java/org/praxislive/code/CodeComponent.java
+++ b/praxiscore-code/src/main/java/org/praxislive/code/CodeComponent.java
@@ -32,6 +32,7 @@ import org.praxislive.core.PacketRouter;
 import org.praxislive.core.Port;
 import org.praxislive.core.VetoException;
 import org.praxislive.core.ComponentInfo;
+import org.praxislive.core.ThreadContext;
 import org.praxislive.core.services.Services;
 import org.praxislive.core.services.LogLevel;
 import org.praxislive.core.services.LogService;
@@ -53,7 +54,8 @@ public final class CodeComponent<D extends CodeDelegate> implements Component {
     private ExecutionContext execCtxt;
     private PacketRouter router;
     private LogInfo logInfo;
-
+    private ProxyContext proxyContext;
+    
     CodeComponent() {
 
     }
@@ -95,7 +97,7 @@ public final class CodeComponent<D extends CodeDelegate> implements Component {
         router = null;
         logInfo = null;
         codeCtxt.handleHierarchyChanged();
-        if (parent == null) {
+        if (address == null) {
             codeCtxt.handleDispose();
         }
     }
@@ -151,6 +153,15 @@ public final class CodeComponent<D extends CodeDelegate> implements Component {
                     .orElse(null);
         }
         return router;
+    }
+    
+    ProxyContext getProxyContext() {
+        if (proxyContext == null) {
+            ThreadContext threadCtxt = getLookup().find(ThreadContext.class)
+                    .orElseThrow(UnsupportedOperationException::new);
+            proxyContext = new ProxyContext(this, threadCtxt);
+        }
+        return proxyContext;
     }
 
     ControlAddress getLogToAddress() {

--- a/praxiscore-code/src/main/java/org/praxislive/code/CodeConnector.java
+++ b/praxiscore-code/src/main/java/org/praxislive/code/CodeConnector.java
@@ -44,6 +44,7 @@ import org.praxislive.code.userapi.Inject;
 import org.praxislive.code.userapi.Out;
 import org.praxislive.code.userapi.P;
 import org.praxislive.code.userapi.Property;
+import org.praxislive.code.userapi.Proxy;
 import org.praxislive.code.userapi.ReadOnly;
 import org.praxislive.code.userapi.Ref;
 import org.praxislive.code.userapi.T;
@@ -423,6 +424,10 @@ public abstract class CodeConnector<D extends CodeDelegate> {
         if (inject != null && analyseInjectField(inject, field)) {
             return;
         }
+        Proxy proxy = field.getAnnotation(Proxy.class);
+        if (proxy != null && analyseProxyField(proxy, field)) {
+            return;
+        }
     }
 
     /**
@@ -610,6 +615,18 @@ public abstract class CodeConnector<D extends CodeDelegate> {
         }
     }
 
+    private boolean analyseProxyField(Proxy ann, Field field) {
+        
+        ProxyDescriptor desc = ProxyDescriptor.create(this, ann, field);
+        if (desc != null) {
+            addReference(desc);
+            return true;
+        } else {
+            return false;
+        }
+        
+    }
+    
     private boolean analyseTriggerMethod(T ann, Method method) {
         TriggerControl.Descriptor tdsc
                 = TriggerControl.Descriptor.create(this, ann, method);

--- a/praxiscore-code/src/main/java/org/praxislive/code/ProxyContext.java
+++ b/praxiscore-code/src/main/java/org/praxislive/code/ProxyContext.java
@@ -1,0 +1,190 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright 2021 Neil C Smith.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License version 3 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * version 3 for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License version 3
+ * along with this work; if not, see http://www.gnu.org/licenses/
+ *
+ *
+ * Please visit https://www.praxislive.org if you need additional information or
+ * have any questions.
+ */
+package org.praxislive.code;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.Callable;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.TimeUnit;
+import org.praxislive.core.ThreadContext;
+
+class ProxyContext {
+
+    private final CodeComponent<?> component;
+    private final ThreadContext threadCtxt;
+    private final ProxyLoader loader;
+    private final Map<ProxyKey, ProxyInfo> proxies;
+
+    ProxyContext(CodeComponent<?> component, ThreadContext threadCtxt) {
+        this.component = component;
+        this.threadCtxt = threadCtxt;
+        this.loader = new ProxyLoader(component.getClass().getClassLoader());
+        this.proxies = new HashMap<>();
+    }
+
+    Object wrap(Class<?> type, String name, Object delegate) {
+        if (!type.isInterface()) {
+            throw new IllegalArgumentException("Type is not interface");
+        }
+        var key = new ProxyKey(type, name);
+        var info = proxies.get(key);
+        if (info != null) {
+            info.handler.swap(delegate, false);
+            return type.cast(info.proxy);
+        } else {
+            var handler = new Handler(delegate, false);
+            var proxy = Proxy.newProxyInstance(loader, new Class<?>[]{type}, handler);
+            proxies.put(key, new ProxyInfo(type, proxy, handler));
+            return type.cast(proxy);
+        }
+    }
+
+    void clear(Class<?> type, String name) {
+        var key = new ProxyKey(type, name);
+        var info = proxies.get(key);
+        if (info != null) {
+            info.handler.swap(null, false);
+        }
+    }
+
+    class Handler implements InvocationHandler {
+
+        private Object delegate;
+        private boolean direct;
+
+        private Handler(Object delegate, boolean direct) {
+            this.delegate = delegate;
+            this.direct = direct;
+        }
+
+        @Override
+        public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+            if (threadCtxt.isRootThread()) {
+                return method.invoke(delegate, args);
+            } else {
+                return invokeOffRootThread(proxy, method, args);
+            }
+        }
+
+        private Object invokeOffRootThread(Object proxy, Method method, Object[] args) throws Throwable {
+            synchronized (this) {
+                if (direct) {
+                    throw new UnsupportedOperationException();
+                }
+            }
+            var task = new FutureTask<Object>(new Callable<Object>() {
+                @Override
+                public Object call() throws Exception {
+                    if (component.getAddress() == null) {
+                        throw new IllegalStateException("Invalid component");
+                    }
+                    return method.invoke(delegate, args);
+                }
+
+            });
+            threadCtxt.invokeLater(task);
+            return task.get(10, TimeUnit.SECONDS);
+        }
+
+        private synchronized Object swap(Object delegate, boolean direct) {
+            Object ret = this.delegate;
+            this.delegate = delegate;
+            this.direct = direct;
+            return ret;
+        }
+
+    }
+
+    private static class ProxyLoader extends ClassLoader {
+
+        public ProxyLoader(ClassLoader parent) {
+            super(parent);
+        }
+
+    }
+
+    private static class ProxyKey {
+
+        private final Class<?> type;
+        private final String name;
+
+        private ProxyKey(Class<?> type, String name) {
+            this.type = type;
+            this.name = name;
+        }
+
+        @Override
+        public int hashCode() {
+            int hash = 5;
+            hash = 37 * hash + Objects.hashCode(this.type);
+            hash = 37 * hash + Objects.hashCode(this.name);
+            return hash;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            final ProxyKey other = (ProxyKey) obj;
+            if (!Objects.equals(this.name, other.name)) {
+                return false;
+            }
+            if (!Objects.equals(this.type, other.type)) {
+                return false;
+            }
+            return true;
+        }
+
+        @Override
+        public String toString() {
+            return "ProxyKey{" + "type=" + type + ", name=" + name + '}';
+        }
+
+    }
+
+    private static class ProxyInfo {
+
+        private final Class<?> type;
+        private final Object proxy;
+        private final Handler handler;
+
+        public ProxyInfo(Class<?> type, Object proxy, Handler handler) {
+            this.type = type;
+            this.proxy = proxy;
+            this.handler = handler;
+        }
+
+    }
+
+}

--- a/praxiscore-code/src/main/java/org/praxislive/code/ProxyContext.java
+++ b/praxiscore-code/src/main/java/org/praxislive/code/ProxyContext.java
@@ -102,7 +102,11 @@ class ProxyContext {
                     if (component.getAddress() == null) {
                         throw new IllegalStateException("Invalid component");
                     }
-                    return method.invoke(delegate, args);
+                    try {
+                        return method.invoke(delegate, args);
+                    } finally {
+                        component.getCodeContext().flush();
+                    }
                 }
 
             });

--- a/praxiscore-code/src/main/java/org/praxislive/code/ProxyDescriptor.java
+++ b/praxiscore-code/src/main/java/org/praxislive/code/ProxyDescriptor.java
@@ -1,0 +1,89 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright 2021 Neil C Smith.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License version 3 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * version 3 for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License version 3
+ * along with this work; if not, see http://www.gnu.org/licenses/
+ *
+ *
+ * Please visit https://www.praxislive.org if you need additional information or
+ * have any questions.
+ */
+package org.praxislive.code;
+
+import java.lang.reflect.Field;
+import org.praxislive.code.userapi.Proxy;
+import org.praxislive.core.services.LogLevel;
+
+final class ProxyDescriptor extends ReferenceDescriptor {
+
+    private final Field field;
+    private final Object delegate;
+    
+    private CodeContext<?> context;
+
+    protected ProxyDescriptor(Field field, Object delegate) {
+        super(field.getName());
+        this.field = field;
+        this.delegate = delegate;
+    }
+
+    @Override
+    public void attach(CodeContext<?> context, ReferenceDescriptor previous) {
+        this.context = context;
+        if (previous instanceof ProxyDescriptor) {
+            var prev = (ProxyDescriptor) previous;
+            if (!field.getType().equals(prev.field.getType())) {
+                prev.dispose();
+            }
+        } else if (previous != null) {
+            previous.dispose();
+        }
+        try {
+            var proxy = context.getComponent().getProxyContext()
+                    .wrap(field.getType(), field.getName(), delegate);
+            field.set(context.getDelegate(), proxy);
+        } catch (Exception ex) {
+            context.getLog().log(LogLevel.ERROR, ex);
+        }
+    }
+
+    @Override
+    public void dispose() {
+        if (context != null) {
+            context.getComponent().getProxyContext().clear(field.getType(), field.getName());
+        }
+        context = null;
+    }
+    
+    
+
+    static ProxyDescriptor create(CodeConnector<?> connector, Proxy ann, Field field) {
+        if (!field.getType().isInterface()) {
+            connector.getLog().log(LogLevel.ERROR,
+                    "@Proxy annotated field " + field.getName() + " is not an interface type.");
+            return null;
+        }
+        try {
+            field.setAccessible(true);
+            Object del = field.get(connector.getDelegate());
+            field.set(connector.getDelegate(), null);
+            return new ProxyDescriptor(field, del);
+        } catch (Exception ex) {
+            connector.getLog().log(LogLevel.ERROR, ex,
+                    "Cannot access @Proxy annotated field " + field.getName());
+            return null;
+        }
+    }
+
+}

--- a/praxiscore-code/src/main/java/org/praxislive/code/userapi/Proxy.java
+++ b/praxiscore-code/src/main/java/org/praxislive/code/userapi/Proxy.java
@@ -1,0 +1,49 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright 2021 Neil C Smith.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License version 3 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * version 3 for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License version 3
+ * along with this work; if not, see http://www.gnu.org/licenses/
+ *
+ *
+ * Please visit https://www.praxislive.org if you need additional information or
+ * have any questions.
+ */
+package org.praxislive.code.userapi;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Mark a field referencing an interface implementation to be wrapped by an
+ * interface proxy. The field must refer to the desired implementation after
+ * delegate instantiation - the easiest way is to initialize the field with the
+ * right value. The field value will be wrapped in a proxy, which will be set as
+ * the new field value during code attachment. This way the implementation of
+ * the interface may be freely changed, while the reference passed to external
+ * code remains constant.
+ * <p>
+ * The field type must be that of the desired interface rather than the
+ * implementation.
+ * <p>
+ * By default, the interface will be called on the active root thread, even if
+ * the calling thread is different.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface Proxy {
+
+//    boolean direct() default false;
+}


### PR DESCRIPTION
Add support for interface fields to be wrapped in a proxy that is carried across code changes, such that the reference can be passed as listeners, callbacks, etc. while the implementation can be rewritten at any time.  By default, calls are made on the root thread, and any other thread will wait on the result - direct execution and configurable timeouts to follow.

```java

@Proxy Runnable foo = () -> doFoo();
@Proxy Runnable bar = this::doBar;

public void init() {
    // by this point, foo and bar wrapped in proxies so safe to pass across
    extRef.addRunnable(foo);
}

```

Resolves #28 