### PR TITLE
Improve logging and other behaviour under CLI

### DIFF
--- a/praxiscore-launcher-jline/src/main/java/org/praxislive/launcher/jline/JLineTerminalIO.java
+++ b/praxiscore-launcher-jline/src/main/java/org/praxislive/launcher/jline/JLineTerminalIO.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright 2020 Neil C Smith.
+ * Copyright 2021 Neil C Smith.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3 only, as
@@ -29,23 +29,8 @@ import org.praxislive.core.PacketRouter;
 import org.praxislive.core.Value;
 import org.praxislive.core.services.ScriptService;
 import org.praxislive.core.services.Services;
-import org.praxislive.core.syntax.Tokenizer;
 import org.praxislive.core.types.PError;
 import org.praxislive.core.types.PString;
-import java.io.IOException;
-import java.util.Locale;
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.TimeUnit;
-import org.jline.reader.EOFError;
-import org.jline.reader.LineReader;
-import org.jline.reader.LineReaderBuilder;
-import org.jline.reader.UserInterruptException;
-import org.jline.reader.impl.completer.ArgumentCompleter;
-import org.jline.terminal.Terminal;
-import org.jline.terminal.TerminalBuilder;
-import org.jline.utils.AttributedString;
-import org.jline.utils.AttributedStyle;
 import org.praxislive.core.services.SystemManagerService;
 
 /**
@@ -53,24 +38,8 @@ import org.praxislive.core.services.SystemManagerService;
  */
 class JLineTerminalIO extends AbstractRoot {
 
-    static {
-        System.setProperty("org.jline.reader.support.parsedline", "true");
-    }
-
-    private static final String PROMPT = "> ";
-    private static final String CONTINUATION_PROMPT = "- ";
-    private static final String EXIT_PROMPT = "Exit [Y/N] ? ";
-    private static final String EXIT_NOTICE = "Shutting down ...";
-
-    private static final System.Logger LOG = System.getLogger(JLineTerminalIO.class.getName());
-
-    private final BlockingQueue<Response> responses = new LinkedBlockingQueue<>();
-
-    private Thread inputThread;
     private ControlAddress scriptService;
     private ControlAddress fromAddress;
-    private Terminal terminal;
-    private LineReader reader;
 
     @Override
     protected void activating() {
@@ -84,36 +53,12 @@ class JLineTerminalIO extends AbstractRoot {
                 .map(cmp -> ControlAddress.of(cmp, ScriptService.EVAL))
                 .orElseThrow();
         fromAddress = ControlAddress.of(getAddress(), "io");
-        try {
-            terminal = TerminalBuilder
-                    .builder()
-                    .jna(true)
-                    .build();
-            reader = LineReaderBuilder.builder()
-                    .terminal(terminal)
-                    .parser((line, cursor, context) -> {
-                        if (isCompleteScript(line)) {
-                            return new ArgumentCompleter.ArgumentLine(line, cursor);
-                        } else {
-                            throw new EOFError(cursor, cursor, line);
-                        }
-                    })
-                    .option(LineReader.Option.DISABLE_EVENT_EXPANSION, true)
-                    .variable(LineReader.SECONDARY_PROMPT_PATTERN, CONTINUATION_PROMPT)
-                    .build();
-            inputThread = new Thread(this::inputLoop);
-            inputThread.start();
-        } catch (IOException ex) {
-            System.err.println("Unable to start terminal IO");
-            setIdle();
-        }
+        TerminalImpl.getInstance().attach(this);
     }
 
     @Override
     protected void terminating() {
-        if (inputThread != null) {
-            inputThread.interrupt();
-        }
+        TerminalImpl.getInstance().detach(this);
     }
 
     @Override
@@ -126,13 +71,11 @@ class JLineTerminalIO extends AbstractRoot {
                 .map(Value::toString)
                 .collect(Collectors.joining(" "));
 
-        try {
-            responses.put(new Response(output, call.isError()));
-        } catch (InterruptedException ex) {
-            // should never happen
-            LOG.log(System.Logger.Level.ERROR, "Queue threw error", ex);
-        }
+        TerminalImpl.getInstance().postResponse(new Response(output, call.isError()));
+    }
 
+    void postScript(String script) {
+        invokeLater(() -> handleScript(script));
     }
 
     private void handleScript(String script) {
@@ -143,8 +86,12 @@ class JLineTerminalIO extends AbstractRoot {
                             getExecutionContext().getTime(),
                             PString.of(script)));
         } catch (Exception e) {
-            responses.add(new Response("" + e, true));
+            TerminalImpl.getInstance().postResponse(new Response("" + e, true));
         }
+    }
+
+    void postExit() {
+        invokeLater(this::handleExit);
     }
 
     private void handleExit() {
@@ -155,90 +102,6 @@ class JLineTerminalIO extends AbstractRoot {
                     getRouter().route(Call.create(exit, fromAddress,
                             getExecutionContext().getTime()));
                 }, () -> System.exit(0));
-    }
-
-    private boolean isCompleteScript(String script) {
-        try {
-            var tok = new Tokenizer(script);
-            for (var t : tok) {
-                // consume to end
-            }
-            return true;
-        } catch (Exception e) {
-            return false;
-        }
-    }
-
-    private void inputLoop() {
-        while (getState() == State.ACTIVE_RUNNING) {
-            try {
-                var script = reader.readLine(PROMPT);
-                if (script != null && !script.isBlank()) {
-                    invokeLater(() -> handleScript(script));
-                    var response = responses.poll(10, TimeUnit.SECONDS);
-                    if (response == null) {
-                        writeResponse(new Response("Timed out", true));
-                    } else {
-                        writeResponse(response);
-                    }
-                }
-                // make sure response queue empty
-                Response response;
-                while ((response = responses.poll()) != null) {
-                    writeResponse(response);
-                }
-            } catch (UserInterruptException ex) {
-                if (ex.getPartialLine().isBlank()) {
-                    try {
-                        var confirm = reader.readLine(EXIT_PROMPT);
-                        if ("y".equals(confirm.trim().toLowerCase(Locale.ROOT))) {
-                            terminal.writer().println(EXIT_NOTICE);
-                            terminal.flush();
-                            invokeLater(this::handleExit);
-                            Thread.sleep(5000);
-                            // should have exited by now
-                        }
-                    } catch (UserInterruptException ex2) {
-                        // continue
-                    } catch (Exception ex2) {
-                        LOG.log(System.Logger.Level.DEBUG, "Exception in exit question", ex);
-                    }
-                }
-            } catch (Exception ex) {
-                LOG.log(System.Logger.Level.DEBUG, "Exception in input loop", ex);
-
-            }
-        }
-    }
-
-    private void writeResponse(Response response) {
-        if (response.error) {
-            terminal.writer()
-                    .println(new AttributedString("ERR : " + response.message,
-                            AttributedStyle.DEFAULT.foreground(AttributedStyle.RED))
-                            .toAnsi(terminal)
-                    );
-            terminal.flush();
-        } else {
-            terminal.writer()
-                    .println(new AttributedString("--- : " + response.message,
-                            AttributedStyle.DEFAULT.foreground(AttributedStyle.GREEN))
-                            .toAnsi(terminal)
-                    );
-            terminal.flush();
-        }
-    }
-
-    private static class Response {
-
-        final String message;
-        final boolean error;
-
-        private Response(String message, boolean error) {
-            this.message = message;
-            this.error = error;
-        }
-
     }
 
 }

--- a/praxiscore-launcher-jline/src/main/java/org/praxislive/launcher/jline/Response.java
+++ b/praxiscore-launcher-jline/src/main/java/org/praxislive/launcher/jline/Response.java
@@ -1,0 +1,43 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright 2021 Neil C Smith.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License version 3 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * version 3 for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License version 3
+ * along with this work; if not, see http://www.gnu.org/licenses/
+ * 
+ *
+ * Please visit https://www.praxislive.org if you need additional information or
+ * have any questions.
+ */
+
+package org.praxislive.launcher.jline;
+
+class Response {
+
+    final String message;
+    final boolean error;
+
+    Response(String message, boolean error) {
+        this.message = message;
+        this.error = error;
+    }
+    
+    String message() {
+        return message;
+    }
+    
+    boolean error() {
+        return error;
+    }
+
+}

--- a/praxiscore-launcher-jline/src/main/java/org/praxislive/launcher/jline/TerminalImpl.java
+++ b/praxiscore-launcher-jline/src/main/java/org/praxislive/launcher/jline/TerminalImpl.java
@@ -1,0 +1,192 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright 2021 Neil C Smith.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License version 3 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * version 3 for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License version 3
+ * along with this work; if not, see http://www.gnu.org/licenses/
+ * 
+ *
+ * Please visit https://www.praxislive.org if you need additional information or
+ * have any questions.
+ */
+package org.praxislive.launcher.jline;
+
+import java.util.Locale;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.jline.reader.EOFError;
+import org.jline.reader.LineReader;
+import org.jline.reader.LineReaderBuilder;
+import org.jline.reader.UserInterruptException;
+import org.jline.reader.impl.completer.ArgumentCompleter;
+import org.jline.terminal.Terminal;
+import org.jline.terminal.TerminalBuilder;
+import org.jline.utils.AttributedString;
+import org.jline.utils.AttributedStyle;
+import org.praxislive.core.syntax.Tokenizer;
+
+class TerminalImpl {
+
+    static {
+        System.setProperty("org.jline.reader.support.parsedline", "true");
+    }
+
+    private static final String PROMPT = "> ";
+    private static final String CONTINUATION_PROMPT = "- ";
+    private static final String EXIT_PROMPT = "Exit [Y/N] ? ";
+    private static final String EXIT_NOTICE = "Shutting down ...";
+
+    private static final System.Logger LOG = System.getLogger(JLineTerminalIO.class.getName());
+
+    private static final TerminalImpl INSTANCE = new TerminalImpl();
+
+    private final BlockingQueue<Response> responses;
+    private final AtomicReference<JLineTerminalIO> service;
+
+    private Thread inputThread;
+    private Terminal terminal;
+    private LineReader reader;
+
+    private TerminalImpl() {
+        responses = new LinkedBlockingQueue<>(200);
+        service = new AtomicReference<>();
+    }
+
+    synchronized void attach(JLineTerminalIO service) {
+        this.service.set(service);
+        if (terminal == null) {
+            try {
+                terminal = TerminalBuilder
+                        .builder()
+                        .jna(true)
+                        .build();
+                reader = LineReaderBuilder.builder()
+                        .terminal(terminal)
+                        .parser((line, cursor, context) -> {
+                            if (isCompleteScript(line)) {
+                                return new ArgumentCompleter.ArgumentLine(line, cursor);
+                            } else {
+                                throw new EOFError(cursor, cursor, line);
+                            }
+                        })
+                        .option(LineReader.Option.DISABLE_EVENT_EXPANSION, true)
+                        .variable(LineReader.SECONDARY_PROMPT_PATTERN, CONTINUATION_PROMPT)
+                        .build();
+                inputThread = new Thread(this::inputLoop);
+                inputThread.start();
+            } catch (Exception ex) {
+                LOG.log(System.Logger.Level.ERROR, "Unable to start terminal IO", ex);
+            }
+        }
+    }
+
+    synchronized void detach(JLineTerminalIO service) {
+        if (this.service.compareAndSet(service, null)) {
+            postResponse(new Response("", false));
+        }
+    }
+
+    synchronized void postResponse(Response response) {
+        if (terminal != null) {
+            responses.add(response);
+        }
+    }
+
+    private void inputLoop() {
+
+        while (true) {
+            try {
+                var script = reader.readLine(PROMPT);
+                if (script != null && !script.isBlank()) {
+                    var root = service.get();
+                    if (root != null) {
+                        root.postScript(script);
+                        var response = responses.poll(10, TimeUnit.SECONDS);
+                        if (response == null) {
+                            writeResponse(new Response("Timed out", true));
+                        } else {
+                            writeResponse(response);
+                        }
+                    } else {
+                        writeResponse(new Response("Not running", true));
+                    }
+                }
+                // make sure response queue empty
+                Response response;
+                while ((response = responses.poll()) != null) {
+                    writeResponse(response);
+                }
+            } catch (UserInterruptException ex) {
+                if (ex.getPartialLine().isBlank()) {
+                    try {
+                        var confirm = reader.readLine(EXIT_PROMPT);
+                        if ("y".equals(confirm.trim().toLowerCase(Locale.ROOT))) {
+                            terminal.writer().println(EXIT_NOTICE);
+                            terminal.flush();
+                            var root = service.get();
+                            if (root != null) {
+                                root.postExit();
+                                Thread.sleep(5000);
+                                // should have exited by now - fall through
+                            }
+                            System.exit(0);
+                        }
+                    } catch (UserInterruptException ex2) {
+                        // continue
+                    } catch (Exception ex2) {
+                        LOG.log(System.Logger.Level.DEBUG, "Exception in exit question", ex);
+                    }
+                }
+            } catch (Exception ex) {
+                LOG.log(System.Logger.Level.DEBUG, "Exception in input loop", ex);
+            }
+        }
+    }
+
+    private synchronized void writeResponse(Response response) {
+        if (response.error) {
+            terminal.writer()
+                    .println(new AttributedString("ERR : " + response.message,
+                            AttributedStyle.DEFAULT.foreground(AttributedStyle.RED))
+                            .toAnsi(terminal)
+                    );
+            terminal.flush();
+        } else {
+            terminal.writer()
+                    .println(new AttributedString("--- : " + response.message,
+                            AttributedStyle.DEFAULT.foreground(AttributedStyle.GREEN))
+                            .toAnsi(terminal)
+                    );
+            terminal.flush();
+        }
+    }
+
+    private boolean isCompleteScript(String script) {
+        try {
+            var tok = new Tokenizer(script);
+            for (var t : tok) {
+                // consume to end
+            }
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    static TerminalImpl getInstance() {
+        return INSTANCE;
+    }
+
+}

--- a/praxiscore-launcher/src/main/java/org/praxislive/launcher/Launcher.java
+++ b/praxiscore-launcher/src/main/java/org/praxislive/launcher/Launcher.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright 2020 Neil C Smith.
+ * Copyright 2021 Neil C Smith.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3 only, as
@@ -36,9 +36,11 @@ import java.util.Arrays;
 import java.util.Optional;
 import java.util.ServiceLoader;
 import java.util.concurrent.Callable;
+import java.util.function.BiConsumer;
 import org.praxislive.code.CodeCompilerService;
 import org.praxislive.core.Lookup;
 import org.praxislive.core.Root;
+import org.praxislive.core.services.LogLevel;
 import org.praxislive.hub.net.NetworkCoreFactory;
 import picocli.CommandLine;
 
@@ -282,8 +284,13 @@ public class Launcher {
                     hubBuilder.addExtension(new ScriptRunner(List.of(script)));
                 }
                 if (interactive) {
-                    hubBuilder.addExtension(createTerminalIO());
+                    var terminalIO = createTerminalIO();
+                    hubBuilder.addExtension(terminalIO);
                 }
+
+                var logLevel = LogLevel.INFO;
+                hubBuilder.addExtension(new LogServiceImpl(logLevel));
+                hubBuilder.extendLookup(logLevel);
 
                 var hub = hubBuilder.build();
                 hub.start();
@@ -378,7 +385,7 @@ public class Launcher {
             var ansiMsg = CommandLine.Help.Ansi.AUTO.string(
                     "@|bold,red " + msg + "|@"
             );
-            System.err.println(ansiMsg);
+            System.out.println(ansiMsg);
         }
 
     }

--- a/praxiscore-launcher/src/main/java/org/praxislive/launcher/LogServiceImpl.java
+++ b/praxiscore-launcher/src/main/java/org/praxislive/launcher/LogServiceImpl.java
@@ -1,0 +1,92 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright 2021 Neil C Smith.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License version 3 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * version 3 for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License version 3
+ * along with this work; if not, see http://www.gnu.org/licenses/
+ *
+ *
+ * Please visit https://www.praxislive.org if you need additional information or
+ * have any questions.
+ *
+ */
+
+package org.praxislive.launcher;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.List;
+import java.util.Objects;
+import org.praxislive.base.AbstractRoot;
+import org.praxislive.core.Call;
+import org.praxislive.core.PacketRouter;
+import org.praxislive.core.RootHub;
+import org.praxislive.core.services.LogLevel;
+import org.praxislive.core.services.LogService;
+import org.praxislive.core.services.Service;
+import org.praxislive.core.types.PError;
+
+class LogServiceImpl extends AbstractRoot implements RootHub.ServiceProvider {
+    
+    private final LogLevel logLevel;
+    
+    LogServiceImpl(LogLevel logLevel) {
+        this.logLevel = Objects.requireNonNull(logLevel);
+    }
+
+    @Override
+    public List<Class<? extends Service>> services() {
+        return List.of(LogService.class);
+    }
+
+    @Override
+    protected void processCall(Call call, PacketRouter router) {
+        if (call.isRequest()) {
+            try {
+                processLog(call);
+                if (call.isReplyRequired()) {
+                    router.route(call.reply());
+                }
+            } catch (Exception ex) {
+                router.route(call.error(PError.of(ex)));
+            }
+        }
+    }
+    
+    private void processLog(Call call) throws Exception {
+        var src = call.from().component();
+        var args = call.args();
+        for (int i = 1; i < args.size(); i += 2) {
+            var level = LogLevel.valueOf(args.get(i - 1).toString());
+            if (!logLevel.isLoggable(level)) {
+                continue;
+            }
+            var arg = args.get(i);
+            var sw = new StringWriter();
+            var pw = new PrintWriter(sw);
+            pw.append(level.name()).append(" : ").append(src.toString()).println();
+            if (arg instanceof PError) {
+                var err = (PError) arg;
+                pw.append(err.exceptionType().getSimpleName()).append(" - ");
+                pw.append(err.message()).append("\n");
+                err.exception().ifPresent(ex -> ex.printStackTrace(pw));
+            } else {
+                pw.append(arg.toString()).println();
+            }
+            pw.flush();
+            System.err.println(sw.toString());
+        }
+        System.err.flush();
+    }
+
+}


### PR DESCRIPTION
Add a default logging handler to launcher module to output log messages to System.err / stderr.

Use a single terminal interface across multiple hubs by splitting out JLine interaction into a singleton class used by JLineTerminalIO services. Fixes issues when using networked hubs when hub may be restarted inside single process.

Fix uncaught exceptions in AbstractRoot::processPacket not sending an error reply (noticed while testing above).