### PR TITLE
Ref.Provider for direct injection, and Persist annotation

### DIFF
--- a/praxiscore-code/src/main/java/org/praxislive/code/CodeConnector.java
+++ b/praxiscore-code/src/main/java/org/praxislive/code/CodeConnector.java
@@ -59,6 +59,7 @@ import org.praxislive.core.protocols.ComponentProtocol;
 import org.praxislive.core.types.PMap;
 import org.praxislive.core.types.PString;
 import org.praxislive.core.services.LogBuilder;
+import org.praxislive.core.services.LogLevel;
 
 /**
  * Base class for analysing a {@link CodeDelegate} and creating the resources
@@ -604,15 +605,27 @@ public abstract class CodeConnector<D extends CodeDelegate> {
                 return false;
             }
         }
+        
+        if (ann.provider() != Ref.Provider.class ||
+                Ref.Provider.getDefault().isSupportedType(field.getType())) {
+            InjectRefImpl.Descriptor idsc = InjectRefImpl.Descriptor.create(this, ann, field);
+            if (idsc != null) {
+                addReference(idsc);
+                return true;
+            }
+            // fall through
+        }
 
         PropertyControl.Descriptor pdsc
                 = PropertyControl.Descriptor.create(this, ann, field);
         if (pdsc != null) {
             addControl(pdsc);
             return true;
-        } else {
-            return false;
         }
+        
+        log.log(LogLevel.WARNING, "No handler found for injected field " + field.getName());
+        return false;
+        
     }
 
     private boolean analyseProxyField(Proxy ann, Field field) {

--- a/praxiscore-code/src/main/java/org/praxislive/code/CodeConnector.java
+++ b/praxiscore-code/src/main/java/org/praxislive/code/CodeConnector.java
@@ -43,6 +43,7 @@ import org.praxislive.code.userapi.In;
 import org.praxislive.code.userapi.Inject;
 import org.praxislive.code.userapi.Out;
 import org.praxislive.code.userapi.P;
+import org.praxislive.code.userapi.Persist;
 import org.praxislive.code.userapi.Property;
 import org.praxislive.code.userapi.Proxy;
 import org.praxislive.code.userapi.ReadOnly;
@@ -429,6 +430,10 @@ public abstract class CodeConnector<D extends CodeDelegate> {
         if (proxy != null && analyseProxyField(proxy, field)) {
             return;
         }
+        Persist persist = field.getAnnotation(Persist.class);
+        if (persist != null && analysePersistField(persist, field)) {
+            return;
+        } 
     }
 
     /**
@@ -631,6 +636,18 @@ public abstract class CodeConnector<D extends CodeDelegate> {
     private boolean analyseProxyField(Proxy ann, Field field) {
         
         ProxyDescriptor desc = ProxyDescriptor.create(this, ann, field);
+        if (desc != null) {
+            addReference(desc);
+            return true;
+        } else {
+            return false;
+        }
+        
+    }
+    
+    private boolean analysePersistField(Persist ann, Field field) {
+        
+        PersistDescriptor desc = PersistDescriptor.create(this, ann, field);
         if (desc != null) {
             addReference(desc);
             return true;

--- a/praxiscore-code/src/main/java/org/praxislive/code/InjectRefImpl.java
+++ b/praxiscore-code/src/main/java/org/praxislive/code/InjectRefImpl.java
@@ -1,0 +1,150 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright 2021 Neil C Smith.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License version 3 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * version 3 for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License version 3
+ * along with this work; if not, see http://www.gnu.org/licenses/
+ *
+ *
+ * Please visit https://www.praxislive.org if you need additional information or
+ * have any questions.
+ */
+package org.praxislive.code;
+
+import java.lang.reflect.Field;
+import java.util.Objects;
+import org.praxislive.code.userapi.Inject;
+import org.praxislive.code.userapi.Ref;
+import org.praxislive.core.ExecutionContext;
+import org.praxislive.core.services.LogLevel;
+
+class InjectRefImpl<T> extends Ref<T> {
+
+    private CodeContext<?> context;
+
+    private InjectRefImpl() {
+    }
+
+    private void attach(CodeContext<?> context) {
+        this.context = context;
+    }
+
+    @Override
+    protected void log(Exception ex) {
+        context.getLog().log(LogLevel.ERROR, ex);
+    }
+
+    static class Descriptor<T> extends ReferenceDescriptor {
+
+        private final Field field;
+        private final Ref.Initializer<T> initializer;
+
+        private CodeContext<?> context;
+        private InjectRefImpl<T> ref;
+
+        private Descriptor(CodeConnector<?> connector, Field field, Ref.Initializer<T> initializer) {
+            super(field.getName());
+            this.field = field;
+            this.initializer = initializer;
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public void attach(CodeContext<?> context, ReferenceDescriptor previous) {
+            this.context = context;
+            if (previous instanceof InjectRefImpl.Descriptor) {
+                InjectRefImpl.Descriptor<?> pd = (InjectRefImpl.Descriptor) previous;
+                if (isCompatible(pd)) {
+                    ref = (InjectRefImpl<T>) pd.ref;
+                    pd.ref = null;
+                } else {
+                    pd.dispose();
+                }
+            } else if (previous != null) {
+                previous.dispose();
+            }
+
+            if (ref == null) {
+                ref = new InjectRefImpl<>();
+            }
+
+            ref.attach(context);
+            initAndSet();
+
+        }
+
+        private boolean isCompatible(Descriptor<?> other) {
+            return field.getGenericType().equals(other.field.getGenericType());
+        }
+
+        @Override
+        public void reset(boolean full) {
+            if (full && context.getExecutionContext().getState() != ExecutionContext.State.ACTIVE) {
+                dispose();
+            } else {
+                initAndSet();
+            }
+        }
+
+        @Override
+        public void dispose() {
+            if (ref != null) {
+                ref.dispose();
+            }
+            if (context != null) {
+                try {
+                    field.set(context.getDelegate(), null);
+                } catch (Exception ex) {
+                    context.getLog().log(LogLevel.ERROR, ex);
+                }
+            }
+        }
+        
+        private void initAndSet() {
+            try {
+                ref.reset();
+                initializer.initialize(ref);
+                field.set(context.getDelegate(), ref.get());
+            } catch (Exception ex) {
+                context.getLog().log(LogLevel.ERROR, ex);
+            }
+        }
+
+        static Descriptor<?> create(CodeConnector<?> connector, Inject ann, Field field) {
+
+            try {
+                Class<? extends Provider> handlerCls = ann.provider();
+                Ref.Provider provider;
+                if (handlerCls == Ref.Provider.class) {
+                    provider = Ref.Provider.getDefault();
+                } else {
+                    provider = handlerCls.getConstructor().newInstance();
+                }
+
+                if (provider.isSupportedType(field.getType())) {
+                    Ref.Initializer<?> init = provider.initializerFor(field.getType());
+                    field.setAccessible(true);
+                    return new Descriptor<>(connector, field, Objects.requireNonNull(init));
+                } else {
+                    return null;
+                }
+            } catch (Exception ex) {
+                connector.getLog().log(LogLevel.ERROR, ex);
+                return null;
+            }
+
+        }
+
+    }
+
+}

--- a/praxiscore-code/src/main/java/org/praxislive/code/PersistDescriptor.java
+++ b/praxiscore-code/src/main/java/org/praxislive/code/PersistDescriptor.java
@@ -1,0 +1,126 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright 2021 Neil C Smith.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License version 3 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * version 3 for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License version 3
+ * along with this work; if not, see http://www.gnu.org/licenses/
+ *
+ *
+ * Please visit https://www.praxislive.org if you need additional information or
+ * have any questions.
+ */
+package org.praxislive.code;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+import org.praxislive.code.userapi.Persist;
+import org.praxislive.core.services.LogLevel;
+
+class PersistDescriptor extends ReferenceDescriptor {
+
+    private static final Map<Class<?>, Object> PRIMITIVE_DEFAULTS = Map.of(
+            int.class, Integer.valueOf(0),
+            long.class, Long.valueOf(0),
+            float.class, Float.valueOf(0),
+            double.class, Double.valueOf(0),
+            byte.class, Byte.valueOf((byte) 0),
+            short.class, Short.valueOf((short) 0),
+            boolean.class, Boolean.FALSE,
+            char.class, Character.valueOf((char) 0)
+    );
+
+    private final Field field;
+    private final boolean autoReset;
+    private final boolean autoClose;
+
+    private CodeContext<?> context;
+
+    PersistDescriptor(Field field, boolean autoReset, boolean autoDispose) {
+        super(field.getName());
+        this.field = field;
+        this.autoReset = autoReset;
+        this.autoClose = autoDispose;
+    }
+
+    @Override
+    public void attach(CodeContext<?> context, ReferenceDescriptor previous) {
+        this.context = context;
+        if (previous instanceof PersistDescriptor) {
+            var prev = (PersistDescriptor) previous;
+            if (field.getGenericType().equals(prev.field.getGenericType())
+                    && prev.context != null) {
+                try {
+                    field.set(context.getDelegate(),
+                            prev.field.get(prev.context.getDelegate()));
+                } catch (Exception ex) {
+                    context.getLog().log(LogLevel.ERROR, ex);
+                }
+            } else {
+                prev.dispose();
+            }
+        } else if (previous != null) {
+            previous.dispose();
+        }
+    }
+
+    @Override
+    public void reset(boolean full) {
+        if (full && autoReset) {
+            try {
+                if (autoClose) {
+                    handleAutoClose();
+                }
+                Object def = null;
+                Class<?> type = field.getType();
+                if (type.isPrimitive()) {
+                    def = PRIMITIVE_DEFAULTS.get(type);
+                }
+                field.set(context.getDelegate(), def);
+            } catch (Exception ex) {
+                context.getLog().log(LogLevel.ERROR, ex);
+            }
+        }
+    }
+
+    @Override
+    public void dispose() {
+        if (context == null) {
+            return;
+        }
+        try {
+            if (autoClose) {
+                handleAutoClose();
+            }
+        } catch (Exception ex) {
+            context.getLog().log(LogLevel.ERROR, ex);
+        }
+    }
+
+    private void handleAutoClose() throws Exception {
+        var value = field.get(context.getDelegate());
+        if (value instanceof AutoCloseable) {
+            ((AutoCloseable) value).close();
+        }
+    }
+
+    static PersistDescriptor create(CodeConnector<?> connector, Persist ann, Field field) {
+        try {
+            field.setAccessible(true);
+            return new PersistDescriptor(field, ann.autoReset(), ann.autoClose());
+        } catch (Exception ex) {
+            connector.getLog().log(LogLevel.ERROR, ex);
+            return null;
+        }
+    }
+    
+}

--- a/praxiscore-code/src/main/java/org/praxislive/code/userapi/Inject.java
+++ b/praxiscore-code/src/main/java/org/praxislive/code/userapi/Inject.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright 2018 Neil C Smith.
+ * Copyright 2021 Neil C Smith.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3 only, as
@@ -31,14 +31,23 @@ import java.lang.annotation.Target;
  * created and persisted between code changes. Injected fields do not have ports
  * or controls, and values are not saved to projects.
  * <p>
- * The @Inject annotation may be used on fields of type {@link Ref}, {@link Property},
- * or any field type that can be backed by a Property - String, double, float, int, boolean,
- * PArray, PBytes, any enum, any Serializable implementation, or a List of Serializable
- * subclasses.
- * 
+ * The @Inject annotation may be used on fields of type
+ * {@link Ref}, {@link Property}, or any field type that can be backed by a
+ * Property - String, double, float, int, boolean, PArray, PBytes, any enum.
+ * <p>
+ * The @Inject annotation may also be used on fields of types supported by the
+ * default Ref.Handler, or the custom Ref.Handler specified.
+ *
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.FIELD)
 public @interface Inject {
-    
+
+    /**
+     * A custom {@link Ref.Provider} that can initialize the provided field type.
+     *
+     * @return custom Ref.Handler or default handler
+     */
+    public Class<? extends Ref.Provider> provider() default Ref.Provider.class;
+
 }

--- a/praxiscore-code/src/main/java/org/praxislive/code/userapi/Persist.java
+++ b/praxiscore-code/src/main/java/org/praxislive/code/userapi/Persist.java
@@ -1,0 +1,58 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright 2021 Neil C Smith.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License version 3 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * version 3 for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License version 3
+ * along with this work; if not, see http://www.gnu.org/licenses/
+ *
+ *
+ * Please visit https://www.praxislive.org if you need additional information or
+ * have any questions.
+ */
+package org.praxislive.code.userapi;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotate a field to be persisted between code changes. Unlike injected
+ * fields, persisted fields are not automatically created. Fields may be of any
+ * type, and field types must match exactly between iterations (including
+ * generics) for values to be persisted.
+ * <p>
+ * By default, values will be reset when the root is stopped (idled), and
+ * {@link AutoCloseable} references will be closed when disposed.
+ * <p>
+ * Persisted fields should be used sparingly and with care!
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface Persist {
+
+    /**
+     * Control whether AutoCloseable field values are closed on disposal.
+     *
+     * @return auto close on dispose
+     */
+    boolean autoClose() default true;
+
+    /**
+     * Control whether to reset values on root stop (idle).
+     *
+     * @return auto reset values
+     */
+    boolean autoReset() default true;
+
+}

--- a/praxiscore-code/src/main/java/org/praxislive/code/userapi/Ref.java
+++ b/praxiscore-code/src/main/java/org/praxislive/code/userapi/Ref.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright 2018 Neil C Smith.
+ * Copyright 2021 Neil C Smith.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3 only, as
@@ -22,24 +22,30 @@
 package org.praxislive.code.userapi;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
 /**
- * A generic object holder for safely passing references between different iterations
- * of code.
+ * A generic object holder for safely passing references between different
+ * iterations of code.
  * <p>
- * Use with {@link Inject} eg. {@code @Inject Ref<List<String>> strings;}  Then in
- * init() / setup() use {@code strings.init(ArrayList::new);}
+ * Use with {@link Inject} eg. {@code @Inject Ref<List<String>> strings;} Then
+ * in init() / setup() use {@code strings.init(ArrayList::new);}
  * <p>
  * <strong>Most methods will throw an Exception if init() has not been called
  * with a Supplier function.</strong>
- * 
- * 
- * @param <T>
+ * <p>
+ * The default dispose handler checks if the referenced value is
+ * {@link AutoCloseable} and automatically closes it.
+ *
+ * @param <T> type of reference
  */
 public abstract class Ref<T> {
 
@@ -50,10 +56,11 @@ public abstract class Ref<T> {
     private List<Runnable> resetTasks;
 
     /**
-     * Initialize the reference, calling the supplier function if a value is needed.
-     * 
-     * The supplier may return null although this is not recommended.
-     * 
+     * Initialize the reference, calling the supplier function if a value is
+     * needed.
+     * <p>
+     * The supplier may return null, although this is not recommended.
+     *
      * @param supplier
      * @return this
      */
@@ -64,11 +71,11 @@ public abstract class Ref<T> {
         inited = true;
         return this;
     }
-    
+
     /**
-     * Return the value. The Ref must be initialized by calling 
+     * Return the value. The Ref must be initialized by calling
      * {@link #init(java.util.function.Supplier) init} first.
-     * 
+     *
      * @return value
      */
     public T get() {
@@ -77,20 +84,20 @@ public abstract class Ref<T> {
     }
 
     /**
-     * Disposes the value and clears initialization. Before using the Ref again 
+     * Disposes the value and clears initialization. Before using the Ref again
      * it must be re-initialized.
-     * 
+     *
      * @return this
      */
     public Ref<T> clear() {
         dispose();
         return this;
     }
-    
+
     /**
      * Pass the value to the provided Consumer function. The value must be
      * initialized first.
-     * 
+     *
      * @param consumer
      * @return this
      */
@@ -99,13 +106,14 @@ public abstract class Ref<T> {
         consumer.accept(value);
         return this;
     }
-    
+
     /**
-     * Transform the value using the supplied function. Either an existing or new
-     * value may be returned. If a new value is returned, the value will be replaced
-     * and any {@link #onReset(java.util.function.Consumer) onReset} and 
-     * {@link #onDispose(java.util.function.Consumer) onDispose} handlers called.
-     * 
+     * Transform the value using the supplied function. Either an existing or
+     * new value may be returned. If a new value is returned, the value will be
+     * replaced and any {@link #onReset(java.util.function.Consumer) onReset}
+     * and {@link #onDispose(java.util.function.Consumer) onDispose} handlers
+     * called.
+     *
      * @param function
      * @return this
      */
@@ -120,34 +128,37 @@ public abstract class Ref<T> {
     }
 
     /**
-     * Run an intensive or time consuming function as a background task to update
-     * the value. The function should be self-contained and try not to capture or
-     * access any state from the component. Use the key argument to pass in data
-     * required to compute the new value - ideally not the current contents of the
-     * Ref unless it is immutable or thread-safe.
+     * Run an intensive or time consuming function as a background task to
+     * update the value. The function should be self-contained and try not to
+     * capture or access any state from the component. Use the key argument to
+     * pass in data required to compute the new value - ideally not the current
+     * contents of the Ref unless it is immutable or thread-safe.
      *
-     * @param <K> type of key value 
+     * @param <K> type of key value
      * @param key a key value used by the function to calculate the new value
      * @param function an intensive or time-consuming function
      * @return this
      */
-    public <K> Ref<T> asyncCompute(K key, Function<K,? extends T> function) {
+    public <K> Ref<T> asyncCompute(K key, Function<K, ? extends T> function) {
         throw new UnsupportedOperationException();
     }
-    
-    
+
     /**
-     * Bind something (usually a callback / listener) to the reference, providing for automatic
-     * removal on reset or disposal. This also allows for the easy removal of listeners
-     * that are lambdas or method references, without the need to keep a reference to them.
-     * 
-     * The binder and unbinder arguments will usually be method references for the
-     * add and remove listener methods. The bindee will usually be the listener,
-     * often as a lambda or method reference.
-     * 
-     * @param <V> the type of the value to bind to the reference, usually a callback / listener
-     * @param binder the function to bind the value, usually a method reference on T that accepts a value V
-     * @param unbinder the function to unbind the value, usually a method reference on T that accepts a value V
+     * Bind something (usually a callback / listener) to the reference,
+     * providing for automatic removal on reset or disposal. This also allows
+     * for the easy removal of listeners that are lambdas or method references,
+     * without the need to keep a reference to them.
+     * <p>
+     * The binder and unbinder arguments will usually be method references for
+     * the add and remove listener methods. The bindee will usually be the
+     * listener, often as a lambda or method reference.
+     *
+     * @param <V> the type of the value to bind to the reference, usually a
+     * callback / listener
+     * @param binder the function to bind the value, usually a method reference
+     * on T that accepts a value V
+     * @param unbinder the function to unbind the value, usually a method
+     * reference on T that accepts a value V
      * @param bindee the value, usually a lambda or method reference
      * @return this
      */
@@ -160,19 +171,22 @@ public abstract class Ref<T> {
             if (resetTasks == null) {
                 resetTasks = new ArrayList<>();
             }
-            resetTasks.add(() -> 
-                unbinder.accept(value, bindee)
+            resetTasks.add(()
+                    -> unbinder.accept(value, bindee)
             );
         } catch (Exception ex) {
             log(ex);
         }
         return this;
     }
-    
+
     /**
-     * Pass the value to the provided Consumer function <strong>if one exists.</strong>
-     * Unlike {@link #apply(java.util.function.Consumer) apply} this may be safely called prior to initialization.
-     * 
+     * Pass the value to the provided Consumer function <strong>if one
+     * exists.</strong>
+     * <p>
+     * Unlike {@link #apply(java.util.function.Consumer) apply} this may be
+     * safely called prior to initialization.
+     *
      * @param consumer
      * @return this
      */
@@ -182,11 +196,11 @@ public abstract class Ref<T> {
         }
         return this;
     }
-    
+
     /**
-     * Provide a function to run on the value whenever the Ref is reset - eg. when
-     * the Ref is passed from one iteration of code to the next.
-     * 
+     * Provide a function to run on the value whenever the Ref is reset - eg.
+     * when the Ref is passed from one iteration of code to the next.
+     *
      * @param onResetHandler
      * @return this
      */
@@ -194,12 +208,13 @@ public abstract class Ref<T> {
         this.onResetHandler = onResetHandler;
         return this;
     }
-    
+
     /**
-     * Provide a function to run on the value whenever the value is being disposed of,
-     * either because the Ref has been removed from the code, the root is being stopped,
-     * or {@link #clear() clear} has been explicitly called.
-     * 
+     * Provide a function to run on the value whenever the value is being
+     * disposed of, either because the Ref has been removed from the code, the
+     * root is being stopped, or {@link #clear() clear} has been explicitly
+     * called.
+     *
      * @param onDisposeHandler
      * @return this
      */
@@ -207,7 +222,7 @@ public abstract class Ref<T> {
         this.onDisposeHandler = onDisposeHandler;
         return this;
     }
-    
+
     protected void dispose() {
         disposeValue();
         value = null;
@@ -215,7 +230,7 @@ public abstract class Ref<T> {
         onDisposeHandler = null;
         inited = false;
     }
-    
+
     protected void reset() {
         runResetTasks();
         if (value != null && onResetHandler != null) {
@@ -229,7 +244,7 @@ public abstract class Ref<T> {
         onDisposeHandler = null;
         inited = false;
     }
-    
+
     protected abstract void log(Exception ex);
 
     private void checkInit() {
@@ -237,7 +252,7 @@ public abstract class Ref<T> {
             throw new IllegalStateException("Ref is not inited");
         }
     }
-    
+
     private void runResetTasks() {
         if (resetTasks != null) {
             resetTasks.forEach(r -> {
@@ -250,7 +265,7 @@ public abstract class Ref<T> {
             resetTasks = null;
         }
     }
-    
+
     private void disposeValue() {
         runResetTasks();
         if (value != null && onResetHandler != null) {
@@ -274,5 +289,143 @@ public abstract class Ref<T> {
             }
         }
     }
-    
+
+    /**
+     * Providers initialize Ref instances so that the underlying value can be
+     * used directly as the injected field type.
+     * <p>
+     * A default provider covers some basic types, or a custom handler type may
+     * be set in {@link Inject#handler()}. A custom handler must have a public,
+     * no-arg constructor which registers initializers.
+     */
+    public static abstract class Provider {
+
+        private final Map<Class<?>, Initializer<?>> initializers;
+
+        /**
+         * Constructor. Subclasses should register initializers during
+         * construction.
+         */
+        public Provider() {
+            this.initializers = new LinkedHashMap<>();
+        }
+
+        /**
+         * Acquire the initializer for the given type.
+         *
+         * @param <T> generic type
+         * @param type type
+         * @return initializer for type, or null if not supported
+         */
+        @SuppressWarnings("unchecked")
+        public final <T> Initializer<T> initializerFor(Class<T> type) {
+            return (Initializer<T>) initializers.get(type);
+        }
+
+        /**
+         * The set of types supported by this handler.
+         *
+         * @return supported types
+         */
+        public final Set<Class<?>> supportedTypes() {
+            return Set.copyOf(initializers.keySet());
+        }
+
+        /**
+         * Check if this handler supports the provided type.
+         *
+         * @param type type
+         * @return supported
+         */
+        public final boolean isSupportedType(Class<?> type) {
+            return initializers.containsKey(type);
+        }
+
+        /**
+         * Register an initializer to configure a Ref for the given type. The
+         * initializer should initialize the Ref, as well as add dispose or
+         * other handlers as required.
+         *
+         * @param <T> generic type
+         * @param type type
+         * @param initializer initializer for type
+         */
+        protected final <T> void register(Class<T> type, Initializer<? extends T> initializer) {
+            initializers.put(type, initializer);
+        }
+
+        /**
+         * Register a constructor for the given type. This is a shortcut method
+         * to register an initializer, equivalent to registering
+         * <code>r -> r.init(constructor)</code>. The reference will use the
+         * default disposer that handles {@link AutoCloseable} - see
+         * documentation of {@link Ref}.
+         *
+         * @param <T> generic type
+         * @param type type
+         * @param constructor constructor for type
+         */
+        protected final <T> void provide(Class<T> type, Supplier<? extends T> constructor) {
+            register(type, r -> r.init(constructor));
+        }
+
+        /**
+         * Register a constructor and disposer for the given type. This is a
+         * shortcut method to register an initializer, equivalent to registering
+         * <code>r -> r.init(constructor).onDispose(disposer)</code>.
+         *
+         * @param <T> generic type
+         * @param type type
+         * @param constructor constructor for type
+         * @param disposer disposer for type
+         */
+        protected final <T> void provide(Class<T> type,
+                Supplier<? extends T> constructor,
+                Consumer<? super T> disposer) {
+            register(type, r -> r.init(constructor).onDispose(disposer));
+        }
+
+        /**
+         * Get the default provider. The default provider supports fields of
+         * type List, Map and Set, via ArrayList, LinkedHashMap and
+         * LinkedHashSet respectively.
+         *
+         * @return default provider
+         */
+        public static Provider getDefault() {
+            return DefaultHandler.INSTANCE;
+        }
+
+    }
+
+    /**
+     * A functional type for initializing a Ref, used by Providers.
+     *
+     * @param <T> generic type of Ref
+     */
+    @FunctionalInterface
+    public static interface Initializer<T> {
+
+        /**
+         * Initialize the provided Ref, as well as add handlers for disposal,
+         * etc. if required.
+         *
+         * @param ref Ref to initialize
+         */
+        public void initialize(Ref<T> ref);
+
+    }
+
+    private static final class DefaultHandler extends Provider {
+
+        private final static DefaultHandler INSTANCE = new DefaultHandler();
+
+        public DefaultHandler() {
+            provide(List.class, ArrayList::new);
+            provide(Map.class, LinkedHashMap::new);
+            provide(Set.class, LinkedHashSet::new);
+        }
+
+    }
+
 }


### PR DESCRIPTION
**Add Ref.Provider for direct injection and management of references.**

Add `Ref.Provider` abstract class and `Ref.Initializer` functional interface.
Add default Ref.Provider with initial support for List, Map and Set.
Add optional provider field to `@Inject` annotation for custom providers.
Add implementation (`InjectRefImpl`) and support in CodeConnector.

**Add `@Persist` annotation and implementation.**

Allow for field values to be persisted across code changes. This is a lighter weight alternative to Ref, mainly useful where values are more transient (eg. result of a method call).

By default, resets values on root stop, and closes AutoCloseable on reset / dispose - this behaviour is configurable.

