### PR TITLE
Updates to Ref inc. ports, pub/sub and async set

### DIFF
--- a/praxiscore-code/src/main/java/module-info.java
+++ b/praxiscore-code/src/main/java/module-info.java
@@ -14,7 +14,7 @@ module org.praxislive.code {
     provides javax.annotation.processing.Processor with 
             org.praxislive.code.internal.GenerateTemplateProcessor;
     provides org.praxislive.core.Port.TypeProvider with
-            org.praxislive.code.DataPort.Provider;
+            org.praxislive.code.internal.CodePortTypeProvider;
     provides org.praxislive.core.Protocol.TypeProvider with
             org.praxislive.code.internal.CodeProtocolsProvider;
     

--- a/praxiscore-code/src/main/java/org/praxislive/code/CodeConnector.java
+++ b/praxiscore-code/src/main/java/org/praxislive/code/CodeConnector.java
@@ -636,7 +636,6 @@ public abstract class CodeConnector<D extends CodeDelegate> {
             RefImpl.Descriptor rdsc = RefImpl.Descriptor.create(this, field);
             if (rdsc != null) {
                 addReference(rdsc);
-                addControl(rdsc.getControlDescriptor());
                 return true;
             } else {
                 return false;

--- a/praxiscore-code/src/main/java/org/praxislive/code/CodeConnector.java
+++ b/praxiscore-code/src/main/java/org/praxislive/code/CodeConnector.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright 2022 Neil C Smith.
+ * Copyright 2023 Neil C Smith.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3 only, as
@@ -522,6 +522,12 @@ public abstract class CodeConnector<D extends CodeDelegate> {
             return true;
         }
 
+        RefPort.InputDescriptor rin = RefPort.InputDescriptor.create(this, ann, field);
+        if (rin != null) {
+            addPort(rin);
+            return true;
+        }
+
         return false;
     }
 
@@ -536,6 +542,12 @@ public abstract class CodeConnector<D extends CodeDelegate> {
         DataPort.InputDescriptor din = DataPort.InputDescriptor.create(this, ann, field);
         if (din != null) {
             addPort(din);
+            return true;
+        }
+
+        RefPort.InputDescriptor rin = RefPort.InputDescriptor.create(this, ann, field);
+        if (rin != null) {
+            addPort(rin);
             return true;
         }
 
@@ -556,6 +568,13 @@ public abstract class CodeConnector<D extends CodeDelegate> {
             return true;
         }
 
+        RefImpl.Descriptor rdsc = RefImpl.Descriptor.create(this, field, ann);
+        if (rdsc != null) {
+            addReference(rdsc);
+            addPort(rdsc.getPortDescriptor());
+            return true;
+        }
+
         return false;
     }
 
@@ -569,6 +588,13 @@ public abstract class CodeConnector<D extends CodeDelegate> {
         DataPort.OutputDescriptor dout = DataPort.OutputDescriptor.create(this, ann, field);
         if (dout != null) {
             addPort(dout);
+            return true;
+        }
+
+        RefImpl.Descriptor rdsc = RefImpl.Descriptor.create(this, field, ann);
+        if (rdsc != null) {
+            addReference(rdsc);
+            addPort(rdsc.getPortDescriptor());
             return true;
         }
 

--- a/praxiscore-code/src/main/java/org/praxislive/code/CodeContainer.java
+++ b/praxiscore-code/src/main/java/org/praxislive/code/CodeContainer.java
@@ -75,6 +75,7 @@ public class CodeContainer<D extends CodeContainerDelegate> extends CodeComponen
     private PMap portMap;
     private ComponentInfo baseInfo;
     private ComponentInfo info;
+    private RefBus refBus;
 
     CodeContainer() {
         container = new ContainerImpl(this);
@@ -206,6 +207,13 @@ public class CodeContainer<D extends CodeContainerDelegate> extends CodeComponen
 
     PMap getPortMap() {
         return portMap;
+    }
+
+    RefBus getRefBus() {
+        if (refBus == null) {
+            refBus = new RefBus();
+        }
+        return refBus;
     }
 
     private class PortProxy implements Port {

--- a/praxiscore-code/src/main/java/org/praxislive/code/CodeRootContainer.java
+++ b/praxiscore-code/src/main/java/org/praxislive/code/CodeRootContainer.java
@@ -52,6 +52,7 @@ public class CodeRootContainer<D extends CodeRootContainerDelegate> extends Code
     private final FilteredTypes filteredTypes;
 
     private Lookup lookup;
+    private RefBus refBus;
 
     CodeRootContainer() {
         container = new ContainerImpl(this);
@@ -91,6 +92,13 @@ public class CodeRootContainer<D extends CodeRootContainerDelegate> extends Code
 
     Control getContainerControl(String id) {
         return container.getControl(id);
+    }
+
+    RefBus getRefBus() {
+        if (refBus == null) {
+            refBus = new RefBus();
+        }
+        return refBus;
     }
 
     @Override

--- a/praxiscore-code/src/main/java/org/praxislive/code/DataPort.java
+++ b/praxiscore-code/src/main/java/org/praxislive/code/DataPort.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  * 
- * Copyright 2021 Neil C Smith.
+ * Copyright 2023 Neil C Smith.
  * 
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3 only, as
@@ -22,8 +22,6 @@
 package org.praxislive.code;
 
 import java.lang.reflect.Field;
-import java.lang.reflect.ParameterizedType;
-import java.lang.reflect.WildcardType;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -46,29 +44,29 @@ import org.praxislive.core.services.LogLevel;
  *
  */
 public abstract class DataPort<T> implements Port {
-
+    
     public final static class Input<T> extends DataPort<T> {
-
+        
         private final InPipe<T> in;
         private final List<Output<T>> connections;
         private final List<PortListener> listeners;
-
+        
         private java.lang.reflect.Type type;
-
+        
         private Input(InputDescriptor desc) {
             this.type = Objects.requireNonNull(desc.type);
             in = new InPipe<>();
             connections = new ArrayList<>();
             listeners = new CopyOnWriteArrayList<>();
         }
-
+        
         private void reconfigure(InputDescriptor desc) {
             if (!Objects.equals(type, desc.type)) {
                 this.type = Objects.requireNonNull(desc.type);
                 in.reset(true);
             }
         }
-
+        
         @Override
         public void connect(Port port) throws PortConnectionException {
             if (port instanceof Output) {
@@ -77,14 +75,14 @@ public abstract class DataPort<T> implements Port {
                 throw new PortConnectionException();
             }
         }
-
+        
         @Override
         public void disconnect(Port port) {
             if (port instanceof Output) {
                 port.disconnect(this);
             }
         }
-
+        
         private void addDataOutputPort(Output<T> port, Data.Pipe<T> source) throws PortConnectionException {
             if (connections.contains(port)) {
                 throw new PortConnectionException();
@@ -97,56 +95,56 @@ public abstract class DataPort<T> implements Port {
                 throw new PortConnectionException(ex);
             }
         }
-
+        
         private void removeDataOutputPort(Output<T> port, Data.Pipe<T> source) {
             if (connections.remove(port)) {
                 in.removeSource(source);
                 listeners.forEach(l -> l.connectionsChanged(this));
             }
         }
-
+        
         @Override
         public void disconnectAll() {
             for (Output<T> connection : connections()) {
                 disconnect(connection);
             }
         }
-
+        
         @Override
         public List<Output<T>> connections() {
             return List.copyOf(connections);
         }
-
+        
         @Override
         public void addListener(PortListener listener) {
             listeners.add(Objects.requireNonNull(listener));
         }
-
+        
         @Override
         public void removeListener(PortListener listener) {
             listeners.remove(listener);
         }
     }
-
+    
     private static class InPipe<T> extends Data.In<T> {
-
+        
         private void reset(boolean full) {
             disconnectSinks();
             if (full) {
                 clearCaches();
             }
         }
-
+        
     }
-
+    
     static final class InputDescriptor extends PortDescriptor {
-
+        
         private final Field field;
         private final java.lang.reflect.Type type;
         private final PortInfo info;
-
+        
         private Input<?> port;
-
+        
         private InputDescriptor(String id,
                 Category category,
                 int index,
@@ -157,14 +155,14 @@ public abstract class DataPort<T> implements Port {
             this.type = type;
             this.info = PortInfo.create(DataPort.class,
                     PortInfo.Direction.IN,
-                    PMap.of("category", typeToCategory(type)));
+                    PMap.of("category", TypeUtils.portCategory(type)));
         }
-
+        
         @Override
         @SuppressWarnings("unchecked")
         public void attach(CodeContext<?> context, Port previous) {
             if (previous instanceof Input
-                    && compatibleDataTypes(type, ((Input<?>) previous).type)) {
+                    && TypeUtils.equivalent(type, ((Input<?>) previous).type)) {
                 port = (Input<?>) previous;
                 port.reconfigure(this);
             } else {
@@ -179,54 +177,56 @@ public abstract class DataPort<T> implements Port {
                 context.getLog().log(LogLevel.ERROR, ex);
             }
         }
-
+        
         @Override
         public Port getPort() {
             return port;
         }
-
+        
         @Override
         public PortInfo getInfo() {
             return info;
         }
-
+        
         @Override
         public void reset(boolean full) {
             if (port != null) {
                 port.in.reset(full);
             }
         }
-
+        
         static InputDescriptor create(CodeConnector<?> connector, In ann, Field field) {
             return create(connector, PortDescriptor.Category.In, ann.value(), field);
         }
-
+        
         static InputDescriptor create(CodeConnector<?> connector, AuxIn ann, Field field) {
             return create(connector, PortDescriptor.Category.AuxIn, ann.value(), field);
         }
-
+        
         private static InputDescriptor create(CodeConnector<?> connector,
                 PortDescriptor.Category category, int index, Field field) {
-            if (Data.In.class.equals(field.getType())
-                    && field.getGenericType() instanceof ParameterizedType) {
-                java.lang.reflect.Type type = extractDataType((ParameterizedType) field.getGenericType());
+            if (Data.In.class.equals(field.getType())) {
+                java.lang.reflect.Type type = TypeUtils.extractTypeParameter(field, Data.In.class);
+                if (type == null) {
+                    return null;
+                }
                 field.setAccessible(true);
                 return new InputDescriptor(connector.findID(field), category, index, field, type);
             } else {
                 return null;
             }
         }
-
+        
     }
-
+    
     public final static class Output<T> extends DataPort<T> {
-
+        
         private final OutPipe<T> out;
         private final List<Input<T>> connections;
         private final List<PortListener> listeners;
-
+        
         private java.lang.reflect.Type type;
-
+        
         private Output(OutputDescriptor desc) {
             this.type = Objects.requireNonNull(desc.type);
             out = new OutPipe<>();
@@ -240,7 +240,7 @@ public abstract class DataPort<T> implements Port {
                 out.reset(true);
             }
         }
-
+        
         @Override
         @SuppressWarnings("unchecked")
         public void connect(Port port) throws PortConnectionException {
@@ -259,7 +259,7 @@ public abstract class DataPort<T> implements Port {
                 throw new PortConnectionException();
             }
         }
-
+        
         @Override
         @SuppressWarnings("unchecked")
         public void disconnect(Port port) {
@@ -272,49 +272,49 @@ public abstract class DataPort<T> implements Port {
                 }
             }
         }
-
+        
         @Override
         public void disconnectAll() {
             for (Input<T> port : connections()) {
                 disconnect(port);
             }
         }
-
+        
         @Override
         public List<Input<T>> connections() {
             return List.copyOf(connections);
         }
-
+        
         @Override
         public void addListener(PortListener listener) {
             listeners.add(Objects.requireNonNull(listener));
         }
-
+        
         @Override
         public void removeListener(PortListener listener) {
             listeners.remove(listener);
         }
     }
-
+    
     private static class OutPipe<T> extends Data.Out<T> {
-
+        
         private void reset(boolean full) {
             disconnectSources();
             if (full) {
                 clearCaches();
             }
         }
-
+        
     }
-
+    
     static class OutputDescriptor extends PortDescriptor {
-
+        
         private final Field field;
         private final java.lang.reflect.Type type;
         private final PortInfo info;
-
+        
         private Output<?> port;
-
+        
         private OutputDescriptor(String id,
                 Category category,
                 int index,
@@ -325,13 +325,13 @@ public abstract class DataPort<T> implements Port {
             this.type = type;
             this.info = PortInfo.create(DataPort.class,
                     PortInfo.Direction.OUT,
-                    PMap.of("category", typeToCategory(type)));
+                    PMap.of("category", TypeUtils.portCategory(type)));
         }
-
+        
         @Override
         public void attach(CodeContext<?> context, Port previous) {
             if (previous instanceof Output
-                    && compatibleDataTypes(type, ((Output<?>) previous).type)) {
+                    && TypeUtils.equivalent(type, ((Output<?>) previous).type)) {
                 port = (Output<?>) previous;
                 port.reconfigure(this);
             } else {
@@ -346,110 +346,56 @@ public abstract class DataPort<T> implements Port {
                 context.getLog().log(LogLevel.ERROR, ex);
             }
         }
-
+        
         @Override
         public Port getPort() {
             return port;
         }
-
+        
         @Override
         public PortInfo getInfo() {
             return info;
         }
-
+        
         @Override
         public void reset(boolean full) {
             if (port != null) {
                 port.out.reset(full);
             }
         }
-
+        
         static OutputDescriptor create(CodeConnector<?> connector, Out ann, Field field) {
             return create(connector, PortDescriptor.Category.Out, ann.value(), field);
         }
-
+        
         static OutputDescriptor create(CodeConnector<?> connector, AuxOut ann, Field field) {
             return create(connector, PortDescriptor.Category.AuxOut, ann.value(), field);
         }
-
+        
         private static OutputDescriptor create(CodeConnector<?> connector,
                 PortDescriptor.Category category, int index, Field field) {
-            if (Data.Out.class.equals(field.getType())
-                    && field.getGenericType() instanceof ParameterizedType) {
-                java.lang.reflect.Type type = extractDataType((ParameterizedType) field.getGenericType());
+            if (Data.Out.class.equals(field.getType())) {
+                java.lang.reflect.Type type = TypeUtils.extractTypeParameter(field, Data.Out.class);
+                if (type == null) {
+                    return null;
+                }
                 field.setAccessible(true);
                 return new OutputDescriptor(connector.findID(field), category, index, field, type);
             } else {
                 return null;
             }
         }
-
+        
     }
-
+    
+    @Deprecated
     public static class Provider implements Port.TypeProvider {
-
+        
         @Override
         public Stream<Type<?>> types() {
             return Stream.of(new Type<>(DataPort.class));
         }
-
+        
     }
-
-    private static java.lang.reflect.Type extractDataType(ParameterizedType type) {
-        java.lang.reflect.Type[] types = type.getActualTypeArguments();
-        if (types.length > 0) {
-            return types[0];
-        } else {
-            return Object.class; // throw Exception here?
-        }
-    }
-
-    private static boolean compatibleDataTypes(java.lang.reflect.Type type1, java.lang.reflect.Type type2) {
-        return Objects.equals(type1, type2) || Objects.equals(type1.toString(), type2.toString());
-    }
-
-    private static String typeToCategory(java.lang.reflect.Type type) {
-        StringBuilder sb = new StringBuilder();
-        buildSimpleName(sb, type);
-        return sb.toString();
-    }
-
-    private static void buildSimpleName(StringBuilder sb, java.lang.reflect.Type type) {
-        if (type instanceof Class) {
-            sb.append(((Class<?>) type).getSimpleName());
-        } else if (type instanceof ParameterizedType) {
-            buildSimpleName(sb, ((ParameterizedType) type).getRawType());
-            java.lang.reflect.Type[] parTypes = ((ParameterizedType) type).getActualTypeArguments();
-            sb.append("<");
-            for (int i = 0; i < parTypes.length; i++) {
-                if (i > 0) {
-                    sb.append(", ");
-                }
-                buildSimpleName(sb, parTypes[i]);
-            }
-            sb.append(">");
-        } else if (type instanceof WildcardType) {
-            java.lang.reflect.Type[] bounds = ((WildcardType) type).getLowerBounds();
-            if (bounds.length > 0) {
-                sb.append("? super ");
-            } else {
-                bounds = ((WildcardType) type).getUpperBounds();
-                if (bounds.length > 0 && !Object.class.equals(bounds[0])) {
-                    sb.append("? extends ");
-                } else {
-                    sb.append("?");
-                    return;
-                }
-            }
-            for (int i = 0; i < bounds.length; i++) {
-                if (i > 0) {
-                    sb.append(" & ");
-                }
-                buildSimpleName(sb, bounds[i]);
-            }
-        } else {
-            sb.append("?");
-        }
-    }
-
+    
 }

--- a/praxiscore-code/src/main/java/org/praxislive/code/RefBus.java
+++ b/praxiscore-code/src/main/java/org/praxislive/code/RefBus.java
@@ -1,0 +1,104 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright 2023 Neil C Smith.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License version 3 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * version 3 for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License version 3
+ * along with this work; if not, see http://www.gnu.org/licenses/
+ *
+ *
+ * Please visit https://www.praxislive.org if you need additional information or
+ * have any questions.
+ */
+package org.praxislive.code;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ *
+ */
+class RefBus {
+
+    private final Map<String, RefImpl<?>> publishers;
+    private final Map<String, List<RefImpl<?>>> subscribers;
+
+    RefBus() {
+        this.publishers = new HashMap<>();
+        this.subscribers = new HashMap<>();
+    }
+
+    boolean publish(String name, RefImpl<?> publisher) {
+        if (publishers.putIfAbsent(name, publisher) == null) {
+            notify(name, publisher);
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    boolean unpublish(String name, RefImpl<?> publisher) {
+        if (publishers.remove(name, publisher)) {
+            notify(name, null);
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    void subscribe(String name, RefImpl<?> sub) {
+        var list = subscribers.computeIfAbsent(name, k -> new ArrayList<RefImpl<?>>());
+        if (list.contains(sub)) {
+            throw new IllegalStateException();
+        }
+        list.add(sub);
+        var publisher = publishers.get(name);
+        if (publisher != null) {
+            sub.updateFromPublisher(publisher);
+        } else {
+            sub.clear();
+        }
+    }
+
+    void unsubscribe(String name, RefImpl<?> sub) {
+        var list = subscribers.get(name);
+        if (list != null) {
+            list.remove(sub);
+            if (list.isEmpty()) {
+                subscribers.remove(name);
+            }
+        }
+    }
+
+    boolean notifySubscribers(String name, RefImpl<?> source) {
+        if (publishers.get(name) == source) {
+            notify(name, source);
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    private void notify(String name, RefImpl<?> source) {
+        var list = subscribers.get(name);
+        if (list != null) {
+            if (source != null) {
+                list.forEach(sub -> sub.updateFromPublisher(source));
+            } else {
+                list.forEach(sub -> sub.clear());
+            }
+        }
+    }
+
+}

--- a/praxiscore-code/src/main/java/org/praxislive/code/RefImpl.java
+++ b/praxiscore-code/src/main/java/org/praxislive/code/RefImpl.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright 2020 Neil C Smith.
+ * Copyright 2023 Neil C Smith.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3 only, as
@@ -62,6 +62,7 @@ class RefImpl<T> extends Ref<T> {
     }
 
     @Override
+    @Deprecated
     public <K> Ref<T> asyncCompute(K key, Function<K, ? extends T> function) {
         ControlAddress to = context.locateService(TaskService.class)
                 .map(ad -> ControlAddress.of(ad, TaskService.SUBMIT))
@@ -181,6 +182,7 @@ class RefImpl<T> extends Ref<T> {
             }
         }
 
+        @Deprecated
         ControlDescriptor getControlDescriptor() {
             return control;
         }
@@ -207,6 +209,7 @@ class RefImpl<T> extends Ref<T> {
 
     }
 
+    @Deprecated
     private static class ControlImpl extends ControlDescriptor implements Control {
 
         private final Descriptor rd;

--- a/praxiscore-code/src/main/java/org/praxislive/code/RefImpl.java
+++ b/praxiscore-code/src/main/java/org/praxislive/code/RefImpl.java
@@ -72,7 +72,7 @@ class RefImpl<T> extends Ref<T> {
     }
 
     @Override
-    protected void valueChanged(T newValue, T oldValue) {
+    protected void valueChanged(T currentValue, T previousValue) {
         if (desc.publishTo != null && desc.publishBus != null) {
             desc.publishBus.notifySubscribers(desc.publishTo, this);
         }

--- a/praxiscore-code/src/main/java/org/praxislive/code/RefPort.java
+++ b/praxiscore-code/src/main/java/org/praxislive/code/RefPort.java
@@ -1,0 +1,362 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright 2023 Neil C Smith.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License version 3 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * version 3 for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License version 3
+ * along with this work; if not, see http://www.gnu.org/licenses/
+ *
+ *
+ * Please visit https://www.praxislive.org if you need additional information or
+ * have any questions.
+ */
+package org.praxislive.code;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.CopyOnWriteArrayList;
+import org.praxislive.code.userapi.AuxIn;
+import org.praxislive.code.userapi.AuxOut;
+import org.praxislive.code.userapi.In;
+import org.praxislive.code.userapi.Out;
+import org.praxislive.code.userapi.Ref;
+import org.praxislive.core.Port;
+import org.praxislive.core.PortConnectionException;
+import org.praxislive.core.PortInfo;
+import org.praxislive.core.PortListener;
+import org.praxislive.core.services.LogLevel;
+import org.praxislive.core.types.PMap;
+
+/**
+ * Ports for sharing Ref values.
+ *
+ * @param <T> type of references
+ */
+public abstract class RefPort<T> implements Port {
+
+    /**
+     * Ref input, linked to {@link Ref.In} implementation.
+     *
+     * @param <T> type of references
+     */
+    public static final class Input<T> extends RefPort<T> {
+
+        private final RefInputImpl<T> refInput;
+        private final List<Output<T>> connections;
+        private final List<PortListener> listeners;
+
+        private java.lang.reflect.Type type;
+
+        private Input(InputDescriptor desc) {
+            refInput = new RefInputImpl<>();
+            connections = new ArrayList<>();
+            listeners = new CopyOnWriteArrayList<>();
+            type = desc.type;
+        }
+
+        private void reconfigure(InputDescriptor desc) {
+            this.type = desc.type;
+        }
+
+        @Override
+        public void addListener(PortListener listener) {
+            listeners.add(Objects.requireNonNull(listener));
+        }
+
+        @Override
+        public void connect(Port port) throws PortConnectionException {
+            if (port instanceof Output) {
+                port.connect(this);
+            } else {
+                throw new PortConnectionException();
+            }
+        }
+
+        @Override
+        public List<? extends Port> connections() {
+            return List.copyOf(connections);
+        }
+
+        @Override
+        public void disconnect(Port port) {
+            if (port instanceof Output) {
+                port.disconnect(this);
+            }
+        }
+
+        @Override
+        public void disconnectAll() {
+            for (var output : connections()) {
+                disconnect(output);
+            }
+        }
+
+        @Override
+        public void removeListener(PortListener listener) {
+            listeners.remove(listener);
+        }
+
+        private void addRefOutputPort(Output<T> port) throws PortConnectionException {
+            if (connections.contains(port)) {
+                throw new PortConnectionException();
+            }
+            connections.add(port);
+            updateRefImpl();
+            listeners.forEach(l -> l.connectionsChanged(this));
+        }
+
+        private void removeRefOutputPort(Output<T> port) {
+            if (connections.remove(port)) {
+                updateRefImpl();
+                listeners.forEach(l -> l.connectionsChanged(this));
+            }
+        }
+
+        @SuppressWarnings("unchecked")
+        private void updateRefImpl() {
+            List<Ref<T>> refs = new ArrayList<>(connections.size());
+            for (var connection : connections) {
+                refs.add((Ref<T>) connection.refDesc.getRef());
+            }
+            refInput.update(refs);
+        }
+
+    }
+
+    private static class RefInputImpl<T> extends Ref.Input<T> {
+
+        @Override
+        protected void update(List<Ref<T>> refs) {
+            super.update(refs);
+        }
+
+    }
+
+    static final class InputDescriptor extends PortDescriptor {
+
+        private final Field field;
+        private final java.lang.reflect.Type type;
+        private final PortInfo info;
+
+        private Input<?> port;
+
+        private InputDescriptor(String id,
+                Category category,
+                int index,
+                Field field,
+                java.lang.reflect.Type type) {
+            super(id, category, index);
+            this.field = field;
+            this.type = type;
+            this.info = PortInfo.create(RefPort.class,
+                    PortInfo.Direction.IN,
+                    PMap.of("category", TypeUtils.portCategory(type)));
+        }
+
+        @Override
+        public void attach(CodeContext<?> context, Port previous) {
+            if (previous instanceof Input
+                    && TypeUtils.equivalent(type, ((Input<?>) previous).type)) {
+                port = (Input<?>) previous;
+                port.reconfigure(this);
+            } else {
+                if (previous != null) {
+                    previous.disconnectAll();
+                }
+                port = new Input<>(this);
+            }
+            try {
+                field.set(context.getDelegate(), port.refInput);
+            } catch (Exception ex) {
+                context.getLog().log(LogLevel.ERROR, ex);
+            }
+        }
+
+        @Override
+        public PortInfo getInfo() {
+            return info;
+        }
+
+        @Override
+        public Port getPort() {
+            return port;
+        }
+
+        @Override
+        public void reset(boolean full) {
+            port.refInput.clearLinks();
+        }
+
+        static InputDescriptor create(CodeConnector<?> connector, In ann, Field field) {
+            return create(connector, PortDescriptor.Category.In, ann.value(), field);
+        }
+
+        static InputDescriptor create(CodeConnector<?> connector, AuxIn ann, Field field) {
+            return create(connector, PortDescriptor.Category.AuxIn, ann.value(), field);
+        }
+
+        private static InputDescriptor create(CodeConnector<?> connector,
+                PortDescriptor.Category category, int index, Field field) {
+            if (Ref.Input.class.equals(field.getType())) {
+                java.lang.reflect.Type type = TypeUtils.extractTypeParameter(field, Ref.Input.class);
+                if (type == null) {
+                    return null;
+                }
+                field.setAccessible(true);
+                return new InputDescriptor(connector.findID(field), category, index, field, type);
+            } else {
+                return null;
+            }
+        }
+
+    }
+
+    /**
+     * Output port linked to {@link Ref} implementation.
+     *
+     * @param <T> type of reference
+     */
+    public static final class Output<T> extends RefPort<T> {
+
+        private final List<Input<T>> connections;
+        private final List<PortListener> listeners;
+
+        private RefImpl.Descriptor refDesc;
+
+        private Output(OutputDescriptor desc) {
+            this.connections = new ArrayList<>();
+            this.listeners = new CopyOnWriteArrayList<>();
+            this.refDesc = desc.refDesc;
+        }
+
+        private void reconfigure(OutputDescriptor desc) {
+            this.refDesc = desc.refDesc;
+        }
+
+        @Override
+        public void addListener(PortListener listener) {
+            listeners.add(Objects.requireNonNull(listener));
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public void connect(Port port) throws PortConnectionException {
+            if (port instanceof Input) {
+                Input<T> input = (Input<T>) port;
+                if (connections.contains(input)) {
+                    throw new PortConnectionException();
+                }
+                // check type
+                input.addRefOutputPort(this);
+                connections.add(input);
+                listeners.forEach(l -> l.connectionsChanged(this));
+            } else {
+                throw new PortConnectionException();
+            }
+        }
+
+        @Override
+        public List<? extends Port> connections() {
+            return List.copyOf(connections);
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public void disconnect(Port port) {
+            if (port instanceof Input) {
+                Input<T> input = (Input<T>) port;
+                if (connections.contains(input)) {
+                    input.removeRefOutputPort(this);
+                    connections.remove(input);
+                    listeners.forEach(l -> l.connectionsChanged(this));
+                }
+            }
+        }
+
+        @Override
+        public void disconnectAll() {
+            for (var input : connections()) {
+                disconnect(input);
+            }
+        }
+
+        @Override
+        public void removeListener(PortListener listener) {
+            listeners.remove(listener);
+        }
+
+        private void revalidateInputs() {
+            connections.forEach(Input::updateRefImpl);
+        }
+
+    }
+
+    static final class OutputDescriptor extends PortDescriptor {
+
+        private final RefImpl.Descriptor refDesc;
+        private final PortInfo info;
+
+        private Output<?> port;
+
+        private OutputDescriptor(String id,
+                Category category,
+                int index,
+                RefImpl.Descriptor refDesc) {
+            super(id, category, index);
+            this.refDesc = refDesc;
+            this.info = PortInfo.create(RefPort.class,
+                    PortInfo.Direction.OUT,
+                    PMap.of("category", TypeUtils.portCategory(refDesc.getRefType())));
+        }
+
+        @Override
+        public void attach(CodeContext<?> context, Port previous) {
+            if (previous instanceof Output
+                    && TypeUtils.equivalent(refDesc.getRefType(),
+                            ((Output<?>) previous).refDesc.getRefType())) {
+                port = (Output<?>) previous;
+                port.reconfigure(this);
+            } else {
+                if (previous != null) {
+                    previous.disconnectAll();
+                }
+                port = new Output<>(this);
+            }
+        }
+
+        @Override
+        public PortInfo getInfo() {
+            return info;
+        }
+
+        @Override
+        public Port getPort() {
+            return port;
+        }
+
+        void fireChange() {
+            port.revalidateInputs();
+        }
+
+        static OutputDescriptor create(String id, Out ann, RefImpl.Descriptor refDesc) {
+            return new OutputDescriptor(id, Category.Out, ann.value(), refDesc);
+        }
+
+        static OutputDescriptor create(String id, AuxOut ann, RefImpl.Descriptor refDesc) {
+            return new OutputDescriptor(id, Category.AuxOut, ann.value(), refDesc);
+        }
+
+    }
+
+}

--- a/praxiscore-code/src/main/java/org/praxislive/code/TypeUtils.java
+++ b/praxiscore-code/src/main/java/org/praxislive/code/TypeUtils.java
@@ -1,0 +1,127 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright 2023 Neil C Smith.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License version 3 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * version 3 for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License version 3
+ * along with this work; if not, see http://www.gnu.org/licenses/
+ * 
+ *
+ * Please visit https://www.praxislive.org if you need additional information or
+ * have any questions.
+ */
+package org.praxislive.code;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.lang.reflect.WildcardType;
+import java.util.Objects;
+
+/**
+ * Various package private type utilities.
+ */
+class TypeUtils {
+
+    private TypeUtils() {
+
+    }
+
+    /**
+     * Check whether two types are equivalent - either equal or by type name.
+     * This can be used eg. in port compatibility checks to cover mutually
+     * changing shared types.
+     *
+     * @param type1
+     * @param type2
+     * @return
+     */
+    static boolean equivalent(Type type1, Type type2) {
+        return Objects.equals(type1, type2) || Objects.equals(type1.toString(), type2.toString());
+    }
+
+    /**
+     * Extract the type parameter of a field, also checking the raw type of the
+     * field against the base type. eg. for a field of {@code Ref<List<String>>}
+     * return the type of {@code List<String>}.
+     *
+     * @param field generic field definition
+     * @param baseType expected raw field type
+     * @return extracted type or null
+     */
+    static Type extractTypeParameter(Field field, Class<?> baseType) {
+        if (field.getType().equals(baseType)) {
+            var fieldType = field.getGenericType();
+            if (fieldType instanceof ParameterizedType) {
+                var paramType = (ParameterizedType) fieldType;
+                var types = paramType.getActualTypeArguments();
+                if (types.length == 1) {
+                    return types[0];
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Build a simplified version of the type to use as a Port category. This
+     * reflects the generic type signature but using
+     * {@link Class#getSimpleName()} for all concrete types.
+     *
+     * @param type type to convert
+     * @return port category as String
+     */
+    static String portCategory(Type type) {
+        StringBuilder sb = new StringBuilder();
+        buildSimpleName(sb, type);
+        return sb.toString();
+    }
+
+    private static void buildSimpleName(StringBuilder sb, java.lang.reflect.Type type) {
+        if (type instanceof Class) {
+            sb.append(((Class<?>) type).getSimpleName());
+        } else if (type instanceof ParameterizedType) {
+            buildSimpleName(sb, ((ParameterizedType) type).getRawType());
+            java.lang.reflect.Type[] parTypes = ((ParameterizedType) type).getActualTypeArguments();
+            sb.append("<");
+            for (int i = 0; i < parTypes.length; i++) {
+                if (i > 0) {
+                    sb.append(", ");
+                }
+                buildSimpleName(sb, parTypes[i]);
+            }
+            sb.append(">");
+        } else if (type instanceof WildcardType) {
+            java.lang.reflect.Type[] bounds = ((WildcardType) type).getLowerBounds();
+            if (bounds.length > 0) {
+                sb.append("? super ");
+            } else {
+                bounds = ((WildcardType) type).getUpperBounds();
+                if (bounds.length > 0 && !Object.class.equals(bounds[0])) {
+                    sb.append("? extends ");
+                } else {
+                    sb.append("?");
+                    return;
+                }
+            }
+            for (int i = 0; i < bounds.length; i++) {
+                if (i > 0) {
+                    sb.append(" & ");
+                }
+                buildSimpleName(sb, bounds[i]);
+            }
+        } else {
+            sb.append("?");
+        }
+    }
+
+}

--- a/praxiscore-code/src/main/java/org/praxislive/code/internal/CodePortTypeProvider.java
+++ b/praxiscore-code/src/main/java/org/praxislive/code/internal/CodePortTypeProvider.java
@@ -1,0 +1,42 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright 2023 Neil C Smith.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License version 3 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * version 3 for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License version 3
+ * along with this work; if not, see http://www.gnu.org/licenses/
+ *
+ *
+ * Please visit https://www.praxislive.org if you need additional information or
+ * have any questions.
+ */
+package org.praxislive.code.internal;
+
+import java.util.stream.Stream;
+import org.praxislive.code.DataPort;
+import org.praxislive.code.RefPort;
+import org.praxislive.core.Port;
+
+/**
+ *
+ */
+public class CodePortTypeProvider implements Port.TypeProvider {
+
+    @Override
+    public Stream<Port.Type<?>> types() {
+        return Stream.of(
+                new Port.Type<>(DataPort.class),
+                new Port.Type<>(RefPort.class)
+        );
+    }
+
+}

--- a/praxiscore-code/src/main/java/org/praxislive/code/userapi/Ref.java
+++ b/praxiscore-code/src/main/java/org/praxislive/code/userapi/Ref.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright 2021 Neil C Smith.
+ * Copyright 2023 Neil C Smith.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3 only, as
@@ -139,6 +139,7 @@ public abstract class Ref<T> {
      * @param function an intensive or time-consuming function
      * @return this
      */
+    @Deprecated
     public <K> Ref<T> asyncCompute(K key, Function<K, ? extends T> function) {
         throw new UnsupportedOperationException();
     }

--- a/praxiscore-code/src/main/java/org/praxislive/code/userapi/Ref.java
+++ b/praxiscore-code/src/main/java/org/praxislive/code/userapi/Ref.java
@@ -373,8 +373,14 @@ public abstract class Ref<T> {
             var err = async.error();
             log(err.exception().orElseGet(() -> new Exception(err.message())));
         } else {
-            var val = async.result();
-            init(() -> val).compute(o -> val);
+            T newValue = async.result();
+            inited = true;
+            if (newValue != value) {
+                disposeValue();
+                T oldValue = value;
+                value = newValue;
+                notifyValueChanged(newValue, oldValue);
+            }
         }
     }
 

--- a/praxiscore-code/src/main/resources/META-INF/services/org.praxislive.core.Port$TypeProvider
+++ b/praxiscore-code/src/main/resources/META-INF/services/org.praxislive.core.Port$TypeProvider
@@ -1,1 +1,1 @@
-org.praxislive.code.DataPort$Provider
+org.praxislive.code.internal.CodePortTypeProvider

--- a/testsuite/tests/config
+++ b/testsuite/tests/config
@@ -6,3 +6,4 @@ core/basic-multiprocess
 core/shared-delegates
 core/async-functions
 core/code-roots
+core/refs

--- a/testsuite/tests/core/refs/project.pxp
+++ b/testsuite/tests/core/refs/project.pxp
@@ -1,0 +1,13 @@
+hub {
+
+}
+compiler {
+  release 11
+}
+libraries {}
+
+# <<<BUILD>>>
+include [file "refs.pxr"]
+
+# <<<RUN>>>
+/refs.start

--- a/testsuite/tests/core/refs/refs.pxr
+++ b/testsuite/tests/core/refs/refs.pxr
@@ -1,0 +1,377 @@
+@ /refs root:custom {
+  #%praxis.version 5.7.0-SNAPSHOT
+  .shared-code "SHARED.Source \{package SHARED;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Consumer;
+
+public class Source \{
+
+    private final List<Consumer<String>> listeners;
+    private final String message;
+
+    public Source(String message) \{
+        this.listeners = new ArrayList<>();
+        this.message = Objects.requireNonNull(message);
+    \}
+
+    public void addListener(Consumer<String> listener) \{
+        listeners.add(Objects.requireNonNull(listener));
+    \}
+
+    public void removeListener(Consumer<String> listener) \{
+        listeners.remove(listener);
+    \}
+
+    public void fire() \{
+        listeners.forEach(l -> l.accept(message));
+    \}
+
+\}
+\}"
+  .code "import SHARED.Source;
+
+
+    @Inject @Ref.Publish
+    Ref<String> defRef;
+
+    @Inject @Ref.Publish(name = \"alt\")
+    Ref<String> altRef;
+
+    @Inject @Ref.Publish
+    Ref<Source> sourceRef;
+
+    @Override
+    public void init() \{
+        defRef.set(\"default\");
+        altRef.set(\"alternate\");
+    \}
+
+    @FN
+    void sourceUpdate(String message) \{
+        var previous = sourceRef.orElse(null);
+        if (message.isBlank()) \{
+            sourceRef.clear();
+        \} else \{
+            sourceRef.set(new Source(message));
+        \}
+        var current = sourceRef.orElse(null);
+        if (previous != null) \{
+            previous.fire();
+        \}
+        if (current != null) \{
+            current.fire();
+        \}
+    \}
+
+"
+  @ ./exit core:custom {
+    #%graph.x 954
+    #%graph.y 95
+    .code "import org.praxislive.core.services.Services;
+import org.praxislive.core.services.SystemManagerService;
+
+
+    @T(1)
+    void exitOK() \{
+        exit(0);
+    \}
+
+    @T(2)
+    void exitFail() \{
+        exit(1);
+    \}
+
+    private void exit(int exitValue) \{
+        find(Services.class)
+                .flatMap(s -> s.locate(SystemManagerService.class))
+                .ifPresent(s -> tell(ControlAddress.of(s, \"system-exit\"), exitValue));
+    \}
+
+"
+  }
+  @ ./test1 core:custom {
+    #%graph.x 486
+    #%graph.y 95
+    #%graph.comment Check pub/sub
+    .code "
+    @Out(1) Output ok;
+    @Out(2) Output error;
+
+    @Inject @Ref.Subscribe
+    Ref<String> defRef;
+
+    @Inject @Ref.Subscribe(name = \"alt\")
+    Ref<String> altRef;
+
+    @Inject @Ref.Subscribe(name = \"unknown\")
+    Ref<String> unknownRef;
+
+    String def, alt, unknown;
+
+    @Override
+    public void init() \{
+        def = defRef.orElse(\"\");
+        alt = altRef.orElse(\"\");
+        unknown = unknownRef.orElse(\"unknown\");
+    \}
+
+    @T(1)
+    void test() \{
+        log(INFO, \"Test 1 : Checking Ref Publish and Subscribe\");
+        if (!\"default\".equals(def)) \{
+            log(ERROR, \"<FAIL> Default reference not correctly set\");
+            error.send();
+        \} else if (!\"alternate\".equals(alt)) \{
+            log(ERROR, \"<FAIL> Named reference not correctly set\");
+            error.send();
+        \} else if (!\"unknown\".equals(unknown)) \{
+            log(ERROR, \"<FAIL> Unknown named reference should not be set\");
+            error.send();
+        \} else \{
+            log(INFO, \"<OK> : Test 1\");
+            ok.send();
+        \}
+    \}
+
+
+"
+  }
+  @ ./start-trigger core:start-trigger {
+    #%graph.x 285
+    #%graph.y 95
+  }
+  @ ./test2 core:custom {
+    #%graph.x 486
+    #%graph.y 255
+    #%graph.comment Check set, setAsync and onChange
+    .code "
+    @Out(1) Output ok;
+    @Out(2) Output error;
+
+    @Inject
+    Ref<String> ref;
+
+    @T(1)
+    void test() \{
+        log(INFO, \"Test 2 : Checking Ref set, asyncSet and onChange\");
+        ref.onChange(null);
+        ref.clear();
+        var value = ref.orElse(\"unset\");
+        if (!\"unset\".equals(value)) \{
+            log(ERROR, \"<FAIL> : ref value is not unset\");
+            error.send();
+            return;
+        \}
+        var called = new boolean\[1\];
+        var failed = new boolean\[1\];
+        ref.onChange(e -> \{
+            called\[0\] = true;
+            if (!\"SYNC\".equals(e.current().orElse(\"FAIL\"))) \{
+                failed\[0\] = true;
+                log(ERROR, \"<FAIL> : expected value SYNC in change event\");
+                error.send();
+            \}
+        \});
+        ref.set(\"SYNC\");
+        if (failed\[0\]) \{
+            return;
+        \}
+        if (!called\[0\]) \{
+            log(ERROR, \"<FAIL> : onChange handler not called\");
+        \}
+        ref.setAsync(async(\"ASYNC\", s -> s));
+        ref.onChange(e -> \{
+            if (!\"ASYNC\".equals(e.current().orElse(\"FAIL\"))) \{
+                log(ERROR, \"<FAIL> : expected value ASYNC in change event\");
+                error.send();
+            \} else \{
+                log(INFO, \"<OK> : Test 2\");
+                ref.onChange(null);
+                ok.send();
+            \}
+        \});
+    \}
+
+
+"
+  }
+  @ ./delay-1 core:timing:delay {
+    #%graph.x 285
+    #%graph.y 255
+    .time 0.01
+  }
+  @ ./delay-2 core:timing:delay {
+    #%graph.x 285
+    #%graph.y 419
+    .time 0.01
+  }
+  @ ./test3 core:custom {
+    #%graph.x 486
+    #%graph.y 419
+    #%graph.comment Check binding
+    .code "import SHARED.Source;
+
+
+    @Out(1) Output ok;
+    @Out(2) Output error;
+
+    @Inject @Ref.Subscribe
+    Ref<Source> ref;
+    @Inject
+    Ref<Source> localRef;
+
+    @Inject List<String> received;
+
+    private final List<String> EXPECTED = List.of(\"MESSAGE 1\", \"MESSAGE 2\");
+    private final ControlAddress ROOT = ControlAddress.of(\"/refs.source-update\");
+
+    @Override
+    public void init() \{
+        localRef.clear();
+        localRef.bind(Source::addListener, Source::removeListener, received::add);
+        ref.bind(Source::addListener, Source::removeListener, msg -> \{
+            received.add(msg);
+            if (received.size() < EXPECTED.size()) \{
+                tell(ROOT, EXPECTED.get(received.size()));
+            \} else \{
+                if (EXPECTED.equals(received)) \{
+                    log(INFO, \"<OK> : Test 3\");
+                    ok.send();
+                \} else \{
+                    log(ERROR, \"<FAIL> : Expected \" + EXPECTED + \" but received \" + received);
+                    error.send();
+                \}
+            \}
+        \});
+    \}
+
+    @T(1)
+    void test() \{
+        log(INFO, \"Test 3 : Checking Ref binding\");
+        received.clear();
+        localRef.set(new Source(\"HELLO WORLD\"));
+        localRef.ifPresent(Source::fire);
+        if (received.isEmpty()) \{
+            log(ERROR, \"<FAIL> : no message received by local listener\");
+            error.send();
+            return;
+        \}
+        if (!\"HELLO WORLD\".equals(received.get(0))) \{
+            log(ERROR, \"<FAIL> : wrong message received by local listener : \" + received.get(0));
+            error.send();
+            return;
+        \}
+        received.clear();
+        tell(ROOT, EXPECTED.get(0));
+    \}
+
+
+"
+  }
+  @ ./ref-out-1 core:custom {
+    #%graph.x 473
+    #%graph.y 566
+    .code "
+    @Out(1)
+    Ref<String> out;
+
+    @In(1)
+    void update(String message) \{
+        if (message.isBlank()) \{
+            out.clear();
+        \} else \{
+            out.set(message);
+        \}
+    \}
+
+"
+  }
+  @ ./ref-out-2 core:custom {
+    #%graph.x 473
+    #%graph.y 668
+    .code "
+    @AuxOut(1)
+    Ref<String> out;
+
+    @In(1)
+    void update(String message) \{
+        if (message.isBlank()) \{
+            out.clear();
+        \} else \{
+            out.set(message);
+        \}
+    \}
+
+"
+  }
+  @ ./test4 core:custom {
+    #%graph.x 677
+    #%graph.y 588
+    #%graph.comment Check input ports
+    .code "import SHARED.Source;
+
+
+    @Out(1) Output ok;
+    @Out(2) Output error;
+
+    @In(1) Ref.Input<String> in;
+
+    @T(1)
+    void test() \{
+        log(INFO, \"Test 4 : Checking Ref ports\");
+        transmit(\"ref-out-1\", \"update\", \"\");
+        transmit(\"ref-out-2\", \"update\", \"\");
+        in.clearLinks();
+        var values = in.values();
+        if (!values.isEmpty()) \{
+            log(ERROR, \"<FAIL> : Expected empty input but received \" + values);
+            error.send();
+            return;
+        \}
+        var expected1 = List.of(\"PORT 1\", \"PORT 2\");
+        transmit(\"ref-out-1\", \"update\", expected1.get(0));
+        transmit(\"ref-out-2\", \"update\", expected1.get(1));
+        values = in.values();
+        if (!values.equals(expected1)) \{
+            log(ERROR, \"<FAIL> : Expected \" + expected1 + \" input but received \" + values);
+            error.send();
+            return;
+        \}
+        var expected2 = List.of(\"NEW PORT 1\", \"NEW PORT 2\");
+        in.onUpdate(l -> \{
+            if (l.equals(expected2)) \{
+                log(INFO, \"<OK> : Test 4\");
+                ok.send();
+            \}
+        \});
+        tell(ControlAddress.of(\"/refs/ref-out-1.update\"), expected2.get(0));
+        tell(ControlAddress.of(\"/refs/ref-out-2.update\"), expected2.get(1));
+
+    \}
+
+
+"
+  }
+  @ ./delay-3 core:timing:delay {
+    #%graph.x 285
+    #%graph.y 588
+    .time 0.01
+  }
+  ~ ./start-trigger!out ./test1!test
+  ~ ./test1!error ./exit!exit-fail
+  ~ ./test2!error ./exit!exit-fail
+  ~ ./test1!ok ./delay-1!in
+  ~ ./delay-1!out ./test2!test
+  ~ ./test2!ok ./delay-2!in
+  ~ ./delay-2!out ./test3!test
+  ~ ./test3!error ./exit!exit-fail
+  ~ ./ref-out-1!out ./test4!in
+  ~ ./ref-out-2!out ./test4!in
+  ~ ./test3!ok ./delay-3!in
+  ~ ./delay-3!out ./test4!test
+  ~ ./test4!ok ./exit!exit-ok
+  ~ ./test4!error ./exit!exit-fail
+}


### PR DESCRIPTION
Various updates to the Ref type.

`@Ref.Publish` and `@Ref.Subscribe` annotations to allow children to access published refs from immediate parent.  Subscription is by type and/or name.

Add Ref ports.  Allow Ref to be annotated as output ports.  Add a `Ref.Input` type for input ports, that provide access to a list of connected values.

Add new `set` and `setAsync` methods. The latter using new async task support.  Deprecate old async compute, and rewrite implementation to use new async method.

Add `onChange` handler to Ref, including access to current and previous values.

Update `Ref::bind` to bind and unbind automatically on all updates to the Ref value.