### PR TITLE
Add ComponentRegistry and optional supported-types to containers

### DIFF
--- a/praxiscore-api/src/main/java/org/praxislive/core/ComponentRegistry.java
+++ b/praxiscore-api/src/main/java/org/praxislive/core/ComponentRegistry.java
@@ -1,0 +1,122 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright 2023 Neil C Smith.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License version 3 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * version 3 for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License version 3
+ * along with this work; if not, see http://www.gnu.org/licenses/
+ * 
+ *
+ * Please visit https://www.praxislive.org if you need additional information or
+ * have any questions.
+ */
+package org.praxislive.core;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A registry of all the components available in the local system along with
+ * their metadata. Implementations usually to be provided in the {@link RootHub}
+ * lookup.
+ * <p>
+ * The registry may change over time, eg. by the addition of libraries.
+ * Implementations should cache the query result, so that object identity can be
+ * used to check for changes.
+ * <p>
+ * The contents of the registry will reflect the contents of all available
+ * {@link ComponentFactory}. The component data from the registry result will
+ * include all component data from the ComponentFactory, as well as the
+ * ComponentFactory itself and any other implementation specific data.
+ *
+ */
+public interface ComponentRegistry {
+
+    /**
+     * Query the components available on the local system. The same result will
+     * be returned unless the data has changed, so object identity can be used
+     * to check for changes.
+     *
+     * @return component information
+     */
+    public Result query();
+
+    /**
+     * Component results to be returned from {@link #query()}.
+     */
+    public static final class Result {
+
+        private final List<ComponentType> componentTypes;
+        private final List<ComponentType> rootTypes;
+        private final Map<ComponentType, Lookup> componentData;
+        private final Map<ComponentType, Lookup> rootData;
+
+        /**
+         * Construct a Result object. The data will be copied from the provided
+         * maps, which should not contain null keys or values. Use of ordered
+         * maps is recommended, and the order will be reflected in the lists of
+         * component and root types.
+         *
+         * @param components map of component types and metadata
+         * @param roots map of root types and metadata
+         */
+        public Result(Map<ComponentType, Lookup> components,
+                Map<ComponentType, Lookup> roots) {
+            this.componentTypes = List.copyOf(components.keySet());
+            this.componentData = Map.copyOf(components);
+            this.rootTypes = List.copyOf(roots.keySet());
+            this.rootData = Map.copyOf(roots);
+        }
+
+        /**
+         * List of component types available on the local system. The returned
+         * list is immutable.
+         *
+         * @return component types
+         */
+        public List<ComponentType> componentTypes() {
+            return componentTypes;
+        }
+
+        /**
+         * Query the data for the provided component type.
+         *
+         * @param type component type
+         * @return data, or null if not a provided type
+         */
+        public Lookup componentData(ComponentType type) {
+            return componentData.get(type);
+        }
+
+        /**
+         * List of root types available on the local system. The returned list
+         * is immutable.
+         *
+         * @return root types
+         */
+        public List<ComponentType> rootTypes() {
+            return rootTypes;
+        }
+
+        /**
+         * Query the data for the provided root type.
+         *
+         * @param type root type
+         * @return data, or null if not a provided type
+         */
+        public Lookup rootData(ComponentType type) {
+            return rootData.get(type);
+        }
+
+    }
+
+}

--- a/praxiscore-api/src/main/java/org/praxislive/core/Protocol.java
+++ b/praxiscore-api/src/main/java/org/praxislive/core/Protocol.java
@@ -52,6 +52,22 @@ public interface Protocol {
     public Stream<String> controls();
 
     /**
+     * The names of additional controls that a component advertising this
+     * protocol might provide. These controls are optional. Any caller should
+     * check whether the component info contains the control, or otherwise
+     * prepare for the control not to be available.
+     * <p>
+     * Implementation note : the protocol implementation should support querying
+     * the control info via {@link #getControlInfo(java.lang.String)}. The
+     * default implementation returns an empty stream.
+     *
+     * @return stream of optional control names
+     */
+    public default Stream<String> optionalControls() {
+        return Stream.empty();
+    }
+
+    /**
      * Query the ControlInfo for the provided control name on this protocol. The
      * component implementing this protocol will generally use the control info
      * provided here inside its component info. In exceptional circumstances,

--- a/praxiscore-api/src/main/java/org/praxislive/core/Protocol.java
+++ b/praxiscore-api/src/main/java/org/praxislive/core/Protocol.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright 2020 Neil C Smith.
+ * Copyright 2023 Neil C Smith.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3 only, as
@@ -38,28 +38,68 @@ import org.praxislive.core.services.SystemManagerService;
 import org.praxislive.core.services.TaskService;
 
 /**
- *
+ * A Protocol defines known controls and behaviours that a component can
+ * provide.
  */
 public interface Protocol {
-    
+
+    /**
+     * The names of the controls that a component advertising this protocol must
+     * provide.
+     *
+     * @return stream of control names
+     */
     public Stream<String> controls();
-    
+
+    /**
+     * Query the ControlInfo for the provided control name on this protocol. The
+     * component implementing this protocol will generally use the control info
+     * provided here inside its component info. In exceptional circumstances,
+     * the component may extend or adapt the behaviour of the control, as long
+     * as it is fully compatible with this control info and the specification.
+     *
+     * @param control name of control
+     * @return control info for named control
+     */
     public ControlInfo getControlInfo(String control);
-    
+
+    /**
+     * A protocol type registration, allowing protocols to be discovered by
+     * class or name. Additional types may be registered using
+     * {@link TypeProvider}.
+     *
+     * @param <T> class of protocol
+     */
     public static class Type<T extends Protocol> {
-        
+
         private final Class<T> cls;
         private final String name;
-        
+
+        /**
+         * Construct a type for the given Protocol class. The name will be the
+         * simple name of the class.
+         *
+         * @param cls Protocol class
+         */
         public Type(Class<T> cls) {
             this.cls = Objects.requireNonNull(cls);
             this.name = cls.getSimpleName();
         }
-        
+
+        /**
+         * Access the class of the Protocol type.
+         *
+         * @return class
+         */
         public Class<T> asClass() {
             return cls;
         }
-        
+
+        /**
+         * Access the name of the Protocol type.
+         *
+         * @return name
+         */
         public String name() {
             return name;
         }
@@ -88,7 +128,15 @@ public interface Protocol {
             final Type<?> other = (Type<?>) obj;
             return Objects.equals(this.cls, other.cls);
         }
-        
+
+        /**
+         * Lookup the Protocol type of the provided class. The type must be
+         * registered.
+         *
+         * @param <T> class type
+         * @param cls class
+         * @return type
+         */
         @SuppressWarnings("unchecked")
         public static <T extends Protocol> Type<T> of(Class<T> cls) {
             Type<T> type = (Type<T>) typesByClass.get(cls);
@@ -97,11 +145,18 @@ public interface Protocol {
             }
             return type;
         }
-        
+
+        /**
+         * Lookup the Protocol type by name. If not registered an empty optional
+         * is returned.
+         *
+         * @param name protocol name
+         * @return optional of type
+         */
         public static Optional<Type<? extends Protocol>> fromName(String name) {
             return Optional.ofNullable(typesByName.get(name));
         }
-        
+
         private final static Map<Class<? extends Protocol>, Type<? extends Protocol>> typesByClass
                 = new HashMap<>();
         private final static Map<String, Type<? extends Protocol>> typesByName
@@ -114,13 +169,13 @@ public interface Protocol {
             typesByClass.put(type.asClass(), type);
             typesByName.put(type.name(), type);
         }
-        
+
         static {
-            
+
             register(new Type<>(ComponentProtocol.class));
             register(new Type<>(ContainerProtocol.class));
             register(new Type<>(StartableProtocol.class));
-            
+
             register(new Type<>(ComponentFactoryService.class));
             register(new Type<>(RootFactoryService.class));
             register(new Type<>(RootManagerService.class));
@@ -128,21 +183,28 @@ public interface Protocol {
             register(new Type<>(SystemManagerService.class));
             register(new Type<>(TaskService.class));
             register(new Type<>(LogService.class));
-            
+
             Lookup.SYSTEM.findAll(TypeProvider.class)
                     .flatMap(TypeProvider::types)
                     .forEachOrdered(Type::register);
-            
-            
-            
+
         }
-        
+
     }
-    
+
+    /**
+     * Provide additional {@link Protocol.Type}. Instances should be registered
+     * to be discovered via {@link Lookup#SYSTEM}.
+     */
     public static interface TypeProvider {
-        
+
+        /**
+         * Types to register.
+         *
+         * @return stream to types
+         */
         Stream<Type> types();
-        
+
     }
-    
+
 }

--- a/praxiscore-api/src/main/java/org/praxislive/core/protocols/ComponentProtocol.java
+++ b/praxiscore-api/src/main/java/org/praxislive/core/protocols/ComponentProtocol.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright 2020 Neil C Smith.
+ * Copyright 2023 Neil C Smith.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3 only, as
@@ -22,32 +22,49 @@
 package org.praxislive.core.protocols;
 
 import java.util.stream.Stream;
+import org.praxislive.core.Component;
 import org.praxislive.core.ComponentInfo;
 import org.praxislive.core.ControlInfo;
 import org.praxislive.core.Info;
 import org.praxislive.core.Protocol;
 
 /**
- *
+ * Basic component protocol, providing access to the component info.
  */
 public class ComponentProtocol implements Protocol {
-    
+
+    @Deprecated
     public final static ComponentProtocol INSTANCE = new ComponentProtocol();
+
+    /**
+     * Name of the info control.
+     */
     public final static String INFO = "info";
-    public final static ControlInfo INFO_INFO =
-            ControlInfo.createReadOnlyPropertyInfo(
-            ComponentInfo.info(),
-            null);
+
+    /**
+     * Control info for the info control. A read-only property that returns the
+     * component info. The response to calling this control should be the same
+     * as calling {@link Component#getInfo}.
+     */
+    public final static ControlInfo INFO_INFO
+            = ControlInfo.createReadOnlyPropertyInfo(
+                    ComponentInfo.info(),
+                    null);
+
+    /**
+     * A component info for this protocol. Can be used with
+     * {@link Info.ComponentInfoBuilder#merge(org.praxislive.core.ComponentInfo)}.
+     */
     public final static ComponentInfo API_INFO = Info.component(cmp -> cmp
             .protocol(ComponentProtocol.class)
             .control(INFO, INFO_INFO)
     );
-    
+
     @Override
     public Stream<String> controls() {
         return Stream.of(INFO);
     }
-    
+
     @Override
     public ControlInfo getControlInfo(String control) {
         if (INFO.equals(control)) {
@@ -55,5 +72,5 @@ public class ComponentProtocol implements Protocol {
         }
         throw new IllegalArgumentException();
     }
-    
+
 }

--- a/praxiscore-api/src/main/java/org/praxislive/core/protocols/ContainerProtocol.java
+++ b/praxiscore-api/src/main/java/org/praxislive/core/protocols/ContainerProtocol.java
@@ -29,6 +29,7 @@ import org.praxislive.core.ComponentInfo;
 import org.praxislive.core.Container;
 import org.praxislive.core.ControlInfo;
 import org.praxislive.core.Info;
+import org.praxislive.core.Lookup;
 import org.praxislive.core.Protocol;
 import org.praxislive.core.types.PArray;
 import org.praxislive.core.types.PMap;
@@ -72,6 +73,11 @@ public class ContainerProtocol implements Protocol {
      * Name of the connections control.
      */
     public final static String CONNECTIONS = "connections";
+
+    /**
+     * Name of the supported-types control.
+     */
+    public final static String SUPPORTED_TYPES = "supported-types";
 
     private final static ArgumentInfo STRING = PString.info();
 
@@ -140,8 +146,23 @@ public class ContainerProtocol implements Protocol {
                     PMap.EMPTY);
 
     /**
+     * Info for the (optional) supported-types control. It is a read-only
+     * property that returns a PArray consisting of all supported
+     * {@link ComponentType} that can be passed to add-child.
+     * <p>
+     * A {@link SupportedTypes} implementation may be registered in the
+     * container's {@link Lookup} to facilitate implementation of this control
+     * by child containers.
+     */
+    public final static ControlInfo SUPPORTED_TYPES_INFO
+            = Info.control(c -> c.readOnlyProperty().output(PArray.class));
+
+    /**
      * A component info for this protocol. Can be used with
      * {@link Info.ComponentInfoBuilder#merge(org.praxislive.core.ComponentInfo)}.
+     * <p>
+     * This does not contain info for optional controls (ie. supported-types)
+     * which must be added additionally if required.
      */
     public static final ComponentInfo API_INFO = Info.component(cmp -> cmp
             .protocol(ContainerProtocol.class)
@@ -160,6 +181,11 @@ public class ContainerProtocol implements Protocol {
     }
 
     @Override
+    public Stream<String> optionalControls() {
+        return Stream.of(SUPPORTED_TYPES);
+    }
+
+    @Override
     public ControlInfo getControlInfo(String control) {
         switch (control) {
             case ADD_CHILD:
@@ -174,7 +200,10 @@ public class ContainerProtocol implements Protocol {
                 return DISCONNECT_INFO;
             case CONNECTIONS:
                 return CONNECTIONS_INFO;
+            case SUPPORTED_TYPES:
+                return SUPPORTED_TYPES_INFO;
         }
         throw new IllegalArgumentException();
     }
+
 }

--- a/praxiscore-api/src/main/java/org/praxislive/core/protocols/ContainerProtocol.java
+++ b/praxiscore-api/src/main/java/org/praxislive/core/protocols/ContainerProtocol.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright 2020 Neil C Smith.
+ * Copyright 2023 Neil C Smith.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3 only, as
@@ -26,6 +26,7 @@ import java.util.stream.Stream;
 import org.praxislive.core.ComponentType;
 import org.praxislive.core.ArgumentInfo;
 import org.praxislive.core.ComponentInfo;
+import org.praxislive.core.Container;
 import org.praxislive.core.ControlInfo;
 import org.praxislive.core.Info;
 import org.praxislive.core.Protocol;
@@ -34,47 +35,114 @@ import org.praxislive.core.types.PMap;
 import org.praxislive.core.types.PString;
 
 /**
- *
+ * A container protocol that allows for calls to add / remove child components,
+ * and connect / disconnect their ports.
  */
 public class ContainerProtocol implements Protocol {
 
+    @Deprecated
     public final static ContainerProtocol INSTANCE = new ContainerProtocol();
+
+    /**
+     * Name of the add-child control.
+     */
     public final static String ADD_CHILD = "add-child";
+
+    /**
+     * Name of the remove-child control.
+     */
     public final static String REMOVE_CHILD = "remove-child";
+
+    /**
+     * Name of the children control.
+     */
     public final static String CHILDREN = "children";
+
+    /**
+     * Name of the connect control.
+     */
     public final static String CONNECT = "connect";
+
+    /**
+     * Name of the disconnect control.
+     */
     public final static String DISCONNECT = "disconnect";
+
+    /**
+     * Name of the connections control.
+     */
     public final static String CONNECTIONS = "connections";
+
     private final static ArgumentInfo STRING = PString.info();
+
+    /**
+     * Info for the add-child control. It is a function control that accepts two
+     * arguments, the child name and the component type. It returns no
+     * arguments. It will respond with an error if the child cannot be added.
+     */
     public final static ControlInfo ADD_CHILD_INFO
             = ControlInfo.createFunctionInfo(
                     List.of(STRING, ComponentType.info()),
                     List.of(),
                     PMap.EMPTY);
+
+    /**
+     * Info for the remove-child control. It is a function control that accepts
+     * one argument, the child name. It returns no arguments.
+     */
     public final static ControlInfo REMOVE_CHILD_INFO
             = ControlInfo.createFunctionInfo(
                     List.of(STRING),
                     List.of(),
                     PMap.EMPTY);
+
+    /**
+     * Info for the children control. It is a read-only property control that
+     * returns a PArray of child names. The response is equivalent to
+     * {@link Container#children()}.
+     */
     public final static ControlInfo CHILDREN_INFO
             = ControlInfo.createReadOnlyPropertyInfo(
                     PArray.info(),
                     PMap.EMPTY);
+
+    /**
+     * Info for the connect control. It is a function control that accepts four
+     * arguments, the first component name, the first port name, the second
+     * component name, and the second port name. It returns no arguments. It
+     * will response with an error if the connection cannot be made.
+     */
     public final static ControlInfo CONNECT_INFO
             = ControlInfo.createFunctionInfo(
                     List.of(STRING, STRING, STRING, STRING),
                     List.of(),
                     PMap.EMPTY);
+
+    /**
+     * Info for the disconnect control. It is a function control that accepts
+     * four arguments, the first component name, the first port name, the second
+     * component name, and the second port name. It returns no arguments.
+     */
     public final static ControlInfo DISCONNECT_INFO
             = ControlInfo.createFunctionInfo(
                     List.of(STRING, STRING, STRING, STRING),
                     List.of(),
                     PMap.EMPTY);
+
+    /**
+     * Info for the connections control. It is a read-only property that returns
+     * a PArray of PArray. Each internal PArray consists of four values,
+     * corresponding to the arguments passed to each call to connect.
+     */
     public final static ControlInfo CONNECTIONS_INFO
             = ControlInfo.createReadOnlyPropertyInfo(
                     PArray.info(),
                     PMap.EMPTY);
 
+    /**
+     * A component info for this protocol. Can be used with
+     * {@link Info.ComponentInfoBuilder#merge(org.praxislive.core.ComponentInfo)}.
+     */
     public static final ComponentInfo API_INFO = Info.component(cmp -> cmp
             .protocol(ContainerProtocol.class)
             .control(ADD_CHILD, ADD_CHILD_INFO)
@@ -93,23 +161,19 @@ public class ContainerProtocol implements Protocol {
 
     @Override
     public ControlInfo getControlInfo(String control) {
-        if (ADD_CHILD.equals(control)) {
-            return ADD_CHILD_INFO;
-        }
-        if (REMOVE_CHILD.equals(control)) {
-            return REMOVE_CHILD_INFO;
-        }
-        if (CHILDREN.equals(control)) {
-            return CHILDREN_INFO;
-        }
-        if (CONNECT.equals(control)) {
-            return CONNECT_INFO;
-        }
-        if (DISCONNECT.equals(control)) {
-            return DISCONNECT_INFO;
-        }
-        if (CONNECTIONS.equals(control)) {
-            return CONNECTIONS_INFO;
+        switch (control) {
+            case ADD_CHILD:
+                return ADD_CHILD_INFO;
+            case REMOVE_CHILD:
+                return REMOVE_CHILD_INFO;
+            case CHILDREN:
+                return CHILDREN_INFO;
+            case CONNECT:
+                return CONNECT_INFO;
+            case DISCONNECT:
+                return DISCONNECT_INFO;
+            case CONNECTIONS:
+                return CONNECTIONS_INFO;
         }
         throw new IllegalArgumentException();
     }

--- a/praxiscore-api/src/main/java/org/praxislive/core/protocols/StartableProtocol.java
+++ b/praxiscore-api/src/main/java/org/praxislive/core/protocols/StartableProtocol.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright 2020 Neil C Smith.
+ * Copyright 2023 Neil C Smith.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3 only, as
@@ -30,29 +30,62 @@ import org.praxislive.core.types.PBoolean;
 import org.praxislive.core.types.PMap;
 
 /**
- *
+ * Protocol for a component that can be started and stopped.
  */
 public class StartableProtocol implements Protocol {
 
+    @Deprecated
     public final static StartableProtocol INSTANCE = new StartableProtocol();
 
+    /**
+     * Name of the start control.
+     */
     public final static String START = "start";
-    public final static String STOP = "stop";
-    public final static String IS_RUNNING = "is-running";
-    public final static ControlInfo START_INFO = ControlInfo.createActionInfo(PMap.EMPTY);
-    public final static ControlInfo STOP_INFO = ControlInfo.createActionInfo(PMap.EMPTY);
-    public final static ControlInfo IS_RUNNING_INFO =
-            ControlInfo.createReadOnlyPropertyInfo(
-                PBoolean.info(),
-                null);;
 
+    /**
+     * Name of the stop control.
+     */
+    public final static String STOP = "stop";
+
+    /**
+     * Name of the is-running control.
+     */
+    public final static String IS_RUNNING = "is-running";
+
+    /**
+     * Info for the start control. It is an action control that should "start"
+     * the component. It may respond with an error if for some reason the
+     * component cannot be started.
+     */
+    public final static ControlInfo START_INFO = ControlInfo.createActionInfo(PMap.EMPTY);
+
+    /**
+     * Info for the stop control. It is an action control that should "stop" the
+     * component. It may respond with an error if for some reason the component
+     * cannot be stopped.
+     */
+    public final static ControlInfo STOP_INFO = ControlInfo.createActionInfo(PMap.EMPTY);
+
+    /**
+     * Info for the is-running control. It is a read-only boolean property that
+     * responds whether the component is currently running / started.
+     */
+    public final static ControlInfo IS_RUNNING_INFO
+            = ControlInfo.createReadOnlyPropertyInfo(
+                    PBoolean.info(),
+                    null);
+    ;
+
+    /**
+     * A component info for this protocol. Can be used with
+     * {@link Info.ComponentInfoBuilder#merge(org.praxislive.core.ComponentInfo)}.
+     */
     public static final ComponentInfo API_INFO = Info.component(cmp -> cmp
             .protocol(StartableProtocol.class)
             .control(START, START_INFO)
             .control(STOP, STOP_INFO)
             .control(IS_RUNNING, IS_RUNNING_INFO)
     );
- 
 
     @Override
     public Stream<String> controls() {
@@ -61,17 +94,14 @@ public class StartableProtocol implements Protocol {
 
     @Override
     public ControlInfo getControlInfo(String control) {
-        if (START.equals(control)) {
-            return START_INFO;
-        }
-        if (STOP.equals(control)) {
-            return STOP_INFO;
-        }
-        if (IS_RUNNING.equals(control)) {
-            return IS_RUNNING_INFO;
+        switch (control) {
+            case START:
+                return START_INFO;
+            case STOP:
+                return STOP_INFO;
+            case IS_RUNNING:
+                return IS_RUNNING_INFO;
         }
         throw new IllegalArgumentException();
     }
 }
-
-

--- a/praxiscore-api/src/main/java/org/praxislive/core/protocols/SupportedTypes.java
+++ b/praxiscore-api/src/main/java/org/praxislive/core/protocols/SupportedTypes.java
@@ -1,0 +1,86 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright 2023 Neil C Smith.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License version 3 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * version 3 for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License version 3
+ * along with this work; if not, see http://www.gnu.org/licenses/
+ * 
+ *
+ * Please visit https://www.praxislive.org if you need additional information or
+ * have any questions.
+ */
+package org.praxislive.core.protocols;
+
+import java.util.List;
+import org.praxislive.core.ComponentType;
+import org.praxislive.core.types.PArray;
+
+/**
+ * Containers can expose an instance of this interface in their lookup to
+ * facilitate child container support of the supported-types control. Child
+ * containers that wish to support the same component types as their parent can
+ * respond to a call to the supported-types control with the result of the
+ * query.
+ */
+public interface SupportedTypes {
+
+    /**
+     * Query the supported types, the same as calling the supported-types
+     * control on the providing container. The same result will be returned
+     * unless the data has changed or otherwise refreshed, so object identity
+     * can be used to verify any cached data.
+     *
+     * @return supported types result
+     */
+    public Result query();
+
+    /**
+     * Supported types result to be returned from {@link #query()}.
+     */
+    public static final class Result {
+
+        private final List<ComponentType> types;
+        private final PArray typesAsArray;
+
+        /**
+         * Construct a Result object. The provided list will be copied if not
+         * already immutable. The list must not contain null values.
+         *
+         * @param types supported types
+         */
+        public Result(List<ComponentType> types) {
+            this.types = List.copyOf(types);
+            this.typesAsArray = PArray.of(this.types);
+        }
+
+        /**
+         * List of supported types as immutable list.
+         *
+         * @return supported types
+         */
+        public List<ComponentType> types() {
+            return types;
+        }
+
+        /**
+         * List of supported types as PArray for response call.
+         *
+         * @return supported types
+         */
+        public PArray typesAsArray() {
+            return typesAsArray;
+        }
+
+    }
+
+}

--- a/praxiscore-api/src/main/java/org/praxislive/core/services/ComponentFactory.java
+++ b/praxiscore-api/src/main/java/org/praxislive/core/services/ComponentFactory.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  * 
- * Copyright 2020 Neil C Smith.
+ * Copyright 2023 Neil C Smith.
  * 
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3 only, as
@@ -21,43 +21,187 @@
  */
 package org.praxislive.core.services;
 
+import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Supplier;
 import java.util.stream.Stream;
 import org.praxislive.core.Component;
 import org.praxislive.core.ComponentType;
 import org.praxislive.core.Lookup;
 import org.praxislive.core.Root;
+import org.praxislive.core.types.PReference;
 
 /**
- *
+ * A provider of component types registered into the system via
+ * {@link ComponentFactoryProvider}. The available components in the local
+ * system will be a combination of results from all registered component
+ * factories.
+ * <p>
+ * The default {@link ComponentFactoryService} or {@link RootFactoryService}
+ * will create instances of components or roots by calling the factory methods
+ * {@link #createComponent(org.praxislive.core.ComponentType)} or
+ * {@link #createRootComponent(org.praxislive.core.ComponentType)}. As an
+ * alternative, redirects can be provided to other services that will be used to
+ * construct the requested type. The alternative service might use the factory
+ * methods, other data in the component data lookups, or its own registry to
+ * construct the component.
+ * <p>
+ * The data lookups can also be used to provide additional metadata related to
+ * each component type.
  */
 public interface ComponentFactory {
 
+    /**
+     * Component types provided by this factory.
+     *
+     * @return stream of component types
+     */
     public Stream<ComponentType> componentTypes();
 
+    /**
+     * Root types provided by this factory.
+     *
+     * @return stream of root types
+     */
     public Stream<ComponentType> rootTypes();
 
-    public MetaData<? extends Component> getMetaData(ComponentType type);
+    @Deprecated
+    public default MetaData<? extends Component> getMetaData(ComponentType type) {
+        Supplier<Lookup> redirect = () -> componentData(type);
+        return new MetaData(redirect) {
+        };
+    }
 
-    public MetaData<? extends Root> getRootMetaData(ComponentType type);
-    
+    @Deprecated
+    public default MetaData<? extends Root> getRootMetaData(ComponentType type) {
+        Supplier<Lookup> redirect = () -> rootData(type);
+        return new MetaData(redirect) {
+        };
+    }
+
+    /**
+     * Query the data associated with this component type.
+     *
+     * @param type component type
+     * @return lookup of data
+     */
+    public default Lookup componentData(ComponentType type) {
+        var metadata = getMetaData(type);
+        if (metadata == null) {
+            return null;
+        } else if (metadata.redirect != null) {
+            return Lookup.EMPTY;
+        } else {
+            return metadata.getLookup();
+        }
+    }
+
+    /**
+     * Query the data associated with this root type.
+     *
+     * @param type root type
+     * @return lookup of data
+     */
+    public default Lookup rootData(ComponentType type) {
+        var metadata = getRootMetaData(type);
+        if (metadata == null) {
+            return null;
+        } else if (metadata.redirect != null) {
+            return Lookup.EMPTY;
+        } else {
+            return metadata.getLookup();
+        }
+    }
+
+    /**
+     * Create an instance of the component associated with this type. Component
+     * factories with a redirect may not support this method, and always throw
+     * an exception. The default implementation always throws an exception.
+     *
+     * @param type component type to create
+     * @return created component instance
+     * @throws ComponentInstantiationException
+     */
     public default Component createComponent(ComponentType type) throws ComponentInstantiationException {
         throw new ComponentInstantiationException();
     }
 
-    public default Root createRootComponent(ComponentType type) throws ComponentInstantiationException {
+    /**
+     * Create an instance of the root associated with this type. Component
+     * factories with a redirect may not support this method, and always throw
+     * an exception. The default implementation always throws an exception.
+     *
+     * @param type root type to create
+     * @return created root instance
+     * @throws ComponentInstantiationException
+     */
+    public default Root createRoot(ComponentType type) throws ComponentInstantiationException {
         throw new ComponentInstantiationException();
     }
-    
+
+    @Deprecated
+    public default Root createRootComponent(ComponentType type) throws ComponentInstantiationException {
+        return createRoot(type);
+    }
+
+    @Deprecated
     public default Class<? extends ComponentFactoryService> getFactoryService() {
         return ComponentFactoryService.class;
     }
-    
+
+    @Deprecated
     public default Class<? extends RootFactoryService> getRootFactoryService() {
         return RootFactoryService.class;
     }
-    
+
+    /**
+     * Optional service to redirect to for component instantiation. The control
+     * on the service should follow the same shape as the default
+     * {@link ComponentFactoryService#NEW_INSTANCE_INFO}, accepting a
+     * {@link ComponentType} and returning the component instance wrapped in a
+     * {@link PReference}.
+     *
+     * @return optional service redirect
+     */
+    public default Optional<Redirect> componentRedirect() {
+        var service = getFactoryService();
+        if (service == null || ComponentFactoryService.class.equals(service)) {
+            return Optional.empty();
+        } else {
+            return Optional.of(new Redirect(service, ComponentFactoryService.NEW_INSTANCE));
+        }
+    }
+
+    /**
+     * Optional service to redirect to for root instantiation. The control on
+     * the service should follow the same shape as the default
+     * {@link RootFactoryService#NEW_ROOT_INSTANCE_INFO}, accepting a
+     * {@link ComponentType} and returning the root instance wrapped in a
+     * {@link PReference}.
+     *
+     * @return optional service redirect
+     */
+    public default Optional<Redirect> rootRedirect() {
+        var service = getRootFactoryService();
+        if (service == null || RootFactoryService.class.equals(service)) {
+            return Optional.empty();
+        } else {
+            return Optional.of(new Redirect(service, RootFactoryService.NEW_ROOT_INSTANCE));
+        }
+    }
+
+    @Deprecated
     public static abstract class MetaData<T> {
+
+        private final Supplier<Lookup> redirect;
+
+        public MetaData() {
+            this.redirect = null;
+        }
+
+        private MetaData(Supplier<Lookup> redirect) {
+            this.redirect = redirect;
+        }
 
         public boolean isDeprecated() {
             return false;
@@ -68,7 +212,74 @@ public interface ComponentFactory {
         }
 
         public Lookup getLookup() {
-            return Lookup.EMPTY;
+            return redirect != null ? redirect.get() : Lookup.EMPTY;
         }
+
+    }
+
+    /**
+     * A factory service redirect. See {@link #componentRedirect()} and
+     * {@link #rootRedirect()}.
+     */
+    public static final class Redirect {
+
+        private final Class<? extends Service> service;
+        private final String control;
+
+        /**
+         * Construct a redirect to the provided service and control.
+         *
+         * @param service service type to redirect to
+         * @param control control on service to redirect to
+         */
+        public Redirect(Class<? extends Service> service, String control) {
+            this.service = Objects.requireNonNull(service);
+            this.control = Objects.requireNonNull(control);
+        }
+
+        /**
+         * Query the service to redirect to.
+         *
+         * @return service
+         */
+        public Class<? extends Service> service() {
+            return service;
+        }
+
+        /**
+         * Query the control on the service to redirect to.
+         *
+         * @return control id
+         */
+        public String control() {
+            return control;
+        }
+
+        @Override
+        public int hashCode() {
+            int hash = 3;
+            hash = 97 * hash + Objects.hashCode(this.service);
+            hash = 97 * hash + Objects.hashCode(this.control);
+            return hash;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            final Redirect other = (Redirect) obj;
+            if (!Objects.equals(this.control, other.control)) {
+                return false;
+            }
+            return Objects.equals(this.service, other.service);
+        }
+
     }
 }

--- a/praxiscore-api/src/main/java/org/praxislive/core/services/ComponentFactoryProvider.java
+++ b/praxiscore-api/src/main/java/org/praxislive/core/services/ComponentFactoryProvider.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  * 
- * Copyright 2018 Neil C Smith.
+ * Copyright 2023 Neil C Smith.
  * 
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3 only, as
@@ -19,16 +19,23 @@
  * Please visit https://www.praxislive.org if you need additional information or
  * have any questions.
  */
-
 package org.praxislive.core.services;
 
+import org.praxislive.core.Lookup;
+
 /**
+ * Provider of {@link ComponentFactory}. Implementations will be discovered via
+ * {@link Lookup#SYSTEM}.
  *
- * 
  */
 public interface ComponentFactoryProvider {
 
+    /**
+     * Get the component factory associated with this provider. Will usually
+     * always return the same instance.
+     *
+     * @return component factory
+     */
     public ComponentFactory getFactory();
-    
-    
+
 }

--- a/praxiscore-api/src/main/java/org/praxislive/core/services/ComponentFactoryService.java
+++ b/praxiscore-api/src/main/java/org/praxislive/core/services/ComponentFactoryService.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright 2020 Neil C Smith.
+ * Copyright 2023 Neil C Smith.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3 only, as
@@ -30,11 +30,23 @@ import org.praxislive.core.types.PMap;
 import org.praxislive.core.types.PReference;
 
 /**
- *
+ * A {@link Service} for creating new component instances. The implementation of
+ * this service will discover all available {@link ComponentFactory} and either
+ * create an instance of the component via
+ * {@link ComponentFactory#createComponent(org.praxislive.core.ComponentType)}
+ * or delegate creation to the correct
+ * {@link ComponentFactory#componentRedirect()}.
  */
 public class ComponentFactoryService implements Service {
 
+    /**
+     * Control ID of the new instance control.
+     */
     public final static String NEW_INSTANCE = "new-instance";
+
+    /**
+     * ControlInfo for the new instance control.
+     */
     public final static ControlInfo NEW_INSTANCE_INFO
             = ControlInfo.createFunctionInfo(
                     List.of(ComponentType.info()),

--- a/praxiscore-api/src/main/java/org/praxislive/core/services/RootFactoryService.java
+++ b/praxiscore-api/src/main/java/org/praxislive/core/services/RootFactoryService.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright 2020 Neil C Smith.
+ * Copyright 2023 Neil C Smith.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3 only, as
@@ -30,16 +30,27 @@ import org.praxislive.core.types.PMap;
 import org.praxislive.core.types.PReference;
 
 /**
- *
+ * A {@link Service} for creating new root instances. The implementation of this
+ * service will discover all available {@link ComponentFactory} and either
+ * create an instance of the component via
+ * {@link ComponentFactory#createRoot(org.praxislive.core.ComponentType)} or
+ * delegate creation to the correct {@link ComponentFactory#rootRedirect()}.
  */
 public class RootFactoryService implements Service {
 
+    /**
+     * Control ID of the new root instance control.
+     */
     public final static String NEW_ROOT_INSTANCE = "new-root-instance";
-    public final static ControlInfo NEW_ROOT_INSTANCE_INFO =
-            ControlInfo.createFunctionInfo(
-            List.of(ComponentType.info()),
-            List.of(PReference.info(Root.class)),
-            PMap.EMPTY);
+    
+    /**
+     * ControlInfo of the new root instance control.
+     */
+    public final static ControlInfo NEW_ROOT_INSTANCE_INFO
+            = ControlInfo.createFunctionInfo(
+                    List.of(ComponentType.info()),
+                    List.of(PReference.info(Root.class)),
+                    PMap.EMPTY);
 
     @Override
     public Stream<String> controls() {
@@ -54,5 +65,3 @@ public class RootFactoryService implements Service {
         throw new IllegalArgumentException();
     }
 }
-
-

--- a/praxiscore-api/src/main/java/org/praxislive/core/services/Service.java
+++ b/praxiscore-api/src/main/java/org/praxislive/core/services/Service.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  * 
- * Copyright 2018 Neil C Smith.
+ * Copyright 2023 Neil C Smith.
  * 
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3 only, as
@@ -21,12 +21,14 @@
  */
 package org.praxislive.core.services;
 
+import org.praxislive.core.RootHub;
 import org.praxislive.core.Protocol;
 
 /**
- *
- * 
+ * An extension of {@link Protocol} for various system services. Component
+ * addresses of services can be queried via the {@link Services} implementation
+ * in {@link RootHub#getLookup()}.
  */
 public interface Service extends Protocol {
-    
+
 }

--- a/praxiscore-api/src/main/java/org/praxislive/core/services/Services.java
+++ b/praxiscore-api/src/main/java/org/praxislive/core/services/Services.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  * 
- * Copyright 2018 Neil C Smith.
+ * Copyright 2023 Neil C Smith.
  * 
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3 only, as
@@ -24,15 +24,30 @@ package org.praxislive.core.services;
 import java.util.Optional;
 import java.util.stream.Stream;
 import org.praxislive.core.ComponentAddress;
+import org.praxislive.core.RootHub;
 
 /**
- *
- * 
+ * Facility to query service addresses. Instances of this interface should be
+ * acquired from {@link RootHub#getLookup()}.
  */
 public interface Services {
 
+    /**
+     * Locate the primary implementation of the requested service, if available.
+     *
+     * @param service class of service to locate
+     * @return optional of service address
+     */
     public Optional<ComponentAddress> locate(Class<? extends Service> service);
-    
+
+    /**
+     * Locate all the available implementations of the requested service, if
+     * available. The primary implementation will be the first implementation in
+     * the stream.
+     *
+     * @param service class of service to locate
+     * @return stream of addresses, or empty stream
+     */
     public Stream<ComponentAddress> locateAll(Class<? extends Service> service);
 
 }

--- a/praxiscore-audio-components/src/main/java/org/praxislive/audio/impl/components/AudioInput.java
+++ b/praxiscore-audio-components/src/main/java/org/praxislive/audio/impl/components/AudioInput.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  * 
- * Copyright 2021 Neil C Smith.
+ * Copyright 2023 Neil C Smith.
  * 
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3 only, as
@@ -30,6 +30,7 @@ import org.praxislive.audio.DefaultAudioOutputPort;
 import org.praxislive.base.AbstractComponent;
 import org.praxislive.base.AbstractProperty;
 import org.praxislive.core.ComponentInfo;
+import org.praxislive.core.ComponentType;
 import org.praxislive.core.Info;
 import org.praxislive.core.Port;
 import org.praxislive.core.Value;
@@ -114,6 +115,7 @@ public class AudioInput extends AbstractComponent {
         if (info == null) {
             info = Info.component(cmp -> {
                 cmp.merge(ComponentProtocol.API_INFO);
+                cmp.property(ComponentInfo.KEY_COMPONENT_TYPE, ComponentType.of("audio:input"));
                 cmp.property(ComponentInfo.KEY_DYNAMIC, PBoolean.TRUE);
                 cmp.control("channels", c -> c.property().input(a -> a
                         .number().min(1).max(MAX_CHANNELS)

--- a/praxiscore-audio-components/src/main/java/org/praxislive/audio/impl/components/AudioOutput.java
+++ b/praxiscore-audio-components/src/main/java/org/praxislive/audio/impl/components/AudioOutput.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  * 
- * Copyright 2021 Neil C Smith.
+ * Copyright 2023 Neil C Smith.
  * 
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3 only, as
@@ -31,6 +31,7 @@ import org.praxislive.audio.DefaultAudioInputPort;
 import org.praxislive.base.AbstractComponent;
 import org.praxislive.base.AbstractProperty;
 import org.praxislive.core.ComponentInfo;
+import org.praxislive.core.ComponentType;
 import org.praxislive.core.Info;
 import org.praxislive.core.Value;
 import org.praxislive.core.protocols.ComponentProtocol;
@@ -108,13 +109,14 @@ public class AudioOutput extends AbstractComponent {
         }
         info = null;
     }
-    
-     @Override
+
+    @Override
     public ComponentInfo getInfo() {
         if (info == null) {
             info = Info.component(cmp -> {
                 cmp.merge(ComponentProtocol.API_INFO);
                 cmp.property(ComponentInfo.KEY_DYNAMIC, PBoolean.TRUE);
+                cmp.property(ComponentInfo.KEY_COMPONENT_TYPE, ComponentType.of("audio:output"));
                 cmp.control("channels", c -> c.property().input(a -> a
                         .number().min(1).max(MAX_CHANNELS)
                         .property(PNumber.KEY_IS_INTEGER, PBoolean.TRUE)

--- a/praxiscore-audio-components/src/main/java/org/praxislive/audio/impl/components/DefaultAudioRoot.java
+++ b/praxiscore-audio-components/src/main/java/org/praxislive/audio/impl/components/DefaultAudioRoot.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  * 
- * Copyright 2021 Neil C Smith.
+ * Copyright 2023 Neil C Smith.
  * 
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3 only, as
@@ -45,6 +45,7 @@ import org.praxislive.core.ArgumentInfo;
 import org.praxislive.core.Call;
 import org.praxislive.core.Clock;
 import org.praxislive.core.ComponentInfo;
+import org.praxislive.core.ComponentType;
 import org.praxislive.core.ControlAddress;
 import org.praxislive.core.Info;
 import org.praxislive.core.Value;
@@ -101,9 +102,9 @@ public class DefaultAudioRoot extends AbstractRootContainer {
     public DefaultAudioRoot() {
         sharedCode = new SharedCodeProperty(this, this::handleLog);
         registerControl("shared-code", sharedCode);
-        
+
         extractLibraryInfo();
-        
+
         // permanent
         sampleRate = new CheckedIntProperty(MIN_SAMPLERATE, MAX_SAMPLERATE, DEFAULT_SAMPLERATE);
         registerControl("sample-rate", sampleRate);
@@ -123,6 +124,7 @@ public class DefaultAudioRoot extends AbstractRootContainer {
         baseInfo = Info.component(cmp -> cmp
                 .merge(ComponentProtocol.API_INFO)
                 .merge(ContainerProtocol.API_INFO)
+                .control(ContainerProtocol.SUPPORTED_TYPES, ContainerProtocol.SUPPORTED_TYPES_INFO)
                 .merge(StartableProtocol.API_INFO)
                 .control("shared-code", SharedCodeProperty.INFO)
                 .control("sample-rate", c -> c.property()
@@ -151,6 +153,7 @@ public class DefaultAudioRoot extends AbstractRootContainer {
                                 .toArray(String[]::new))
                 ))
                 .property(ComponentInfo.KEY_DYNAMIC, PBoolean.TRUE)
+                .property(ComponentInfo.KEY_COMPONENT_TYPE, ComponentType.of("root:audio"))
         );
         info = baseInfo;
 
@@ -301,8 +304,8 @@ public class DefaultAudioRoot extends AbstractRootContainer {
         }
         LOG.log(System.Logger.Level.TRACE,
                 "Found audio library {0}\n{1}", new Object[]{
-            libInfo.provider.getLibraryName(), libInfo.provider.getLibraryDescription()
-        });
+                    libInfo.provider.getLibraryName(), libInfo.provider.getLibraryDescription()
+                });
 
         Device device = findDevice(libInfo, usingDefault, false);
         if (device != null) {
@@ -489,14 +492,14 @@ public class DefaultAudioRoot extends AbstractRootContainer {
                 .ifPresent(logger -> {
                     var to = ControlAddress.of(logger, LogService.LOG);
                     var from = ControlAddress.of(getAddress(), "_log");
-                    var call =  Call.createQuiet(to,
+                    var call = Call.createQuiet(to,
                             from,
                             getExecutionContext().getTime(),
                             log.toList());
                     getRouter().route(call);
                 });
     }
-    
+
     private class AudioDelegate extends Delegate
             implements PipesAudioClient.Listener {
 

--- a/praxiscore-base/src/main/java/org/praxislive/base/AbstractContainer.java
+++ b/praxiscore-base/src/main/java/org/praxislive/base/AbstractContainer.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  * 
- * Copyright 2021 Neil C Smith.
+ * Copyright 2023 Neil C Smith.
  * 
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3 only, as
@@ -44,6 +44,7 @@ import org.praxislive.core.PortListener;
 import org.praxislive.core.Value;
 import org.praxislive.core.VetoException;
 import org.praxislive.core.protocols.ContainerProtocol;
+import org.praxislive.core.protocols.SupportedTypes;
 import org.praxislive.core.services.ComponentFactoryService;
 import org.praxislive.core.types.PArray;
 import org.praxislive.core.types.PReference;
@@ -73,6 +74,11 @@ public abstract class AbstractContainer extends AbstractComponent implements Con
         registerControl(ContainerProtocol.CONNECT, new ConnectControl());
         registerControl(ContainerProtocol.DISCONNECT, new DisconnectControl());
         registerControl(ContainerProtocol.CONNECTIONS, new ConnectionsControl());
+        registerControl(ContainerProtocol.SUPPORTED_TYPES, (call, router) -> {
+            router.route(call.reply(getLookup().find(SupportedTypes.class)
+                    .map(types -> types.query().typesAsArray())
+                    .orElse(PArray.EMPTY)));
+        });
     }
 
     @Override

--- a/praxiscore-base/src/main/java/org/praxislive/base/AbstractRootContainer.java
+++ b/praxiscore-base/src/main/java/org/praxislive/base/AbstractRootContainer.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  * 
- * Copyright 2020 Neil C Smith.
+ * Copyright 2023 Neil C Smith.
  * 
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3 only, as
@@ -44,6 +44,8 @@ import org.praxislive.core.types.PError;
 public abstract class AbstractRootContainer extends AbstractRoot implements Container {
 
     private final ContainerImpl delegate;
+
+    private Lookup lookup;
 
     protected AbstractRootContainer() {
         delegate = new ContainerImpl(this);
@@ -97,6 +99,14 @@ public abstract class AbstractRootContainer extends AbstractRoot implements Cont
     @Override
     public Port getPort(String id) {
         return delegate.getPort(id);
+    }
+
+    @Override
+    public Lookup getLookup() {
+        if (lookup == null) {
+            lookup = Lookup.of(super.getLookup(), FilteredTypes.create(this));
+        }
+        return lookup;
     }
 
     @Override
@@ -166,9 +176,9 @@ public abstract class AbstractRootContainer extends AbstractRoot implements Cont
     }
 
     private static class ContainerImpl extends AbstractContainer.Delegate {
-        
+
         private final AbstractRootContainer wrapper;
-        
+
         private ContainerImpl(AbstractRootContainer wrapper) {
             this.wrapper = wrapper;
         }
@@ -192,8 +202,6 @@ public abstract class AbstractRootContainer extends AbstractRoot implements Cont
         protected void notifyChild(Component child) throws VetoException {
             child.parentNotify(wrapper);
         }
-        
-        
 
     }
 

--- a/praxiscore-base/src/main/java/org/praxislive/base/FilteredTypes.java
+++ b/praxiscore-base/src/main/java/org/praxislive/base/FilteredTypes.java
@@ -1,0 +1,230 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright 2023 Neil C Smith.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License version 3 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * version 3 for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License version 3
+ * along with this work; if not, see http://www.gnu.org/licenses/
+ * 
+ *
+ * Please visit https://www.praxislive.org if you need additional information or
+ * have any questions.
+ */
+package org.praxislive.base;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import org.praxislive.core.ComponentInfo;
+import org.praxislive.core.ComponentRegistry;
+import org.praxislive.core.ComponentType;
+import org.praxislive.core.Container;
+import org.praxislive.core.protocols.SupportedTypes;
+
+/**
+ * An implementation of {@link SupportedTypes} that can be included in the
+ * lookup of a container. The implementation automatically searches the parent
+ * lookup for other SupportedTypes, or otherwise a {@link ComponentRegistry}.
+ * <p>
+ * Results can be subject to further filtering, or additional types can be
+ * included.
+ * <p>
+ * The result is cached. The FilteredTypes must be {@link #reset()} on hierarchy
+ * changes, and in any circumstances where the behaviour of the filter or
+ * additional types supplier changes.
+ */
+public class FilteredTypes implements SupportedTypes {
+
+    private final Container context;
+    private final Predicate<ComponentType> filter;
+    private final Supplier<List<ComponentType>> additional;
+
+    private Result result;
+    private SupportedTypes delegate;
+    private Result delegateResult;
+
+    private FilteredTypes(Container context,
+            Predicate<ComponentType> filter,
+            Supplier<List<ComponentType>> additional) {
+        this.context = context;
+        this.filter = filter;
+        this.additional = additional;
+    }
+
+    @Override
+    public Result query() {
+        if (result == null) {
+            delegate = Optional.ofNullable(context.getParent())
+                    .flatMap(p -> p.getLookup().find(SupportedTypes.class))
+                    .filter(d -> d != this)
+                    .orElseGet(() -> new BaseDelegate(this));
+            delegateResult = delegate.query();
+            result = calculateResult(delegateResult);
+        } else {
+            var delRes = delegate.query();
+            if (delRes != delegateResult) {
+                delegateResult = delRes;
+                result = calculateResult(delegateResult);
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Reset and cause the result to be recalculated on the next call to
+     * {@link #query()}. The FilteredTypes should be reset on hierarchy changes
+     * of the container, and in any circumstances where the behaviour of the
+     * filter or additional types supplier changes.
+     */
+    public void reset() {
+        result = null;
+        delegate = null;
+        delegateResult = null;
+    }
+
+    private Result calculateResult(Result delegateResult) {
+        if (filter == null && additional == null) {
+            return delegateResult;
+        }
+        List<ComponentType> list = new ArrayList<>(delegateResult.types());
+        if (filter != null) {
+            list.removeIf(Predicate.not(filter));
+        }
+        if (additional != null) {
+            list.addAll(additional.get());
+        }
+        return new Result(list);
+    }
+
+    /**
+     * Create a FilteredTypes for the provided context. If no
+     * {@link SupportedTypes} is found in the parent lookup, then the
+     * implementation will attempt to filter the {@link ComponentRegistry}
+     * result according to the root type.
+     *
+     * @param context container this will be added to
+     * @return instance
+     */
+    public static FilteredTypes create(Container context) {
+        return create(context, null, null);
+    }
+
+    /**
+     * Create a FilteredTypes for the provided context, additionally filtering
+     * the available types from the parent by the passed in filter.
+     * <p>
+     * If the filter is null then a default filter will be used according to
+     * root type - see {@link #create(org.praxislive.core.Container)}.
+     *
+     * @param context container this will be added to
+     * @param filter filtering to apply to parent result
+     * @return instance
+     */
+    public static FilteredTypes create(Container context,
+            Predicate<ComponentType> filter) {
+        return create(context, filter, null);
+    }
+
+    /**
+     * Create a FilteredTypes for the provided context, additionally filtering
+     * the available types from the parent by the passed in filter, and adding
+     * in types from the supplied list.
+     * <p>
+     * If the filter is null then a default filter will be used according to
+     * root type - see {@link #create(org.praxislive.core.Container)}.
+     *
+     * @param context container this will be added to
+     * @param filter filtering to apply to parent result
+     * @param additional supplier of a list of additional types
+     * @return instance
+     */
+    public static FilteredTypes create(Container context,
+            Predicate<ComponentType> filter,
+            Supplier<List<ComponentType>> additional) {
+        Objects.requireNonNull(context);
+        return new FilteredTypes(context, filter, additional);
+    }
+
+    private static class BaseDelegate implements SupportedTypes {
+
+        private final ComponentRegistry registry;
+        private final Predicate<ComponentType> baseFilter;
+
+        private ComponentRegistry.Result registryResult;
+        private Result result;
+
+        private BaseDelegate(FilteredTypes filteredTypes) {
+            this.registry = filteredTypes.context.getLookup()
+                    .find(ComponentRegistry.class).orElse(null);
+            if (filteredTypes.filter != null) {
+                baseFilter = null;
+            } else {
+                baseFilter = createBaseFilter(filteredTypes.context);
+            }
+        }
+
+        @Override
+        public Result query() {
+            if (registry == null) {
+                if (result == null) {
+                    result = new Result(List.of());
+                }
+            } else {
+                var regResult = registry.query();
+                if (result == null || regResult != registryResult) {
+                    registryResult = regResult;
+                    if (baseFilter == null) {
+                        result = new Result(regResult.componentTypes());
+                    } else {
+                        result = new Result(regResult.componentTypes().stream()
+                                .filter(baseFilter)
+                                .collect(Collectors.toList()));
+                    }
+                }
+            }
+            return result;
+        }
+
+        private static Predicate<ComponentType> createBaseFilter(Container context) {
+            var core = "core:";
+            var category = findRootCategory(context);
+            if (category != null) {
+                var match = category + ":";
+                return type -> type.toString().startsWith(core)
+                        || type.toString().startsWith(match);
+            } else {
+                return type -> false;
+            }
+        }
+
+        private static String findRootCategory(Container context) {
+            var c = context;
+            var p = c.getParent();
+            while (p != null) {
+                c = p;
+                p = c.getParent();
+            }
+            var type = c.getInfo().properties().getString(ComponentInfo.KEY_COMPONENT_TYPE, "");
+            if (type.startsWith("root:")) {
+                return type.substring(5);
+            } else {
+                return null;
+            }
+        }
+
+    }
+
+}

--- a/praxiscore-code/src/main/java/org/praxislive/code/CodeContainer.java
+++ b/praxiscore-code/src/main/java/org/praxislive/code/CodeContainer.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright 2022 Neil C Smith.
+ * Copyright 2023 Neil C Smith.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3 only, as
@@ -334,6 +334,8 @@ public class CodeContainer<D extends CodeContainerDelegate> extends CodeComponen
                     ContainerProtocol.DISCONNECT_INFO, getInternalIndex()));
             addControl(new ContainerControlDescriptor(ContainerProtocol.CONNECTIONS,
                     ContainerProtocol.CONNECTIONS_INFO, getInternalIndex()));
+            addControl(new ContainerControlDescriptor(ContainerProtocol.SUPPORTED_TYPES,
+                    ContainerProtocol.SUPPORTED_TYPES_INFO, getInternalIndex()));
         }
 
         @Override

--- a/praxiscore-code/src/main/java/org/praxislive/code/CodeRootContainer.java
+++ b/praxiscore-code/src/main/java/org/praxislive/code/CodeRootContainer.java
@@ -23,6 +23,7 @@ package org.praxislive.code;
 
 import java.util.stream.Stream;
 import org.praxislive.base.AbstractContainer;
+import org.praxislive.base.FilteredTypes;
 import org.praxislive.core.Component;
 import org.praxislive.core.ComponentAddress;
 import org.praxislive.core.ComponentInfo;
@@ -48,9 +49,13 @@ public class CodeRootContainer<D extends CodeRootContainerDelegate> extends Code
         implements Container {
 
     private final ContainerImpl container;
+    private final FilteredTypes filteredTypes;
+
+    private Lookup lookup;
 
     CodeRootContainer() {
         container = new ContainerImpl(this);
+        filteredTypes = FilteredTypes.create(this, type -> type.toString().startsWith("core:"));
     }
 
     @Override
@@ -69,7 +74,17 @@ public class CodeRootContainer<D extends CodeRootContainerDelegate> extends Code
     }
 
     @Override
+    public Lookup getLookup() {
+        if (lookup == null) {
+            lookup = Lookup.of(super.getLookup(), filteredTypes);
+        }
+        return lookup;
+    }
+
+    @Override
     public void hierarchyChanged() {
+        lookup = null;
+        filteredTypes.reset();
         super.hierarchyChanged();
         container.hierarchyChanged();
     }
@@ -153,6 +168,8 @@ public class CodeRootContainer<D extends CodeRootContainerDelegate> extends Code
                     ContainerProtocol.DISCONNECT_INFO, getInternalIndex()));
             addControl(new ContainerControlDescriptor(ContainerProtocol.CONNECTIONS,
                     ContainerProtocol.CONNECTIONS_INFO, getInternalIndex()));
+            addControl(new ContainerControlDescriptor(ContainerProtocol.SUPPORTED_TYPES,
+                    ContainerProtocol.SUPPORTED_TYPES_INFO, getInternalIndex()));
         }
 
         @Override

--- a/praxiscore-data/src/main/java/org/praxislive/data/DataRoot.java
+++ b/praxiscore-data/src/main/java/org/praxislive/data/DataRoot.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  * 
- * Copyright 2021 Neil C Smith.
+ * Copyright 2023 Neil C Smith.
  * 
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3 only, as
@@ -26,6 +26,7 @@ import org.praxislive.base.BindingContextControl;
 import org.praxislive.code.SharedCodeProperty;
 import org.praxislive.core.Call;
 import org.praxislive.core.ComponentInfo;
+import org.praxislive.core.ComponentType;
 import org.praxislive.core.ControlAddress;
 import org.praxislive.core.Info;
 import org.praxislive.core.Lookup;
@@ -48,8 +49,10 @@ public class DataRoot extends AbstractRootContainer {
         INFO = Info.component(cmp -> cmp
                 .merge(ComponentProtocol.API_INFO)
                 .merge(ContainerProtocol.API_INFO)
+                .control(ContainerProtocol.SUPPORTED_TYPES, ContainerProtocol.SUPPORTED_TYPES_INFO)
                 .merge(StartableProtocol.API_INFO)
                 .control("shared-code", SharedCodeProperty.INFO)
+                .property(ComponentInfo.KEY_COMPONENT_TYPE, ComponentType.of("root:data"))
         );
     }
 

--- a/praxiscore-hub/src/main/java/org/praxislive/hub/ComponentRegistry.java
+++ b/praxiscore-hub/src/main/java/org/praxislive/hub/ComponentRegistry.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright 2020 Neil C Smith.
+ * Copyright 2023 Neil C Smith.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3 only, as
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 import org.praxislive.core.services.ComponentFactory;
 import org.praxislive.core.services.ComponentFactoryProvider;
 import org.praxislive.core.ComponentType;
@@ -63,6 +64,20 @@ class ComponentRegistry {
 
     ComponentFactory getRootComponentFactory(ComponentType type) {
         return rootCache.get(type);
+    }
+
+    org.praxislive.core.ComponentRegistry.Result createRegistryResult() {
+        Map<ComponentType, Lookup> components = componentCache.entrySet().stream()
+                .collect(Collectors.toMap(e -> e.getKey(),
+                        e -> Lookup.of(e.getValue().componentData(e.getKey()), e.getValue()),
+                        (v1, v2) -> v2,
+                        LinkedHashMap::new));
+        Map<ComponentType, Lookup> roots = rootCache.entrySet().stream()
+                .collect(Collectors.toMap(e -> e.getKey(),
+                        e -> Lookup.of(e.getValue().rootData(e.getKey()), e.getValue()),
+                        (v1, v2) -> v2,
+                        LinkedHashMap::new));
+        return new org.praxislive.core.ComponentRegistry.Result(components, roots);
     }
 
     static ComponentRegistry getInstance() {

--- a/praxiscore-video-components/src/main/java/org/praxislive/video/impl/components/DefaultVideoRoot.java
+++ b/praxiscore-video-components/src/main/java/org/praxislive/video/impl/components/DefaultVideoRoot.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  * 
- * Copyright 2021 Neil C Smith.
+ * Copyright 2023 Neil C Smith.
  * 
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3 only, as
@@ -29,6 +29,7 @@ import org.praxislive.base.AbstractRootContainer;
 import org.praxislive.code.SharedCodeProperty;
 import org.praxislive.core.Call;
 import org.praxislive.core.ComponentInfo;
+import org.praxislive.core.ComponentType;
 import org.praxislive.core.ControlAddress;
 import org.praxislive.core.Info;
 import org.praxislive.core.Lookup;
@@ -100,6 +101,7 @@ public class DefaultVideoRoot extends AbstractRootContainer {
         info = Info.component(cmp -> cmp
                 .merge(ComponentProtocol.API_INFO)
                 .merge(ContainerProtocol.API_INFO)
+                .control(ContainerProtocol.SUPPORTED_TYPES, ContainerProtocol.SUPPORTED_TYPES_INFO)
                 .merge(StartableProtocol.API_INFO)
                 .control("shared-code", SharedCodeProperty.INFO)
                 .control("renderer", c -> c.property()
@@ -124,6 +126,7 @@ public class DefaultVideoRoot extends AbstractRootContainer {
                     .defaultValue(PBoolean.TRUE)
                     .input(PBoolean.class)
                 )
+                .property(ComponentInfo.KEY_COMPONENT_TYPE, ComponentType.of("root:video"))
         );
 
         ctxt = new VideoContextImpl();

--- a/praxiscore-video-components/src/main/java/org/praxislive/video/impl/components/VideoOutput.java
+++ b/praxiscore-video-components/src/main/java/org/praxislive/video/impl/components/VideoOutput.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  * 
- * Copyright 2021 Neil C Smith.
+ * Copyright 2023 Neil C Smith.
  * 
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3 only, as
@@ -30,6 +30,7 @@ import org.praxislive.core.ArgumentInfo;
 import org.praxislive.core.Value;
 import org.praxislive.core.ComponentAddress;
 import org.praxislive.core.ComponentInfo;
+import org.praxislive.core.ComponentType;
 import org.praxislive.core.Info;
 import org.praxislive.core.Lookup;
 import org.praxislive.core.protocols.ComponentProtocol;
@@ -106,8 +107,9 @@ public class VideoOutput extends AbstractComponent {
                 .control("always-on-top", c -> c.property().input(PBoolean.class).defaultValue(PBoolean.FALSE))
                 .control("undecorated", c -> c.property().input(PBoolean.class).defaultValue(PBoolean.FALSE))
                 .control("show-cursor", c -> c.property().input(PBoolean.class).defaultValue(PBoolean.FALSE))
-                
+
                 .port("in", p -> p.input(VideoPort.class))
+                .property(ComponentInfo.KEY_COMPONENT_TYPE, ComponentType.of("video:output"))
         );
 
         device = new IntegerProperty();


### PR DESCRIPTION
Add ComponentRegistry API, and basic implementation in hub.
Add optional controls support to Protocols.
Add optional `.supported-types` control to ContainerProtocol.
Add SupportedTypes API and FilteredTypes to aid implementation of supported-types controls.
Add supported-types control to AbstractContainer.
Update docs of core protocol types.
Add type information to various non-code components.