### PR TITLE
Initial test suite support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,27 @@
+name: Test Suite
+
+on:
+  [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+          cache: 'maven'
+      - name: Build with Maven
+        run: mvn --batch-mode --update-snapshots install
+      - name: Assemble PraxisCORE
+        run: |
+          mvn --batch-mode -f ./praxiscore-bin package appassembler:assemble
+          mv ./praxiscore-bin/target/appassembler ./CORE
+          ./CORE/bin/praxis --show-environment
+      - name: Run Test Suite
+        run: ./CORE/bin/praxis -f ./testsuite/
+

--- a/praxiscore-api/src/main/java/org/praxislive/core/services/SystemManagerService.java
+++ b/praxiscore-api/src/main/java/org/praxislive/core/services/SystemManagerService.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright 2020 Neil C Smith.
+ * Copyright 2021 Neil C Smith.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3 only, as
@@ -21,29 +21,33 @@
  */
 package org.praxislive.core.services;
 
-import java.util.List;
 import java.util.stream.Stream;
+import org.praxislive.core.ArgumentInfo;
 import org.praxislive.core.ControlInfo;
-import org.praxislive.core.types.PMap;
+import org.praxislive.core.Info;
+import org.praxislive.core.types.PBoolean;
+import org.praxislive.core.types.PNumber;
 
 /**
- * 
+ *
  */
 public class SystemManagerService implements Service {
-
+    
     public final static String SYSTEM_EXIT = "system-exit";
-
+    
     public final static ControlInfo SYSTEM_EXIT_INFO
-            = ControlInfo.createFunctionInfo(
-                    List.of(),
-                    List.of(),
-                    PMap.EMPTY);
-
+            = Info.control(c -> c.function()
+                .inputs(i -> i.type(PNumber.class)
+                    .property(PNumber.KEY_IS_INTEGER, PBoolean.TRUE)
+                    .property(ArgumentInfo.KEY_OPTIONAL, PBoolean.TRUE)
+                )
+            );
+    
     @Override
     public Stream<String> controls() {
         return Stream.of(SYSTEM_EXIT);
     }
-
+    
     @Override
     public ControlInfo getControlInfo(String control) {
         if (SYSTEM_EXIT.equals(control)) {
@@ -51,5 +55,5 @@ public class SystemManagerService implements Service {
         }
         throw new IllegalArgumentException();
     }
-
+    
 }

--- a/praxiscore-hub/src/main/java/org/praxislive/hub/Hub.java
+++ b/praxiscore-hub/src/main/java/org/praxislive/hub/Hub.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  * 
- * Copyright 2020 Neil C Smith.
+ * Copyright 2021 Neil C Smith.
  * 
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3 only, as
@@ -119,6 +119,14 @@ public final class Hub {
     
     public boolean isAlive() {
         return coreThread.isAlive();
+    }
+    
+    public int exitValue() {
+        if (core instanceof BasicCoreRoot) {
+            return ((BasicCoreRoot) core).exitValue();
+        } else {
+            return 0;
+        }
     }
 
     private boolean registerRootController(String id, Root.Controller controller) {

--- a/praxiscore-launcher/src/main/java/org/praxislive/launcher/Launcher.java
+++ b/praxiscore-launcher/src/main/java/org/praxislive/launcher/Launcher.java
@@ -258,6 +258,8 @@ public class Launcher {
             }
 
             final var main = new MainThreadImpl();
+            
+            int exitValue = 0;
 
             do {
                 var coreBuilder = NetworkCoreFactory.builder()
@@ -304,10 +306,12 @@ public class Launcher {
                     out(LISTENING_STATUS + port);
                 }
                 main.run(hub);
+                
+                exitValue = hub.exitValue();
 
             } while (requireServer);
 
-            return 0;
+            return exitValue;
         }
 
         private void installChildSignalOverrides() {

--- a/testsuite/project.pxp
+++ b/testsuite/project.pxp
@@ -1,0 +1,13 @@
+hub {
+
+}
+compiler {
+  release 11
+}
+libraries {}
+
+# <<<BUILD>>>
+include [file "runner.pxr"]
+
+# <<<RUN>>>
+/runner.start

--- a/testsuite/runner.pxr
+++ b/testsuite/runner.pxr
@@ -1,0 +1,223 @@
+@ /runner root:data {
+  #%praxis.version 5.3.0
+  .shared-code "SHARED.Utils \{package SHARED;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
+import java.util.concurrent.FutureTask;
+import java.util.stream.Collectors;
+import com.sun.jna.Platform;
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public class Utils \{
+
+    public static Path findLauncher() throws Exception \{
+        var launcherName = Platform.isWindows() ? \"praxis.bat\" : \"praxis\";
+        var appHome = System.getProperty(\"app.home\");
+        if (appHome != null) \{
+            Path launcher = Path.of(appHome)
+                    .resolve(\"bin\")
+                    .resolve(launcherName);
+            if (Files.exists(launcher)) \{
+                return launcher;
+            \}
+        \}
+        // try if running inside IDE
+        var nbHome = System.getProperty(\"netbeans.home\");
+        if (nbHome != null) \{
+            Path launcher = Path.of(nbHome).getParent()
+                    .resolve(\"praxiscore\")
+                    .resolve(\"bin\")
+                    .resolve(launcherName);
+            if (Files.exists(launcher)) \{
+                return launcher;
+            \}
+        \}
+        throw new IllegalStateException(\"No launcher found\");
+    \}
+
+    public static Future<String> collectOutput(Process process) \{
+        Callable<String> task = () -> \{
+            try (var in = new BufferedReader(new InputStreamReader(process.getInputStream()))) \{
+                String ret = in.lines().collect(Collectors.joining(System.lineSeparator()));
+//                int exit = process.waitFor();
+//                if (exit != 0) \{
+//                    ret = ret + System.lineSeparator()
+//                            + \"<FAIL> Test process output : \" + exit;
+//                \}
+                return ret;
+            \}
+        \};
+        FutureTask<String> future = new FutureTask<>(task) \{
+
+            @Override
+            public boolean cancel(boolean mayInterruptIfRunning) \{
+                process.destroy();
+                return super.cancel(mayInterruptIfRunning);
+            \}
+
+        \};
+        new Thread(future).start();
+        return future;
+    \}
+
+\}
+\}"
+  @ ./start core:start-trigger {
+    #%graph.x 66
+    #%graph.y 79
+  }
+  @ ./exit core:custom {
+    #%graph.x 599
+    #%graph.y 79
+    .code "
+
+    @T(1)
+    void exitOK() \{
+        tellIn(0.2, self(\"exit\"), 0);
+    \}
+
+    @T(2)
+    void exitFail() \{
+        tellIn(0.2, self(\"exit\"), 1);
+    \}
+
+    @In(1) @Config.Port(false)
+    void exit(int value) \{
+        System.exit(value);
+    \}
+
+"
+  }
+  @ ./test-exec core:custom {
+    #%graph.x 309
+    #%graph.y 79
+    .code "import java.nio.file.Path;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import SHARED.Utils;
+import java.nio.file.Files;
+
+
+    final long TIMEOUT = Long.getLong(\"testsuite.timeout\", 20000);
+    final String SEP = System.lineSeparator();
+    
+    @P(1)
+    Optional<PResource> configuration;
+
+    @Out(1) Output done;
+    @Out(2) Output failed;
+
+    @Inject List<Path> tests;
+
+    @Persist Process process;
+    @Persist Future<String> result;
+    @Persist long processStart;
+    @Persist Path launcher;
+
+    @T(1) public void start() \{
+        stop();
+        try \{
+            launcher = Utils.findLauncher();
+            tests.addAll(readConfig());
+            logTests();
+            execNextTest();
+        \} catch (Exception ex) \{
+            log(ERROR, ex.toString());
+            failed.send();
+            return;
+        \}
+    \}
+
+    @T(2) public void stop() \{
+        if (process != null) \{
+            process.destroy();
+            process = null;
+        \}
+        result = null;
+        tests.clear();
+    \}
+
+    @Override
+    public void update() \{
+        if (result == null) \{
+            return;
+        \}
+        if (result.isDone()) \{
+            try \{
+                String output = result.get();
+                if (output.contains(\"<FAIL>\") || output.contains(\"<ERROR>\")) \{
+                    log(ERROR, output + SEP + \"TEST FAILED\" + SEP);
+                    stop();
+                    failed.send();
+                \} else \{
+                    log(INFO, output + SEP + \"TEST PASSED\" + SEP);
+                    execNextTest();
+                \}
+            \} catch (Exception ex) \{
+                log(ERROR, SEP + \"TEST EXCEPTION\" + SEP + ex.toString() + SEP);
+                stop();
+                failed.send();
+            \}
+        \} else if ((millis() - processStart) > TIMEOUT) \{
+            log(ERROR, SEP + \"<FAIL> TEST TIMEOUT\" + SEP);
+            if (process != null) \{
+                process.destroy();
+            \}
+            try \{
+                log(ERROR, result.get(2, TimeUnit.SECONDS));
+            \} catch (Exception ex) \{
+                log(ERROR, \"No output\");
+            \}
+            stop();
+            failed.send();
+        \}
+    \}
+    
+    private List<Path> readConfig() throws Exception \{
+        var conf = configuration.get().value();
+        return PArray.parse(Files.readString(Path.of(conf))).stream()
+                .map(rel -> conf.resolve(rel.toString()))
+                .map(Path::of)
+                .collect(Collectors.toList());
+    \}
+
+    private void logTests() \{
+        var output = tests.stream()
+                .map(Path::toString)
+                .collect(Collectors.joining(
+                        SEP, \"TEST SUITE\" + SEP + \"==========\" + SEP, SEP));
+        log(INFO, output);
+    \}
+
+    private void execNextTest() throws Exception \{
+        if (tests.isEmpty()) \{
+            stop();
+            done.send();
+            return;
+        \}
+        var test = tests.remove(0);
+        log(INFO, SEP + \"STARTING TEST : \" + test + SEP);
+        var pb = new ProcessBuilder(launcher.toString(), \"--file\", test.toString());
+        var javaHome = System.getProperty(\"java.home\");
+        if (javaHome != null) \{
+            pb.environment().put(\"JAVA_HOME\", javaHome);
+        \}
+        pb.redirectErrorStream(true);
+        processStart = millis();
+        process = pb.start();
+        log(INFO, process.info().toString());
+        result = Utils.collectOutput(process);
+    \}
+    
+"
+    .configuration [file "tests/config"]
+  }
+  ~ ./test-exec!done ./exit!exit-ok
+  ~ ./test-exec!failed ./exit!exit-fail
+  ~ ./start!out ./test-exec!start
+}

--- a/testsuite/tests/config
+++ b/testsuite/tests/config
@@ -1,0 +1,4 @@
+# Core tests
+
+core/testcheck
+core/components

--- a/testsuite/tests/core/components/data.pxr
+++ b/testsuite/tests/core/components/data.pxr
@@ -1,0 +1,269 @@
+@ /data root:data {
+  #%praxis.version 5.3.0
+  #%graph.comment Check all built-in core components can be created.
+  #%graph.properties Show
+  @ ./start-trigger core:start-trigger {
+    #%graph.x 170
+    #%graph.y 160
+  }
+  @ ./exit core:custom {
+    #%graph.x 1474
+    #%graph.y 227
+    .code "
+
+    @T(1)
+    void exitOK() \{
+        tellIn(0.2, self(\"exit\"), 0);
+    \}
+
+    @T(2)
+    void exitFail() \{
+        tellIn(0.2, self(\"exit\"), 1);
+    \}
+
+    @In(1) @Config.Port(false)
+    void exit(int value) \{
+        System.exit(value);
+    \}
+
+"
+  }
+  @ ./container core:container {
+    #%graph.x 420
+    #%graph.y 290
+    #%praxis.version 5.3.0
+    .ports "delay-in delay!in delay-out delay!out"
+    @ ./delay core:timing:delay {
+      #%graph.x 472
+      #%graph.y 296
+      .time 0.1
+    }
+  }
+  @ ./property core:property {
+    #%graph.x 571
+    #%graph.y 722
+    .value Hello
+  }
+  @ ./tracker core:tracker {
+    #%graph.x 651
+    #%graph.y 138
+    .patterns "Hello . . .
+World . . .
+.
+.
+.
+.
+.
+.
+.
+.
+.
+.
+.
+.
+.
+.
+"
+  }
+  @ ./variable core:variable {
+    #%graph.x 1049
+    #%graph.y 689
+    .value World
+  }
+  @ ./iterator core:array:iterator {
+    #%graph.x 649
+    #%graph.y 529
+    .values [array Hello World]
+  }
+  @ ./order core:routing:order {
+    #%graph.x 800
+    #%graph.y 689
+  }
+  @ ./random core:array:random {
+    #%graph.x 303
+    #%graph.y 649
+    #%graph.minimized true
+  }
+  @ ./add core:math:add {
+    #%graph.x 130
+    #%graph.y 848
+    .value 20
+  }
+  @ ./multiply core:math:multiply {
+    #%graph.x 284
+    #%graph.y 854
+    .value 4
+  }
+  @ ./random-number core:math:random {
+    #%graph.x 178
+    #%graph.y 500
+    #%graph.minimized true
+  }
+  @ ./scale core:math:scale {
+    #%graph.x 462
+    #%graph.y 854
+    .x2 100
+    .y2 50
+  }
+  @ ./threshold core:math:threshold {
+    #%graph.x 641
+    #%graph.y 854
+    .threshold 43
+  }
+  @ ./one core:property {
+    #%graph.x 93
+    #%graph.y 755
+    .value 1
+  }
+  @ ./test core:custom {
+    #%graph.x 1303
+    #%graph.y 212
+    .code "
+
+    @P(1) @Transient @Config.Port(false)
+    String str1;
+    @P(2) @Transient @Config.Port(false)
+    String str2;
+    @P(3) @Transient @Config.Port(false)
+    String str3;
+    @P(4) @Transient @Config.Port(false)
+    String str4;
+    @P(5) @Transient @Config.Port(false)
+    int int1;
+
+    @Out(1) Output testOK;
+    @Out(2) Output testFail;
+    
+    @Override
+    public void init() \{
+        str1 = str2 = str3 = str4 = \"\";
+        int1 = 0;
+    \}
+
+    @In(1)
+    void in1(String in) \{
+        str1 = concat(str1, in);
+    \}
+
+    @In(2)
+    void in2(String in) \{
+        str2 = concat(str2, in);
+    \}
+
+    @In(3)
+    void in3(String in) \{
+        str3 = concat(str3, in);
+    \}
+
+    @In(4)
+    void in4(String in) \{
+        str4 = concat(str4, in);
+    \}
+    
+    @In(5)
+    void in5(int in) \{
+        int1 = in;
+    \}
+    
+    @T(1) @Config.Port(false)
+    void test() \{
+        boolean ok = true;
+        if (!\"Hello World\".equals(str1)) \{
+            ok = false;
+            log(ERROR, \"<FAIL> str1 = \" + str1);
+        \}
+        if (!\"Hello World\".equals(str2)) \{
+            ok = false;
+            log(ERROR, \"<FAIL> str2 = \" + str2);
+        \}
+        if (!\"Hello World\".equals(str3)) \{
+            ok = false;
+            log(ERROR, \"<FAIL> str3 = \" + str3);
+        \}
+        if (!\"World\".equals(str4)) \{
+            ok = false;
+            log(ERROR, \"<FAIL> str4 = \" + str4);
+        \}
+        if (int1 != 42) \{
+            ok = false;
+            log(ERROR, \"<FAIL> int1 = \" + int1);
+        \}
+        if (ok) \{
+            log(INFO, \"<PASS> all value tests passed\");
+            testOK.send();
+        \} else \{
+            testFail.send();
+        \}
+    \}
+
+    private String concat(String existing, String input) \{
+        return existing.isEmpty() ? input : existing + \" \" + input;
+    \}
+
+
+"
+  }
+  @ ./every core:routing:every {
+    #%graph.x 178
+    #%graph.y 552
+    #%graph.minimized true
+  }
+  @ ./gate core:routing:gate {
+    #%graph.x 858
+    #%graph.y 294
+    .active true
+    .pattern [array 0 1]
+  }
+  @ ./animator core:timing:animator {
+    #%graph.x 303
+    #%graph.y 595
+    #%graph.minimized true
+  }
+  @ ./timer core:timing:timer {
+    #%graph.x 174
+    #%graph.y 595
+    .period 0.5
+  }
+  @ ./join core:routing:join {
+    #%graph.x 1303
+    #%graph.y 543
+  }
+  @ ./inhibitor core:routing:inhibitor {
+    #%graph.x 1287
+    #%graph.y 716
+    .time 60
+  }
+  @ ./send core:routing:send {
+    #%graph.x 183
+    #%graph.y 396
+    .address /data/test.test
+  }
+  @ ./test-delay core:timing:delay {
+    #%graph.x 178
+    #%graph.y 255
+    .time 0.5
+  }
+  ~ ./start-trigger!out ./container!delay-in
+  ~ ./start-trigger!out ./tracker!trigger
+  ~ ./container!delay-out ./tracker!trigger
+  ~ ./property!out ./order!in
+  ~ ./order!out-2 ./variable!trigger
+  ~ ./one!out ./add!in
+  ~ ./add!out ./multiply!in
+  ~ ./multiply!out ./scale!in
+  ~ ./scale!out ./threshold!in
+  ~ ./tracker!out-1 ./test!in-1
+  ~ ./variable!out ./test!in-3
+  ~ ./order!out-1 ./test!in-3
+  ~ ./iterator!out ./test!in-2
+  ~ ./iterator!out ./gate!in
+  ~ ./gate!out ./test!in-4
+  ~ ./threshold!out-low ./test!in-5
+  ~ ./start-trigger!out ./iterator!reset
+  ~ ./start-trigger!out ./iterator!trigger
+  ~ ./container!delay-out ./iterator!trigger
+  ~ ./start-trigger!out ./test-delay!in
+  ~ ./test-delay!out ./send!in
+  ~ ./test!test-ok ./exit!exit-ok
+  ~ ./test!test-fail ./exit!exit-fail
+}

--- a/testsuite/tests/core/components/data.pxr
+++ b/testsuite/tests/core/components/data.pxr
@@ -9,21 +9,24 @@
   @ ./exit core:custom {
     #%graph.x 1474
     #%graph.y 227
-    .code "
+    .code "import org.praxislive.core.services.Services;
+import org.praxislive.core.services.SystemManagerService;
+
 
     @T(1)
     void exitOK() \{
-        tellIn(0.2, self(\"exit\"), 0);
+        exit(0);
     \}
 
     @T(2)
     void exitFail() \{
-        tellIn(0.2, self(\"exit\"), 1);
+        exit(1);
     \}
 
-    @In(1) @Config.Port(false)
-    void exit(int value) \{
-        System.exit(value);
+    private void exit(int exitValue) \{
+        find(Services.class)
+                .flatMap(s -> s.locate(SystemManagerService.class))
+                .ifPresent(s -> tell(ControlAddress.of(s, \"system-exit\"), exitValue));
     \}
 
 "

--- a/testsuite/tests/core/components/project.pxp
+++ b/testsuite/tests/core/components/project.pxp
@@ -1,0 +1,38 @@
+hub {
+  enable-fileserver false
+  proxies {
+    video {
+      host localhost
+      port auto
+      id-pattern *
+      type-pattern video
+      exec {
+        command default
+        java-options {
+          -XstartOnFirstThread
+          -XX:+IgnoreUnrecognizedVMOptions
+          -Djava.awt.headless=true
+        }
+      }
+    }
+    audio {
+      host localhost
+      port auto
+      id-pattern *
+      type-pattern audio
+      exec {
+        command default
+      }
+    }
+  }
+}
+compiler {
+  release 11
+}
+libraries {}
+
+# <<<BUILD>>>
+include [file "data.pxr"]
+
+# <<<RUN>>>
+/data.start

--- a/testsuite/tests/core/testcheck/data.pxr
+++ b/testsuite/tests/core/testcheck/data.pxr
@@ -1,0 +1,70 @@
+@ /data root:data {
+  #%praxis.version 5.3.0
+  #%graph.comment A test to test tests!\n\nCheck a value is correctly set and exit.
+  @ ./start-trigger core:start-trigger {
+    #%graph.x 106
+    #%graph.y 144
+  }
+  @ ./test core:custom {
+    #%graph.x 666
+    #%graph.y 144
+    .code "
+
+    int value;
+    
+    @Out(1) Output testOK;
+    @Out(2) Output testFail;
+
+    @Override
+    public void init() \{
+        value = 24;
+    \}
+    
+    @T(1) void set() \{
+        value = 42;
+    \}
+    
+    @T(2) void test() \{
+        if (value == 42) \{
+            log(INFO, \"<PASS> Value is 42\");
+            testOK.send();
+        \} else \{
+            log(ERROR, \"<FAIL> Value is \" + value);
+            testFail.send();
+        \}
+    \}
+
+"
+  }
+  @ ./delay core:timing:delay {
+    #%graph.x 403
+    #%graph.y 236
+  }
+  @ ./exit core:custom {
+    #%graph.x 924
+    #%graph.y 170
+    .code "
+
+    @T(1)
+    void exitOK() \{
+        tellIn(0.2, self(\"exit\"), 0);
+    \}
+
+    @T(2)
+    void exitFail() \{
+        tellIn(0.2, self(\"exit\"), 1);
+    \}
+
+    @In(1) @Config.Port(false)
+    void exit(int value) \{
+        System.exit(value);
+    \}
+
+"
+  }
+  ~ ./start-trigger!out ./delay!in
+  ~ ./start-trigger!out ./test!set
+  ~ ./delay!out ./test!test
+  ~ ./test!test-ok ./exit!exit-ok
+  ~ ./test!test-fail ./exit!exit-fail
+}

--- a/testsuite/tests/core/testcheck/data.pxr
+++ b/testsuite/tests/core/testcheck/data.pxr
@@ -41,23 +41,26 @@
     #%graph.y 236
   }
   @ ./exit core:custom {
-    #%graph.x 924
-    #%graph.y 170
-    .code "
+    #%graph.x 913
+    #%graph.y 196
+    .code "import org.praxislive.core.services.Services;
+import org.praxislive.core.services.SystemManagerService;
+
 
     @T(1)
     void exitOK() \{
-        tellIn(0.2, self(\"exit\"), 0);
+        exit(0);
     \}
 
     @T(2)
     void exitFail() \{
-        tellIn(0.2, self(\"exit\"), 1);
+        exit(1);
     \}
 
-    @In(1) @Config.Port(false)
-    void exit(int value) \{
-        System.exit(value);
+    private void exit(int exitValue) \{
+        find(Services.class)
+                .flatMap(s -> s.locate(SystemManagerService.class))
+                .ifPresent(s -> tell(ControlAddress.of(s, \"system-exit\"), exitValue));
     \}
 
 "

--- a/testsuite/tests/core/testcheck/project.pxp
+++ b/testsuite/tests/core/testcheck/project.pxp
@@ -1,0 +1,13 @@
+hub {
+
+}
+compiler {
+  release 11
+}
+libraries {}
+
+# <<<BUILD>>>
+include [file "data.pxr"]
+
+# <<<RUN>>>
+/data.start


### PR DESCRIPTION
Add initial test suite based on a PraxisCORE project running a series of subprojects. Simple test test, and test of core components, to start with.

Add ability to specify exit code values to SystemManagerService to allow for process fail.

Add support for building, running unit tests and executing test suite via GitHub Actions.