### PR TITLE
Initial implementation of recodeable roots

### DIFF
--- a/praxiscore-api/src/main/java/org/praxislive/core/ThreadContext.java
+++ b/praxiscore-api/src/main/java/org/praxislive/core/ThreadContext.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright 2021 Neil C Smith.
+ * Copyright 2023 Neil C Smith.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3 only, as
@@ -20,6 +20,8 @@
  * have any questions.
  */
 package org.praxislive.core;
+
+import java.util.concurrent.Callable;
 
 /**
  * An optional context available from the {@link Root} lookup, providing the
@@ -57,5 +59,36 @@ public interface ThreadContext {
      * @param task task to be executed
      */
     public void invokeLater(Runnable task);
+
+    /**
+     * Check whether the ThreadContext implementation supports direct invocation
+     * using {@link #invoke(java.util.concurrent.Callable)}. The default
+     * implementation returns false.
+     *
+     * @return true if direct invocation is supported
+     */
+    public default boolean supportsDirectInvoke() {
+        return false;
+    }
+
+    /**
+     * Invoke the passed in task on the calling thread, taking any required
+     * locks or other resources. This method should be used with caution when
+     * absolutely necessary. Callers should check the method is supported via
+     * {@link #supportsDirectInvoke()}.
+     * <p>
+     * The default implementation throws {@link UnsupportedOperationException},
+     * even when {@link #isInUpdate()} is true and it is therefore safe for the
+     * caller to directly execute the task.
+     *
+     * @param <T> generic type of task
+     * @param task task to invoke
+     * @return result of task
+     * @throws UnsupportedOperationException if direct invoke not supported
+     * @throws Exception from execution of underlying task
+     */
+    public default <T> T invoke(Callable<T> task) throws Exception {
+        throw new UnsupportedOperationException();
+    }
 
 }

--- a/praxiscore-base/src/main/java/org/praxislive/base/AbstractRoot.java
+++ b/praxiscore-base/src/main/java/org/praxislive/base/AbstractRoot.java
@@ -24,6 +24,7 @@ package org.praxislive.base;
 import java.util.ArrayDeque;
 import java.util.List;
 import java.util.Queue;
+import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -531,6 +532,21 @@ public abstract class AbstractRoot implements Root {
                 } else {
                     return false;
                 }
+            }
+        }
+
+        @Override
+        public boolean supportsDirectInvoke() {
+            return true;
+        }
+
+        @Override
+        public <T> T invoke(Callable<T> task) throws Exception {
+            lock.lock();
+            try {
+                return task.call();
+            } finally {
+                lock.unlock();
             }
         }
 

--- a/praxiscore-base/src/main/java/org/praxislive/base/AbstractRoot.java
+++ b/praxiscore-base/src/main/java/org/praxislive/base/AbstractRoot.java
@@ -381,7 +381,13 @@ public abstract class AbstractRoot implements Root {
             pollQueue();
         }
 
-        this.time = time;
+        if ((time - this.time) < 0) {
+            LOG.log(Level.WARNING, () -> "Update time is not monotonic : behind by " + (time - this.time));
+            this.time++;
+        } else {
+            this.time = time;
+        }
+
         context.updateClock(time);
         pendingPackets.setTime(time);
 
@@ -441,14 +447,14 @@ public abstract class AbstractRoot implements Root {
         }
 
     }
-    
+
     private void shutdownQueues() {
         for (Object obj = queue.poll(); obj != null; obj = queue.poll()) {
             pending.add(obj);
         }
 
         pendingPackets.drainTo(pending);
-        
+
         for (Object obj = pending.poll(); obj != null; obj = pending.poll()) {
             if (obj instanceof Call) {
                 router.route(((Call) obj).error(PError.of("Root terminated")));
@@ -460,7 +466,7 @@ public abstract class AbstractRoot implements Root {
                 }
             }
         }
-        
+
     }
 
     private void processPacket(Packet packet) {
@@ -553,6 +559,16 @@ public abstract class AbstractRoot implements Root {
     }
 
     /**
+     * Create a {@link DelegateConfiguration} object for passing up to the
+     * constructor when creating a {@link Delegate} subclass.
+     *
+     * @return delegate configuration
+     */
+    protected static DelegateConfiguration delegateConfig() {
+        return new DelegateConfiguration();
+    }
+
+    /**
      * Implementation of Root.Controller.
      */
     protected class Controller implements Root.Controller {
@@ -604,7 +620,7 @@ public abstract class AbstractRoot implements Root {
          */
         protected void onQueueReceipt() {
             Delegate del = delegate.get();
-            if (del != null) {
+            if (del != null && !del.backgroundPoll) {
                 del.onQueueReceipt();
             } else {
                 if (updateQueued.compareAndSet(false, true)) {
@@ -625,36 +641,26 @@ public abstract class AbstractRoot implements Root {
 
         private void doUpdate() {
             Delegate del = delegate.get();
-            if (del != null) {
-                // do clock check
-                if (Math.abs(hub.getClock().getTime() - time) > 10_000_000_000L) {
-                    LOG.log(Level.SEVERE, "Delegate not updating time");
-//                    detachDelegate(del);
+            if (del != null && !del.clockCheck()) {
+                return;
+            }
+            lock.lock();
+            try {
+                if (!update(hub.getClock().getTime(), true)) {
+                    updateTask.cancel(false);
+                    doTerminate();
                 }
-            } else {
-                if (lock.tryLock()) {
-                    try {
-                        if (!update(hub.getClock().getTime(), true)) {
-                            updateTask.cancel(false);
-                            doTerminate();
-                        }
-                    } catch (Throwable t) {
-                        LOG.log(Level.SEVERE, "Uncaught error", t);
-                    } finally {
-                        lock.unlock();
-                    }
-                } else {
-                    LOG.info("Lock already taken");
-                }
+            } catch (Throwable t) {
+                LOG.log(Level.SEVERE, "Uncaught error", t);
+            } finally {
+                lock.unlock();
             }
         }
 
         private void doPoll() {
             updateQueued.set(false);
             Delegate del = delegate.get();
-            if (del != null) {
-                // do nothing
-            } else {
+            if (del == null || del.backgroundPoll) {
                 if (lock.tryLock()) {
                     try {
                         pollQueue();
@@ -663,8 +669,6 @@ public abstract class AbstractRoot implements Root {
                     } finally {
                         lock.unlock();
                     }
-                } else {
-                    LOG.info("Lock already taken");
                 }
             }
         }
@@ -719,12 +723,31 @@ public abstract class AbstractRoot implements Root {
 
         private final ReentrantLock pollLock;
         private final Condition pollCondition;
+        private final boolean backgroundPoll;
+        private final long forceUpdateAfterNS;
+        private final long maxDriftNS;
 
         private Thread delegateThread;
 
+        /**
+         * Create a Delegate with the default configuration.
+         */
         protected Delegate() {
+            this(null);
+        }
+
+        /**
+         * Create a Delegate subclass with the provided configuration.
+         *
+         * @param config delegate configuration
+         *
+         */
+        protected Delegate(DelegateConfiguration config) {
             this.pollLock = new ReentrantLock();
             this.pollCondition = pollLock.newCondition();
+            this.backgroundPoll = config == null ? false : config.backgroundPoll;
+            this.forceUpdateAfterNS = config == null ? 0 : config.forceUpdateNanos;
+            this.maxDriftNS = TimeUnit.SECONDS.toNanos(1);
         }
 
         /**
@@ -737,23 +760,19 @@ public abstract class AbstractRoot implements Root {
          * detached
          */
         protected final boolean doUpdate(long time) {
-            if (delegate.get() == this) {
-                if (lock.tryLock()) {
-                    try {
-                        delegateThread = Thread.currentThread();
-                        return update(time, true);
-                    } catch (Throwable t) {
-                        LOG.log(Level.SEVERE, "Uncaught error", t);
-                    } finally {
-                        lock.unlock();
-                    }
-                } else {
-                    LOG.finest("Lock already taken");
+            lock.lock();
+            try {
+                if (delegate.get() != this) {
+                    LOG.info("Delegate invalid");
+                    return false;
                 }
+                delegateThread = Thread.currentThread();
+                return update(correctUpdateTime(time), true);
+            } catch (Throwable t) {
+                LOG.log(Level.SEVERE, "Uncaught error", t);
                 return true;
-            } else {
-                LOG.info("Delegate invalid");
-                return false;
+            } finally {
+                lock.unlock();
             }
         }
 
@@ -762,21 +781,17 @@ public abstract class AbstractRoot implements Root {
          * packets with a timecode before the current Root time.
          */
         protected final void doPollQueue() {
-            if (delegate.get() == this) {
-                if (lock.tryLock()) {
-                    try {
+            if (lock.tryLock()) {
+                try {
+                    if (delegate.get() == this) {
                         delegateThread = Thread.currentThread();
                         pollQueue();
-                    } catch (Throwable t) {
-                        LOG.log(Level.SEVERE, "Uncaught error", t);
-                    } finally {
-                        lock.unlock();
                     }
-                } else {
-                    LOG.finest("Lock already taken");
+                } catch (Throwable t) {
+                    LOG.log(Level.SEVERE, "Uncaught error", t);
+                } finally {
+                    lock.unlock();
                 }
-            } else {
-                LOG.info("Delegate invalid");
             }
         }
 
@@ -790,15 +805,17 @@ public abstract class AbstractRoot implements Root {
          * @throws InterruptedException
          */
         protected final void doTimedPoll(long time, TimeUnit unit) throws InterruptedException {
-            if (pollLock.tryLock()) {
+            if (time > 0) {
+                pollLock.lockInterruptibly();
                 try {
-                    if (pollCondition.await(time, unit)) {
-                        doPollQueue();
+                    if (queue.isEmpty()) {
+                        pollCondition.await(time, unit);
                     }
                 } finally {
                     pollLock.unlock();
                 }
             }
+            doPollQueue();
         }
 
         /**
@@ -846,6 +863,91 @@ public abstract class AbstractRoot implements Root {
          */
         protected boolean isRootThread() {
             return Thread.currentThread() == delegateThread;
+        }
+
+        /**
+         * Called on standard root thread, not delegate thread, to check
+         * delegate is being updated. If a force update time has been set and
+         * the root time is behind the hub clock time more than the threshold,
+         * returns true to trigger update on root thread.
+         *
+         * @return true to force update on root thread
+         */
+        private boolean clockCheck() {
+            long delta = hub.getClock().getTime() - time;
+            if (forceUpdateAfterNS > 0 && delta > forceUpdateAfterNS) {
+                return true;
+            }
+            if (Math.abs(delta) > 10_000_000_000L) {
+                LOG.log(Level.SEVERE, "Delegate not updating time");
+            }
+            return false;
+        }
+
+        private long correctUpdateTime(final long updateTime) {
+            long hubTime = hub.getClock().getTime();
+            long rootTime = AbstractRoot.this.time;
+            long correctedTime = updateTime;
+            long delta = updateTime - hubTime;
+            if (delta < -maxDriftNS) {
+                correctedTime = hubTime - maxDriftNS;
+            } else if (delta > maxDriftNS) {
+                correctedTime = hubTime + maxDriftNS;
+            }
+
+            delta = updateTime - rootTime;
+            if (delta < 0) {
+                correctedTime = rootTime + 1;
+            }
+            return correctedTime;
+        }
+
+    }
+
+    /**
+     * A configuration object used for customizing {@link Delegate} behaviour in
+     * a subclass. Create using {@link #delegateConfig()}.
+     */
+    protected static final class DelegateConfiguration {
+
+        private boolean backgroundPoll;
+        private long forceUpdateNanos;
+
+        private DelegateConfiguration() {
+            this.backgroundPoll = false;
+            this.forceUpdateNanos = 0;
+        }
+
+        /**
+         * Whether to poll for incoming calls in another thread in-between calls
+         * to update. Default is disabled.
+         * <p>
+         * Background polling will use the original root thread or executor.
+         *
+         * @return this for chaining
+         */
+        public DelegateConfiguration pollInBackground() {
+            backgroundPoll = true;
+            return this;
+        }
+
+        /**
+         * Whether to force an update on another thread if the delegate hasn't
+         * called update in the given time period. Default is disabled.
+         * <p>
+         * Forced updates will use the original root thread or executor.
+         *
+         * @param time maximum time period before update will be forced
+         * @param unit unit of time argument
+         * @return this for chaining
+         */
+        public DelegateConfiguration forceUpdateAfter(long time, TimeUnit unit) {
+            long ns = unit.toNanos(time);
+            if (ns < 1) {
+                throw new IllegalArgumentException();
+            }
+            forceUpdateNanos = ns;
+            return this;
         }
 
     }

--- a/praxiscore-base/src/main/java/org/praxislive/base/PacketQueue.java
+++ b/praxiscore-base/src/main/java/org/praxislive/base/PacketQueue.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  * 
- * Copyright 2019 Neil C Smith.
+ * Copyright 2023 Neil C Smith.
  * 
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3 only, as
@@ -21,7 +21,7 @@
  */
 package org.praxislive.base;
 
-import java.util.List;
+import java.util.Collection;
 import java.util.PriorityQueue;
 import org.praxislive.core.Packet;
 
@@ -69,8 +69,8 @@ class PacketQueue {
         return null;
     }
     
-    void drainTo(List<Packet> list) {
-        list.addAll(q);
+    void drainTo(Collection<Object> queue) {
+        queue.addAll(q);
         q.clear();
     }
     

--- a/praxiscore-base/src/test/java/org/praxislive/base/PacketQueueTest.java
+++ b/praxiscore-base/src/test/java/org/praxislive/base/PacketQueueTest.java
@@ -1,3 +1,24 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ * 
+ * Copyright 2023 Neil C Smith.
+ * 
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License version 3 only, as
+ * published by the Free Software Foundation.
+ * 
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * version 3 for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License version 3
+ * along with this work; if not, see http://www.gnu.org/licenses/
+ * 
+ * 
+ * Please visit https://www.praxislive.org if you need additional information or
+ * have any questions.
+ */
 package org.praxislive.base;
 
 import org.praxislive.core.Call;

--- a/praxiscore-code-services/src/main/java/org/praxislive/code/services/ComponentRegistry.java
+++ b/praxiscore-code-services/src/main/java/org/praxislive/code/services/ComponentRegistry.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright 2020 Neil C Smith.
+ * Copyright 2023 Neil C Smith.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3 only, as
@@ -23,9 +23,8 @@ package org.praxislive.code.services;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.Set;
-import java.util.logging.Logger;
 import org.praxislive.code.CodeComponentFactoryService;
+import org.praxislive.code.CodeRootFactoryService;
 import org.praxislive.core.services.ComponentFactory;
 import org.praxislive.core.services.ComponentFactoryProvider;
 import org.praxislive.core.ComponentType;
@@ -36,17 +35,10 @@ import org.praxislive.core.Lookup;
  */
 class ComponentRegistry {
 
-    private final static Logger logger
-            = Logger.getLogger(ComponentRegistry.class.getName());
     private final Map<ComponentType, ComponentFactory> componentCache;
 
     private ComponentRegistry(Map<ComponentType, ComponentFactory> componentCache) {
         this.componentCache = componentCache;
-    }
-
-    ComponentType[] getComponentTypes() {
-        Set<ComponentType> keys = componentCache.keySet();
-        return keys.toArray(new ComponentType[keys.size()]);
     }
 
     ComponentFactory getComponentFactory(ComponentType type) {
@@ -63,6 +55,17 @@ class ComponentRegistry {
                         -> factory.getFactoryService() == CodeComponentFactoryService.class)
                 .forEachOrdered(factory -> {
                     factory.componentTypes().forEachOrdered(type -> {
+                        componentCache.put(type, factory);
+                    });
+                }
+                );
+        
+        Lookup.SYSTEM.findAll(ComponentFactoryProvider.class)
+                .map(ComponentFactoryProvider::getFactory)
+                .filter(factory
+                        -> factory.getRootFactoryService() == CodeRootFactoryService.class)
+                .forEachOrdered(factory -> {
+                    factory.rootTypes().forEachOrdered(type -> {
                         componentCache.put(type, factory);
                     });
                 }

--- a/praxiscore-code/src/main/java/org/praxislive/code/CodeComponent.java
+++ b/praxiscore-code/src/main/java/org/praxislive/code/CodeComponent.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright 2021 Neil C Smith.
+ * Copyright 2023 Neil C Smith.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3 only, as
@@ -66,7 +66,7 @@ public class CodeComponent<D extends CodeDelegate> implements Component {
     }
 
     @Override
-    public final void parentNotify(Container parent) throws VetoException {
+    public void parentNotify(Container parent) throws VetoException {
         if (parent == null) {
             if (this.parent != null) {
                 this.parent = null;
@@ -88,16 +88,11 @@ public class CodeComponent<D extends CodeDelegate> implements Component {
 
     @Override
     public void hierarchyChanged() {
-        if (parent != null) {
-            address = parent.getAddress(this);
-        } else {
-            address = null;
-        }
         execCtxt = null;
         router = null;
         logInfo = null;
         codeCtxt.handleHierarchyChanged();
-        if (address == null) {
+        if (getAddress() == null) {
             codeCtxt.handleDispose();
         }
     }
@@ -140,6 +135,11 @@ public class CodeComponent<D extends CodeDelegate> implements Component {
     }
 
     ComponentAddress getAddress() {
+        if (parent == null) {
+            address = null;
+        } else if (address == null) {
+            address = parent.getAddress(this);
+        }
         return address;
     }
 

--- a/praxiscore-code/src/main/java/org/praxislive/code/CodeContext.java
+++ b/praxiscore-code/src/main/java/org/praxislive/code/CodeContext.java
@@ -224,13 +224,14 @@ public abstract class CodeContext<D extends CodeDelegate> {
         if (execState == source.getState()) {
             return;
         }
+        if (source.getState() == ExecutionContext.State.IDLE) {
+            stopping(source, full);
+        }
         reset(full);
         update(source.getTime());
         execState = source.getState();
         if (execState == ExecutionContext.State.ACTIVE) {
             starting(source, full);
-        } else {
-            stopping(source, full);
         }
         flush();
     }

--- a/praxiscore-code/src/main/java/org/praxislive/code/CodeFactory.java
+++ b/praxiscore-code/src/main/java/org/praxislive/code/CodeFactory.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright 2021 Neil C Smith.
+ * Copyright 2023 Neil C Smith.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3 only, as
@@ -120,7 +120,17 @@ public class CodeFactory<D extends CodeDelegate> {
      *
      * @return component type
      */
+    @Deprecated
     public final ComponentType getComponentType() {
+        return type;
+    }
+
+    /**
+     * Get the component type.
+     *
+     * @return component type
+     */
+    public final ComponentType componentType() {
         return type;
     }
 
@@ -141,7 +151,7 @@ public class CodeFactory<D extends CodeDelegate> {
 
         });
     }
-    
+
     final String getClassBodyContextName() {
         return lookup.find(ClassBodyContext.class)
                 .map(cbc -> cbc.getClass().getName())
@@ -153,7 +163,17 @@ public class CodeFactory<D extends CodeDelegate> {
      *
      * @return source template
      */
+    @Deprecated
     public final String getSourceTemplate() {
+        return template;
+    }
+
+    /**
+     * The source template corresponding to the default delegate class.
+     *
+     * @return source template
+     */
+    public final String sourceTemplate() {
         return template;
     }
 
@@ -162,8 +182,18 @@ public class CodeFactory<D extends CodeDelegate> {
      *
      * @return optional precompiled default delegate
      */
+    @Deprecated
     public final Optional<Class<? extends D>> getDefaultDelegateClass() {
         return Optional.ofNullable(defaultDelegateClass);
+    }
+
+    /**
+     * Query the default delegate class.
+     *
+     * @return default delegate class
+     */
+    public final Class<? extends D> defaultDelegateClass() {
+        return defaultDelegateClass;
     }
 
     /**
@@ -236,6 +266,48 @@ public class CodeFactory<D extends CodeDelegate> {
             List<String> baseImports,
             BiFunction<CodeFactory.Task<B>, B, CodeContext<B>> contextCreator) {
         return new Base<>(baseClass, baseImports, CodeContainer::new, contextCreator, Lookup.EMPTY);
+    }
+
+    /**
+     * Create a root component {@link CodeFactory.Base} for the given base
+     * delegate class, from which can be created individual CodeFactory
+     * instances. The base class and default imports will be used to wrap user
+     * sources passed across to the compiler. The context creator function is
+     * used to wrap the compiled delegate in a {@link CodeContext}, and will
+     * usually correspond to <code>(task, delegate) -> new XXXCodeContext(new
+     * XXXCodeConnector(task, delegate))</code>
+     *
+     * @param <B> base delegate type
+     * @param baseClass base delegate superclass
+     * @param baseImports default base imports
+     * @param contextCreator create context for delegate
+     * @return code factory base
+     */
+    public static <B extends CodeRootDelegate> Base<B> rootBase(Class<B> baseClass,
+            List<String> baseImports,
+            BiFunction<CodeFactory.Task<B>, B, CodeContext<B>> contextCreator) {
+        return new Base<>(baseClass, baseImports, CodeRoot::new, contextCreator, Lookup.EMPTY);
+    }
+
+    /**
+     * Create a root container {@link CodeFactory.Base} for the given base
+     * delegate class, from which can be created individual CodeFactory
+     * instances. The base class and default imports will be used to wrap user
+     * sources passed across to the compiler. The context creator function is
+     * used to wrap the compiled delegate in a {@link CodeContext}, and will
+     * usually correspond to <code>(task, delegate) -> new XXXCodeContext(new
+     * XXXCodeConnector(task, delegate))</code>
+     *
+     * @param <B> base delegate type
+     * @param baseClass base delegate superclass
+     * @param baseImports default base imports
+     * @param contextCreator create context for delegate
+     * @return code factory base
+     */
+    public static <B extends CodeRootContainerDelegate> Base<B> rootContainerBase(Class<B> baseClass,
+            List<String> baseImports,
+            BiFunction<CodeFactory.Task<B>, B, CodeContext<B>> contextCreator) {
+        return new Base<>(baseClass, baseImports, CodeRootContainer::new, contextCreator, Lookup.EMPTY);
     }
 
     /**

--- a/praxiscore-code/src/main/java/org/praxislive/code/CodeProperty.java
+++ b/praxiscore-code/src/main/java/org/praxislive/code/CodeProperty.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright 2021 Neil C Smith.
+ * Copyright 2023 Neil C Smith.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3 only, as
@@ -209,13 +209,12 @@ class CodeProperty<D extends CodeDelegate>
         private ControlInfo createInfo(CodeFactory<D> factory) {
             return ControlInfo.createPropertyInfo(
                     ArgumentInfo.of(PString.class,
-                            PMap.builder(5)
-                                    .put(PString.KEY_MIME_TYPE, MIME_TYPE)
-                                    .put(ArgumentInfo.KEY_TEMPLATE, factory.getSourceTemplate())
-                                    .put(ClassBodyContext.KEY, factory.getClassBodyContextName())
-                                    .put(CodeFactory.BASE_CLASS_KEY, factory.baseClass().getName())
-                                    .put(CodeFactory.BASE_IMPORTS_KEY, factory.baseImports().stream().map(PString::of).collect(PArray.collector()))
-                                    .build()
+                            PMap.of(PString.KEY_MIME_TYPE, MIME_TYPE,
+                                    ArgumentInfo.KEY_TEMPLATE, factory.getSourceTemplate(),
+                                    ClassBodyContext.KEY, factory.getClassBodyContextName(),
+                                    CodeFactory.BASE_CLASS_KEY, factory.baseClass().getName(),
+                                    CodeFactory.BASE_IMPORTS_KEY,
+                                    factory.baseImports().stream().map(PString::of).collect(PArray.collector()))
                     ),
                     PString.EMPTY,
                     PMap.EMPTY);

--- a/praxiscore-code/src/main/java/org/praxislive/code/CodeRoot.java
+++ b/praxiscore-code/src/main/java/org/praxislive/code/CodeRoot.java
@@ -24,6 +24,7 @@ package org.praxislive.code;
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.util.concurrent.TimeUnit;
 import org.praxislive.base.AbstractRoot;
 import org.praxislive.core.Call;
 import org.praxislive.core.ComponentAddress;
@@ -300,6 +301,13 @@ public class CodeRoot<D extends CodeRootDelegate> extends CodeComponent<D> imple
         }
 
         private class DelegateImpl extends Delegate {
+            
+            private DelegateImpl() {
+                super(delegateConfig()
+                        .pollInBackground()
+                        .forceUpdateAfter(1, TimeUnit.SECONDS)
+                );
+            }
 
             private void handleUpdate(long time) {
                 doUpdate(time);

--- a/praxiscore-code/src/main/java/org/praxislive/code/CodeRoot.java
+++ b/praxiscore-code/src/main/java/org/praxislive/code/CodeRoot.java
@@ -1,0 +1,260 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright 2023 Neil C Smith.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License version 3 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * version 3 for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License version 3
+ * along with this work; if not, see http://www.gnu.org/licenses/
+ *
+ *
+ * Please visit https://www.praxislive.org if you need additional information or
+ * have any questions.
+ */
+package org.praxislive.code;
+
+import java.lang.reflect.AnnotatedElement;
+import org.praxislive.base.AbstractRoot;
+import org.praxislive.core.Call;
+import org.praxislive.core.ComponentAddress;
+import org.praxislive.core.Container;
+import org.praxislive.core.Control;
+import org.praxislive.core.ControlAddress;
+import org.praxislive.core.ControlInfo;
+import org.praxislive.core.Info;
+import org.praxislive.core.Lookup;
+import org.praxislive.core.PacketRouter;
+import org.praxislive.core.Root;
+import org.praxislive.core.RootHub;
+import org.praxislive.core.VetoException;
+import org.praxislive.core.protocols.StartableProtocol;
+import org.praxislive.core.services.LogLevel;
+import org.praxislive.core.types.PBoolean;
+import org.praxislive.core.types.PError;
+
+/**
+ * A {@link Root} component instance that is rewritable at runtime. The CodeRoot
+ * itself remains constant, but passes most responsibility to a {@link Context}
+ * wrapping a {@link CodeRootDelegate} (user code). This component handles
+ * switching from one context to the next. A CodeRoot cannot be created directly
+ * - see {@link CodeFactory}.
+ *
+ * @param <D> wrapped delegate type
+ */
+public class CodeRoot<D extends CodeRootDelegate> extends CodeComponent<D> implements Root {
+
+    private final RootImpl root;
+    private final Control startControl;
+    private final Control stopControl;
+    private final Control isRunningControl;
+
+    CodeRoot() {
+        root = new RootImpl(this);
+        startControl = (call, router) -> {
+            root.start();
+            router.route(call.reply());
+        };
+        stopControl = (call, router) -> {
+            root.stop();
+            router.route(call.reply());
+        };
+        isRunningControl = (call, router) -> {
+            router.route(call.reply(PBoolean.of(root.isRunning())));
+        };
+    }
+
+    @Override
+    public Controller initialize(String ID, RootHub hub) {
+        var controller = root.initialize(ID, hub);
+        hierarchyChanged();
+        return controller;
+    }
+
+    @Override
+    public Lookup getLookup() {
+        return root.getLookup();
+    }
+
+    @Override
+    public void parentNotify(Container parent) throws VetoException {
+        throw new VetoException();
+    }
+
+    @Override
+    ComponentAddress getAddress() {
+        return root.address();
+    }
+
+    void processCall(Call call, PacketRouter router) {
+        Control control = findControl(call.to());
+        try {
+            if (control != null) {
+                control.call(call, router);
+            } else {
+                if (call.isRequest()) {
+                    router.route(call.error(PError.of("Unknown control address : " + call.to())));
+                }
+            }
+        } catch (Exception ex) {
+            if (call.isRequest()) {
+                router.route(call.error(PError.of(ex)));
+            }
+        }
+    }
+
+    Control findControl(ControlAddress address) {
+        if (address.component().depth() == 1) {
+            return getControl(address.controlID());
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * CodeContext subclass for CodeRoots.
+     *
+     * @param <D> wrapped delegate base type
+     */
+    public static class Context<D extends CodeRootDelegate> extends CodeContext<D> {
+
+        public Context(CodeConnector<D> connector) {
+            super(connector);
+        }
+
+        @Override
+        void setComponent(CodeComponent<D> cmp) {
+            setComponentImpl((CodeRoot<D>) cmp);
+        }
+
+        private void setComponentImpl(CodeRoot<D> cmp) {
+            super.setComponent(cmp);
+        }
+
+        @Override
+        public CodeRoot<D> getComponent() {
+            return (CodeRoot<D>) super.getComponent();
+        }
+
+    }
+
+    /**
+     * CodeConnector subclass for CodeRoots.
+     *
+     * @param <D> wrapped delegate base type
+     */
+    public static class Connector<D extends CodeRootDelegate> extends CodeConnector<D> {
+
+        public Connector(CodeFactory.Task<D> task, D delegate) {
+            super(task, delegate);
+        }
+
+        @Override
+        protected void addDefaultControls() {
+            super.addDefaultControls();
+            addControl(new RootControlDescriptor(StartableProtocol.START, getInternalIndex()));
+            addControl(new RootControlDescriptor(StartableProtocol.STOP, getInternalIndex()));
+            addControl(new RootControlDescriptor(StartableProtocol.IS_RUNNING, getInternalIndex()));
+        }
+
+        @Override
+        protected void buildBaseComponentInfo(Info.ComponentInfoBuilder cmp) {
+            super.buildBaseComponentInfo(cmp);
+            cmp.merge(StartableProtocol.API_INFO);
+        }
+
+        @Override
+        public void addPort(PortDescriptor port) {
+            getLog().log(LogLevel.ERROR, "Cannot add port to root component");
+        }
+
+        @Override
+        public boolean shouldAddPort(AnnotatedElement element) {
+            return false;
+        }
+
+    }
+
+    private static class RootImpl extends AbstractRoot {
+
+        private final CodeRoot<?> wrapper;
+
+        private RootImpl(CodeRoot<?> wrapper) {
+            this.wrapper = wrapper;
+        }
+
+        @Override
+        protected void processCall(Call call, PacketRouter router) {
+            wrapper.processCall(call, router);
+        }
+
+        private void start() {
+            setRunning();
+        }
+
+        private void stop() {
+            setIdle();
+        }
+
+        private boolean isRunning() {
+            return getState() == State.ACTIVE_RUNNING;
+        }
+
+        private ComponentAddress address() {
+            return getAddress();
+        }
+
+    }
+
+    private static class RootControlDescriptor extends ControlDescriptor {
+
+        private final String controlID;
+
+        private CodeRoot<?> root;
+
+        private RootControlDescriptor(String controlID, int index) {
+            super(controlID, Category.Internal, index);
+            this.controlID = controlID;
+        }
+
+        @Override
+        public void attach(CodeContext<?> context, Control previous) {
+            root = (CodeRoot<?>) context.getComponent();
+        }
+
+        @Override
+        public Control getControl() {
+            switch (controlID) {
+                case StartableProtocol.START:
+                    return root.startControl;
+                case StartableProtocol.STOP:
+                    return root.stopControl;
+                case StartableProtocol.IS_RUNNING:
+                    return root.isRunningControl;
+            }
+            return null;
+        }
+
+        @Override
+        public ControlInfo getInfo() {
+            switch (controlID) {
+                case StartableProtocol.START:
+                    return StartableProtocol.START_INFO;
+                case StartableProtocol.STOP:
+                    return StartableProtocol.STOP_INFO;
+                case StartableProtocol.IS_RUNNING:
+                    return StartableProtocol.IS_RUNNING_INFO;
+            }
+            return null;
+        }
+
+    }
+
+}

--- a/praxiscore-code/src/main/java/org/praxislive/code/CodeRootContainer.java
+++ b/praxiscore-code/src/main/java/org/praxislive/code/CodeRootContainer.java
@@ -107,7 +107,7 @@ public class CodeRootContainer<D extends CodeRootContainerDelegate> extends Code
      */
     public static class Context<D extends CodeRootContainerDelegate> extends CodeRoot.Context<D> {
 
-        public Context(CodeConnector<D> connector) {
+        public Context(Connector<D> connector) {
             super(connector);
         }
 

--- a/praxiscore-code/src/main/java/org/praxislive/code/CodeRootContainer.java
+++ b/praxiscore-code/src/main/java/org/praxislive/code/CodeRootContainer.java
@@ -1,0 +1,225 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright 2023 Neil C Smith.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License version 3 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * version 3 for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License version 3
+ * along with this work; if not, see http://www.gnu.org/licenses/
+ *
+ *
+ * Please visit https://www.praxislive.org if you need additional information or
+ * have any questions.
+ */
+package org.praxislive.code;
+
+import java.util.stream.Stream;
+import org.praxislive.base.AbstractContainer;
+import org.praxislive.core.Component;
+import org.praxislive.core.ComponentAddress;
+import org.praxislive.core.ComponentInfo;
+import org.praxislive.core.Container;
+import org.praxislive.core.Control;
+import org.praxislive.core.ControlAddress;
+import org.praxislive.core.ControlInfo;
+import org.praxislive.core.Info;
+import org.praxislive.core.Lookup;
+import org.praxislive.core.VetoException;
+import org.praxislive.core.protocols.ContainerProtocol;
+
+/**
+ * A {@link Root} container instance that is rewritable at runtime. The
+ * CodeRootContainer itself remains constant, but passes most responsibility to
+ * a {@link Context} wrapping a {@link CodeRootContainerDelegate} (user code).
+ * This component handles switching from one context to the next. A CodeRoot
+ * cannot be created directly - see {@link CodeFactory}.
+ *
+ * @param <D> wrapped delegate type
+ */
+public class CodeRootContainer<D extends CodeRootContainerDelegate> extends CodeRoot<D>
+        implements Container {
+
+    private final ContainerImpl container;
+
+    CodeRootContainer() {
+        container = new ContainerImpl(this);
+    }
+
+    @Override
+    public Stream<String> children() {
+        return container.children();
+    }
+
+    @Override
+    public ComponentAddress getAddress(Component child) {
+        return container.getAddress(child);
+    }
+
+    @Override
+    public Component getChild(String id) {
+        return container.getChild(id);
+    }
+
+    @Override
+    public void hierarchyChanged() {
+        super.hierarchyChanged();
+        container.hierarchyChanged();
+    }
+
+    Control getContainerControl(String id) {
+        return container.getControl(id);
+    }
+
+    @Override
+    Control findControl(ControlAddress address) {
+        Component comp = findComponent(address.component());
+        if (comp != null) {
+            return comp.getControl(address.controlID());
+        } else {
+            return null;
+        }
+    }
+
+    private Component findComponent(ComponentAddress address) {
+        Component comp = this;
+        for (int i = 1; i < address.depth(); i++) {
+            if (comp instanceof Container) {
+                comp = ((Container) comp).getChild(address.componentID(i));
+            } else {
+                return null;
+            }
+        }
+        return comp;
+    }
+
+    /**
+     * CodeContext subclass for CodeRootContainers.
+     *
+     * @param <D> wrapped delegate base type
+     */
+    public static class Context<D extends CodeRootContainerDelegate> extends CodeRoot.Context<D> {
+
+        public Context(CodeConnector<D> connector) {
+            super(connector);
+        }
+
+        @Override
+        void setComponent(CodeComponent<D> cmp) {
+            setComponentImpl((CodeRootContainer<D>) cmp);
+        }
+
+        private void setComponentImpl(CodeRootContainer<D> cmp) {
+            super.setComponent(cmp);
+        }
+
+        @Override
+        public CodeRootContainer<D> getComponent() {
+            return (CodeRootContainer<D>) super.getComponent();
+        }
+
+    }
+
+    /**
+     * CodeConnector subclass for CodeRootContainers.
+     *
+     * @param <D> wrapped delegate base type
+     */
+    public static class Connector<D extends CodeRootContainerDelegate> extends CodeRoot.Connector<D> {
+
+        public Connector(CodeFactory.Task<D> task, D delegate) {
+            super(task, delegate);
+        }
+
+        @Override
+        protected void addDefaultControls() {
+            super.addDefaultControls();
+            addControl(new ContainerControlDescriptor(ContainerProtocol.ADD_CHILD,
+                    ContainerProtocol.ADD_CHILD_INFO, getInternalIndex()));
+            addControl(new ContainerControlDescriptor(ContainerProtocol.REMOVE_CHILD,
+                    ContainerProtocol.REMOVE_CHILD_INFO, getInternalIndex()));
+            addControl(new ContainerControlDescriptor(ContainerProtocol.CHILDREN,
+                    ContainerProtocol.CHILDREN_INFO, getInternalIndex()));
+            addControl(new ContainerControlDescriptor(ContainerProtocol.CONNECT,
+                    ContainerProtocol.CONNECT_INFO, getInternalIndex()));
+            addControl(new ContainerControlDescriptor(ContainerProtocol.DISCONNECT,
+                    ContainerProtocol.DISCONNECT_INFO, getInternalIndex()));
+            addControl(new ContainerControlDescriptor(ContainerProtocol.CONNECTIONS,
+                    ContainerProtocol.CONNECTIONS_INFO, getInternalIndex()));
+        }
+
+        @Override
+        protected void buildBaseComponentInfo(Info.ComponentInfoBuilder cmp) {
+            super.buildBaseComponentInfo(cmp);
+            cmp.merge(ContainerProtocol.API_INFO);
+        }
+
+    }
+
+    private static class ContainerImpl extends AbstractContainer.Delegate {
+
+        private final CodeRootContainer<?> wrapper;
+
+        private ContainerImpl(CodeRootContainer<?> wrapper) {
+            this.wrapper = wrapper;
+        }
+
+        @Override
+        public ComponentInfo getInfo() {
+            return wrapper.getInfo();
+        }
+
+        @Override
+        public Lookup getLookup() {
+            return wrapper.getLookup();
+        }
+
+        @Override
+        protected ComponentAddress getAddress() {
+            return wrapper.getAddress();
+        }
+
+        @Override
+        protected void notifyChild(Component child) throws VetoException {
+            child.parentNotify(wrapper);
+        }
+
+    }
+
+    private static class ContainerControlDescriptor extends ControlDescriptor {
+
+        private final ControlInfo info;
+
+        private Control control;
+
+        ContainerControlDescriptor(String id, ControlInfo info, int index) {
+            super(id, ControlDescriptor.Category.Internal, index);
+            this.info = info;
+        }
+
+        @Override
+        public void attach(CodeContext<?> context, Control previous) {
+            control = ((CodeRootContainer<?>) context.getComponent())
+                    .getContainerControl(getID());
+        }
+
+        @Override
+        public Control getControl() {
+            return control;
+        }
+
+        @Override
+        public ControlInfo getInfo() {
+            return info;
+        }
+
+    }
+
+}

--- a/praxiscore-code/src/main/java/org/praxislive/code/CodeRootContainerDelegate.java
+++ b/praxiscore-code/src/main/java/org/praxislive/code/CodeRootContainerDelegate.java
@@ -14,36 +14,36 @@
  *
  * You should have received a copy of the GNU Lesser General Public License version 3
  * along with this work; if not, see http://www.gnu.org/licenses/
- * 
+ *
  *
  * Please visit https://www.praxislive.org if you need additional information or
  * have any questions.
  */
-package org.praxislive.code.internal;
+package org.praxislive.code;
 
 import java.util.stream.Stream;
-import org.praxislive.code.CodeCompilerService;
-import org.praxislive.code.CodeComponentFactoryService;
-import org.praxislive.code.CodeContextFactoryService;
-import org.praxislive.code.CodeRootFactoryService;
-import org.praxislive.code.SharedCodeService;
-import org.praxislive.core.Protocol;
 
 /**
- *
- * 
+ * Base class for user rewritable Root container code.
  */
-public class CodeProtocolsProvider implements Protocol.TypeProvider {
+public class CodeRootContainerDelegate extends CodeRootDelegate {
 
     @Override
-    public Stream<Protocol.Type> types() {
-        return Stream.of(
-                new Protocol.Type<>(CodeCompilerService.class),
-                new Protocol.Type<>(CodeComponentFactoryService.class),
-                new Protocol.Type<>(CodeRootFactoryService.class),
-                new Protocol.Type<>(CodeContextFactoryService.class),
-                new Protocol.Type<>(SharedCodeService.class)
-        );
+    public void init() {
+    }
+
+    /**
+     * Stream of child IDs.
+     *
+     * @return stream of child IDs
+     */
+    public final Stream<String> children() {
+        var ctxt = getContext();
+        if (ctxt instanceof CodeRootContainer.Context) {
+            return ((CodeRootContainer.Context<?>) ctxt).getComponent().children();
+        } else {
+            return Stream.empty();
+        }
     }
     
 }

--- a/praxiscore-code/src/main/java/org/praxislive/code/CodeRootDelegate.java
+++ b/praxiscore-code/src/main/java/org/praxislive/code/CodeRootDelegate.java
@@ -14,33 +14,19 @@
  *
  * You should have received a copy of the GNU Lesser General Public License version 3
  * along with this work; if not, see http://www.gnu.org/licenses/
- * 
+ *
  *
  * Please visit https://www.praxislive.org if you need additional information or
  * have any questions.
  */
-
 package org.praxislive.code;
 
-import java.util.stream.Stream;
-import org.praxislive.core.Protocol;
-import org.praxislive.core.services.ComponentFactoryService;
-
 /**
- *
- * 
+ * Base class for user rewritable Root code.
  */
-public class CodeComponentFactoryService extends ComponentFactoryService {
-    
-    
-    @Deprecated
-    public static class Provider implements Protocol.TypeProvider {
+public class CodeRootDelegate extends CodeDelegate {
 
-        @Override
-        public Stream<Type> types() {
-            return Stream.of(new Protocol.Type<>(CodeComponentFactoryService.class));
-        }
-        
+    public void init() {
     }
-    
+
 }

--- a/praxiscore-code/src/main/java/org/praxislive/code/CodeRootDelegate.java
+++ b/praxiscore-code/src/main/java/org/praxislive/code/CodeRootDelegate.java
@@ -31,9 +31,36 @@ import java.lang.annotation.Target;
  */
 public class CodeRootDelegate extends CodeDelegate {
 
+    /**
+     * Hook called whenever the delegate needs to be initialized. Will be called
+     * when the root is started, and any time the code is updated. Because this
+     * code is called in a running root, the code should be suitable for
+     * real-time usage.
+     */
     public void init() {
     }
 
+    /**
+     * Mark a field referencing an interface implementation to be wrapped by an
+     * interface proxy, and used to drive updates of the root. Any call to the
+     * proxy will cause a root update on the calling thread, prior to calling
+     * through to the interface implementation.
+     * <p>
+     * By default, polling for messages will be done in a background thread
+     * between calls to the interface - code may execute outside of calls to the
+     * interface. Updates may also be forced on the background thread if the
+     * interface has not been called in some time.
+     * <p>
+     * The field must refer to the desired implementation after delegate
+     * instantiation - the easiest way is to initialize the field with the right
+     * value. The field value will be wrapped in a proxy, which will be set as
+     * the new field value during code attachment. This way the implementation
+     * of the interface may be freely changed, while the reference passed to
+     * external code remains constant.
+     * <p>
+     * The field type must be that of the desired interface rather than its
+     * implementation.
+     */
     @Retention(RetentionPolicy.RUNTIME)
     @Target(ElementType.FIELD)
     public @interface Driver {

--- a/praxiscore-code/src/main/java/org/praxislive/code/CodeRootDelegate.java
+++ b/praxiscore-code/src/main/java/org/praxislive/code/CodeRootDelegate.java
@@ -21,12 +21,22 @@
  */
 package org.praxislive.code;
 
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
 /**
  * Base class for user rewritable Root code.
  */
 public class CodeRootDelegate extends CodeDelegate {
 
     public void init() {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.FIELD)
+    public @interface Driver {
     }
 
 }

--- a/praxiscore-code/src/main/java/org/praxislive/code/CodeRootFactoryService.java
+++ b/praxiscore-code/src/main/java/org/praxislive/code/CodeRootFactoryService.java
@@ -22,25 +22,12 @@
 
 package org.praxislive.code;
 
-import java.util.stream.Stream;
-import org.praxislive.core.Protocol;
-import org.praxislive.core.services.ComponentFactoryService;
+import org.praxislive.core.services.RootFactoryService;
 
 /**
  *
  * 
  */
-public class CodeComponentFactoryService extends ComponentFactoryService {
-    
-    
-    @Deprecated
-    public static class Provider implements Protocol.TypeProvider {
-
-        @Override
-        public Stream<Type> types() {
-            return Stream.of(new Protocol.Type<>(CodeComponentFactoryService.class));
-        }
+public class CodeRootFactoryService extends RootFactoryService {
         
-    }
-    
 }

--- a/praxiscore-components/src/main/java/org/praxislive/core/components/CoreComponents.java
+++ b/praxiscore-components/src/main/java/org/praxislive/core/components/CoreComponents.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright 2021 Neil C Smith.
+ * Copyright 2023 Neil C Smith.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3 only, as
@@ -85,7 +85,11 @@ public class CoreComponents implements ComponentFactoryProvider {
             add(CoreCode.containerBase().create(
                     "core:container", CoreContainer.class,
                     source(CoreContainer.TEMPLATE_PATH)));
-
+            
+            // ROOT
+            addRoot(CoreCode.rootContainerBase().create(
+                    "root:custom", CoreRootCustom.class,
+                    source(CoreRootCustom.TEMPLATE_PATH)));
         }
 
         private void add(String type, Class<? extends CoreCodeDelegate> cls, String path) {

--- a/praxiscore-components/src/main/java/org/praxislive/core/components/CoreRootCustom.java
+++ b/praxiscore-components/src/main/java/org/praxislive/core/components/CoreRootCustom.java
@@ -14,36 +14,43 @@
  *
  * You should have received a copy of the GNU Lesser General Public License version 3
  * along with this work; if not, see http://www.gnu.org/licenses/
- * 
+ *
  *
  * Please visit https://www.praxislive.org if you need additional information or
  * have any questions.
  */
-package org.praxislive.code.internal;
+package org.praxislive.core.components;
 
-import java.util.stream.Stream;
-import org.praxislive.code.CodeCompilerService;
-import org.praxislive.code.CodeComponentFactoryService;
-import org.praxislive.code.CodeContextFactoryService;
-import org.praxislive.code.CodeRootFactoryService;
-import org.praxislive.code.SharedCodeService;
-import org.praxislive.core.Protocol;
+import org.praxislive.code.GenerateTemplate;
+
+import org.praxislive.core.code.CoreRootContainerDelegate;
+
+// default imports
+import java.util.*;
+import java.util.function.*;
+import java.util.stream.*;
+import org.praxislive.core.*;
+import org.praxislive.core.types.*;
+import org.praxislive.code.userapi.*;
+
+import static org.praxislive.code.userapi.Constants.*;
 
 /**
  *
  * 
  */
-public class CodeProtocolsProvider implements Protocol.TypeProvider {
+@GenerateTemplate(CoreRootCustom.TEMPLATE_PATH)
+public class CoreRootCustom extends CoreRootContainerDelegate {
+    
+    final static String TEMPLATE_PATH = "resources/root_custom.pxj";
 
+    // PXJ-BEGIN:body
+    
     @Override
-    public Stream<Protocol.Type> types() {
-        return Stream.of(
-                new Protocol.Type<>(CodeCompilerService.class),
-                new Protocol.Type<>(CodeComponentFactoryService.class),
-                new Protocol.Type<>(CodeRootFactoryService.class),
-                new Protocol.Type<>(CodeContextFactoryService.class),
-                new Protocol.Type<>(SharedCodeService.class)
-        );
+    public void init() {
+
     }
+    
+    // PXJ-END:body
     
 }

--- a/praxiscore-core-code/src/main/java/org/praxislive/core/code/CoreCode.java
+++ b/praxiscore-core-code/src/main/java/org/praxislive/core/code/CoreCode.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright 2021 Neil C Smith.
+ * Copyright 2023 Neil C Smith.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3 only, as
@@ -42,6 +42,11 @@ public class CoreCode {
             = CodeFactory.containerBase(CoreContainerDelegate.class,
                     DEFAULT_IMPORTS,
                     (task, delegate) -> new CoreContainerCodeContext(new CoreContainerCodeConnector(task, delegate)));
+    
+    private final static CodeFactory.Base<CoreRootContainerDelegate> ROOT_CONTAINER_BASE
+            = CodeFactory.rootContainerBase(CoreRootContainerDelegate.class,
+                    DEFAULT_IMPORTS,
+                    (task, delegate) -> new CoreRootContainerCodeContext(new CoreRootContainerCodeConnector(task, delegate)));
 
     private CoreCode() {
     }
@@ -62,6 +67,15 @@ public class CoreCode {
      */
     public static CodeFactory.Base<CoreContainerDelegate> containerBase() {
         return CONTAINER_BASE;
+    }
+    
+    /**
+     * Access {@link CodeFactory.Base} for {@link CoreRootContainerDelegate}.
+     *
+     * @return code factory base for CoreRootContainerDelegate.
+     */
+    public static CodeFactory.Base<CoreRootContainerDelegate> rootContainerBase() {
+        return ROOT_CONTAINER_BASE;
     }
 
 }

--- a/praxiscore-core-code/src/main/java/org/praxislive/core/code/CoreCodeDelegate.java
+++ b/praxiscore-core-code/src/main/java/org/praxislive/core/code/CoreCodeDelegate.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright 2018 Neil C Smith.
+ * Copyright 2023 Neil C Smith.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3 only, as
@@ -25,10 +25,19 @@ import org.praxislive.code.DefaultCodeDelegate;
 
 /**
  *
- * 
+ *
  */
 public class CoreCodeDelegate extends DefaultCodeDelegate {
 
+    /**
+     * Hook called whenever the delegate needs to be initialized. Will be called
+     * when the root is started, on adding a component to a running root, and
+     * any time the code is updated. Because this code is called in a running
+     * root, the code should be suitable for real-time usage.
+     * <p>
+     * Implementation detail : this method calls the deprecated setup() by
+     * default().
+     */
     @SuppressWarnings("deprecation")
     public void init() {
         setup();
@@ -38,12 +47,26 @@ public class CoreCodeDelegate extends DefaultCodeDelegate {
     public void setup() {
     }
 
+    /**
+     * Hook called whenever the root is started. This method will be called
+     * after {@link #init()}. It is not called on code updates.
+     */
     public void starting() {
     }
 
+    /**
+     * Hook called on every clock update. This will vary depending on the root
+     * the component is installed into - it may correspond to every buffer or
+     * frame. If a component reacts solely to input and doesn't need to be
+     * called every cycle, do not override this method so that the delegate does
+     * not have to be connected to the clock (for efficiency).
+     */
     public void update() {
     }
 
+    /**
+     * Hook called when the root is stopping.
+     */
     public void stopping() {
     }
 

--- a/praxiscore-core-code/src/main/java/org/praxislive/core/code/CoreContainerDelegate.java
+++ b/praxiscore-core-code/src/main/java/org/praxislive/core/code/CoreContainerDelegate.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright 2021 Neil C Smith.
+ * Copyright 2023 Neil C Smith.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3 only, as
@@ -30,16 +30,36 @@ import org.praxislive.code.DefaultDelegateAPI;
  */
 public class CoreContainerDelegate extends CodeContainerDelegate implements DefaultDelegateAPI {
 
+    /**
+     * Hook called whenever the delegate needs to be initialized. Will be called
+     * when the root is started, on adding a component to a running root, and
+     * any time the code is updated. Because this code is called in a running
+     * root, the code should be suitable for real-time usage.
+     */
     @Override
     public void init() {
     }
 
+    /**
+     * Hook called whenever the root is started. This method will be called
+     * after {@link #init()}. It is not called on code updates.
+     */
     public void starting() {
     }
 
+    /**
+     * Hook called on every clock update. This will vary depending on the root
+     * the component is installed into - it may correspond to every buffer or
+     * frame. If a component reacts solely to input and doesn't need to be
+     * called every cycle, do not override this method so that the delegate does
+     * not have to be connected to the clock (for efficiency).
+     */
     public void update() {
     }
 
+    /**
+     * Hook called when the root is stopping.
+     */
     public void stopping() {
     }
 

--- a/praxiscore-core-code/src/main/java/org/praxislive/core/code/CoreRootContainerCodeConnector.java
+++ b/praxiscore-core-code/src/main/java/org/praxislive/core/code/CoreRootContainerCodeConnector.java
@@ -1,0 +1,60 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright 2023 Neil C Smith.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License version 3 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * version 3 for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License version 3
+ * along with this work; if not, see http://www.gnu.org/licenses/
+ *
+ *
+ * Please visit https://www.praxislive.org if you need additional information or
+ * have any questions.
+ *
+ */
+package org.praxislive.core.code;
+
+import java.lang.reflect.Method;
+import org.praxislive.code.CodeFactory;
+import org.praxislive.code.CodeRootContainer;
+
+/**
+ *
+ * 
+ */
+class CoreRootContainerCodeConnector extends CodeRootContainer.Connector<CoreRootContainerDelegate> {
+
+    private final static String UPDATE = "update";
+
+    private boolean foundUpdate;
+
+    CoreRootContainerCodeConnector(CodeFactory.Task<CoreRootContainerDelegate> contextCreator,
+            CoreRootContainerDelegate delegate) {
+        super(contextCreator, delegate);
+    }
+
+    @Override
+    protected boolean requiresClock() {
+        return super.requiresClock() || foundUpdate;
+    }
+
+    @Override
+    protected void analyseMethod(Method method) {
+
+        if (UPDATE.equals(method.getName())
+                && method.getParameterCount() == 0) {
+            foundUpdate = true;
+        }
+
+        super.analyseMethod(method);
+    }
+
+}

--- a/praxiscore-core-code/src/main/java/org/praxislive/core/code/CoreRootContainerCodeContext.java
+++ b/praxiscore-core-code/src/main/java/org/praxislive/core/code/CoreRootContainerCodeContext.java
@@ -38,6 +38,7 @@ class CoreRootContainerCodeContext extends CodeRootContainer.Context<CoreRootCon
 
     @Override
     protected void starting(ExecutionContext source, boolean fullStart) {
+        super.starting(source, fullStart);
         try {
             getDelegate().init();
         } catch (Exception e) {
@@ -61,6 +62,7 @@ class CoreRootContainerCodeContext extends CodeRootContainer.Context<CoreRootCon
                 getLog().log(LogLevel.ERROR, e, "Exception thrown during stopping()");
             }
         }
+        super.stopping(source, fullStop);
     }
 
     @Override

--- a/praxiscore-core-code/src/main/java/org/praxislive/core/code/CoreRootContainerCodeContext.java
+++ b/praxiscore-core-code/src/main/java/org/praxislive/core/code/CoreRootContainerCodeContext.java
@@ -1,0 +1,75 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright 2023 Neil C Smith.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License version 3 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * version 3 for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License version 3
+ * along with this work; if not, see http://www.gnu.org/licenses/
+ *
+ *
+ * Please visit https://www.praxislive.org if you need additional information or
+ * have any questions.
+ *
+ */
+package org.praxislive.core.code;
+
+import org.praxislive.code.CodeContext;
+import org.praxislive.code.CodeRootContainer;
+import org.praxislive.core.ExecutionContext;
+import org.praxislive.core.services.LogLevel;
+
+/**
+ * A {@link CodeContext} for core root containers.
+ */
+class CoreRootContainerCodeContext extends CodeRootContainer.Context<CoreRootContainerDelegate> {
+    
+    CoreRootContainerCodeContext(CoreRootContainerCodeConnector connector) {
+        super(connector);
+    }
+
+    @Override
+    protected void starting(ExecutionContext source, boolean fullStart) {
+        try {
+            getDelegate().init();
+        } catch (Exception e) {
+            getLog().log(LogLevel.ERROR, e, "Exception thrown during init()");
+        }
+        if (fullStart) {
+            try {
+                getDelegate().starting();
+            } catch (Exception e) {
+                getLog().log(LogLevel.ERROR, e, "Exception thrown during starting()");
+            }
+        }
+    }
+
+    @Override
+    protected void stopping(ExecutionContext source, boolean fullStop) {
+        if (fullStop) {
+            try {
+                getDelegate().stopping();
+            } catch (Exception e) {
+                getLog().log(LogLevel.ERROR, e, "Exception thrown during stopping()");
+            }
+        }
+    }
+
+    @Override
+    protected void tick(ExecutionContext source) {
+        try {
+            getDelegate().update();
+        } catch (Exception e) {
+            getLog().log(LogLevel.ERROR, e, "Exception thrown during update()");
+        }
+    }
+
+}

--- a/praxiscore-core-code/src/main/java/org/praxislive/core/code/CoreRootContainerDelegate.java
+++ b/praxiscore-core-code/src/main/java/org/praxislive/core/code/CoreRootContainerDelegate.java
@@ -14,36 +14,34 @@
  *
  * You should have received a copy of the GNU Lesser General Public License version 3
  * along with this work; if not, see http://www.gnu.org/licenses/
- * 
+ *
  *
  * Please visit https://www.praxislive.org if you need additional information or
  * have any questions.
  */
-package org.praxislive.code.internal;
+package org.praxislive.core.code;
 
-import java.util.stream.Stream;
-import org.praxislive.code.CodeCompilerService;
-import org.praxislive.code.CodeComponentFactoryService;
-import org.praxislive.code.CodeContextFactoryService;
-import org.praxislive.code.CodeRootFactoryService;
-import org.praxislive.code.SharedCodeService;
-import org.praxislive.core.Protocol;
+import org.praxislive.code.CodeRootContainerDelegate;
+import org.praxislive.code.DefaultDelegateAPI;
 
 /**
  *
- * 
+ *
  */
-public class CodeProtocolsProvider implements Protocol.TypeProvider {
+public class CoreRootContainerDelegate extends CodeRootContainerDelegate
+        implements DefaultDelegateAPI {
 
     @Override
-    public Stream<Protocol.Type> types() {
-        return Stream.of(
-                new Protocol.Type<>(CodeCompilerService.class),
-                new Protocol.Type<>(CodeComponentFactoryService.class),
-                new Protocol.Type<>(CodeRootFactoryService.class),
-                new Protocol.Type<>(CodeContextFactoryService.class),
-                new Protocol.Type<>(SharedCodeService.class)
-        );
+    public void init() {
     }
-    
+
+    public void starting() {
+    }
+
+    public void update() {
+    }
+
+    public void stopping() {
+    }
+
 }

--- a/praxiscore-core-code/src/main/java/org/praxislive/core/code/CoreRootContainerDelegate.java
+++ b/praxiscore-core-code/src/main/java/org/praxislive/core/code/CoreRootContainerDelegate.java
@@ -31,16 +31,36 @@ import org.praxislive.code.DefaultDelegateAPI;
 public class CoreRootContainerDelegate extends CodeRootContainerDelegate
         implements DefaultDelegateAPI {
 
+    /**
+     * Hook called whenever the delegate needs to be initialized. Will be called
+     * when the root is started, and any time the code is updated. Because this
+     * code is called in a running root, the code should be suitable for
+     * real-time usage.
+     */
     @Override
     public void init() {
     }
 
+    /**
+     * Hook called whenever the root is started. This method will be called
+     * after {@link #init()}. It is not called on code updates.
+     */
     public void starting() {
     }
 
+    /**
+     * Hook called on every clock update. This will vary depending on the root
+     * the component is installed into - it may correspond to every buffer or
+     * frame. If a component reacts solely to input and doesn't need to be
+     * called every cycle, do not override this method so that the delegate does
+     * not have to be connected to the clock (for efficiency).
+     */
     public void update() {
     }
 
+    /**
+     * Hook called when the root is stopping.
+     */
     public void stopping() {
     }
 

--- a/testsuite/tests/config
+++ b/testsuite/tests/config
@@ -5,3 +5,4 @@ core/components
 core/basic-multiprocess
 core/shared-delegates
 core/async-functions
+core/code-roots

--- a/testsuite/tests/core/code-roots/custom1.pxr
+++ b/testsuite/tests/core/code-roots/custom1.pxr
@@ -1,0 +1,107 @@
+@ /custom1 root:custom {
+  #%praxis.version 5.6.0-SNAPSHOT
+  .shared-code "SHARED.Types \{package SHARED;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import org.praxislive.code.userapi.Ref;
+
+public class Types extends Ref.Provider \{
+
+    public static final String THREAD_NAME = \"CUSTOM1\";
+    
+    public Types() \{
+        provide(ScheduledExecutorService.class,
+                () -> Executors.newSingleThreadScheduledExecutor(
+                        r -> new Thread(r, THREAD_NAME)
+                ),
+                ScheduledExecutorService::shutdown);
+    \}
+    
+\}\}"
+  .code "import SHARED.Types;
+import java.util.concurrent.*;
+
+
+    
+    @Inject(provider = Types.class)
+    ScheduledExecutorService exec;
+
+    @Persist Future<?> controller;
+    @Driver Runnable task = this::run;
+    
+    @P(1) @ReadOnly String threadName;
+    
+    @Override
+    public void starting() \{
+        controller = exec.scheduleAtFixedRate(task, 10, 10, TimeUnit.MILLISECONDS);
+    \}
+
+    @Override
+    public void stopping() \{
+        controller.cancel(true);
+        threadName = \"\";
+    \}
+
+    @Override
+    public void update() \{
+        threadName = Thread.currentThread().getName();
+    \}
+    
+    
+    
+    private void run() \{
+        if (Types.THREAD_NAME.equals(threadName)) \{
+            tell(ControlAddress.of(\"/custom1/join.in-1\"), \"\");
+        \} else \{
+            tell(ControlAddress.of(\"/custom1/exit.exit-fail\"), \"\");
+        \}
+    \}
+    
+    
+    
+"
+  @ ./exit core:custom {
+    #%graph.x 491
+    #%graph.y 50
+    .code "import org.praxislive.core.services.Services;
+import org.praxislive.core.services.SystemManagerService;
+
+
+    @T(1)
+    void exitOK() \{
+        exit(0);
+    \}
+
+    @T(2)
+    void exitFail() \{
+        exit(1);
+    \}
+
+    private void exit(int exitValue) \{
+        find(Services.class)
+                .flatMap(s -> s.locate(SystemManagerService.class))
+                .ifPresent(s -> tell(ControlAddress.of(s, \"system-exit\"), exitValue));
+    \}
+
+"
+  }
+  @ ./gate core:routing:gate {
+    #%graph.x 202
+    #%graph.y 50
+    .active true
+    .pattern [array 0 0 1]
+  }
+  @ ./join core:routing:join {
+    #%graph.x 349
+    #%graph.y 50
+  }
+  @ ./timer core:timing:timer {
+    #%graph.x 50
+    #%graph.y 50
+    .period 0.05
+  }
+  ~ ./timer!out ./gate!in
+  ~ ./gate!out ./join!in-2
+  ~ ./join!out ./exit!exit-ok
+}

--- a/testsuite/tests/core/code-roots/project.pxp
+++ b/testsuite/tests/core/code-roots/project.pxp
@@ -1,0 +1,13 @@
+hub {
+
+}
+compiler {
+  release 11
+}
+libraries {}
+
+# <<<BUILD>>>
+include [file "custom1.pxr"]
+
+# <<<RUN>>>
+/custom1.start


### PR DESCRIPTION
Initial implementation of recodeable roots, including support for `@Driver` annotated interface proxies to drive root updates from a different source. Some fixes and changes to `AbstractRoot` delegate and thread handling to support actions under lock, and better background polling.