### PR TITLE
Update to libP5X 0.353.0-beta-4 and LWJGL 3.3.2.

### DIFF
--- a/praxiscore-base/src/main/java/org/praxislive/base/AbstractRoot.java
+++ b/praxiscore-base/src/main/java/org/praxislive/base/AbstractRoot.java
@@ -382,7 +382,7 @@ public abstract class AbstractRoot implements Root {
         }
 
         if ((time - this.time) < 0) {
-            LOG.log(Level.WARNING, () -> "Update time is not monotonic : behind by " + (time - this.time));
+            LOG.log(Level.FINE, () -> "Update time is not monotonic : behind by " + (time - this.time));
             this.time++;
         } else {
             this.time = time;

--- a/praxiscore-video-components/src/main/java/org/praxislive/video/impl/components/DefaultVideoRoot.java
+++ b/praxiscore-video-components/src/main/java/org/praxislive/video/impl/components/DefaultVideoRoot.java
@@ -189,6 +189,7 @@ public class DefaultVideoRoot extends AbstractRootContainer {
     protected void stopping() {
         lookup = null;
         player.terminate();
+        player = null;
         interrupt();
     }
 

--- a/praxiscore-video-pgl-natives/pom.xml
+++ b/praxiscore-video-pgl-natives/pom.xml
@@ -15,7 +15,7 @@
       <dependency>
         <groupId>org.lwjgl</groupId>
         <artifactId>lwjgl-bom</artifactId>
-        <version>3.2.3</version>
+        <version>3.3.2</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>

--- a/praxiscore-video-pgl/pom.xml
+++ b/praxiscore-video-pgl/pom.xml
@@ -15,7 +15,7 @@
       <dependency>
         <groupId>org.lwjgl</groupId>
         <artifactId>lwjgl-bom</artifactId>
-        <version>3.2.3</version>
+        <version>3.3.2</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>
@@ -36,12 +36,12 @@
     <dependency>
       <groupId>org.praxislive.libp5x</groupId>
       <artifactId>processing-core</artifactId>
-      <version>0.353.0-beta-3</version>
+      <version>0.353.0-beta-4</version>
     </dependency>
     <dependency>
       <groupId>org.praxislive.libp5x</groupId>
       <artifactId>processing-lwjgl</artifactId>
-      <version>0.353.0-beta-3</version>
+      <version>0.353.0-beta-4</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Update to libP5X 0.353.0-beta-4 and LWJGL 3.3.2. Fixes #43 

Also explicitly set player to null after window closing. Also move monotonic logging to lower level - delegate might be ahead of time.