### PR TITLE
Add support for custom type registration

### DIFF
--- a/praxiscore-api/src/main/java/org/praxislive/core/ComponentInfo.java
+++ b/praxiscore-api/src/main/java/org/praxislive/core/ComponentInfo.java
@@ -69,6 +69,13 @@ public class ComponentInfo extends PMap.MapBasedValue {
      */
     public static final String KEY_DYNAMIC = "dynamic";
 
+    /**
+     * Optional key for adding a hint how the component, and its children if a
+     * container, should be displayed. Value must be a map. The {@code type} key
+     * is mandatory. Other keys may be used to provide additional configuration.
+     */
+    public static final String KEY_DISPLAY_HINT = "display-hint";
+
     private final OrderedMap<String, ControlInfo> controls;
     private final OrderedMap<String, PortInfo> ports;
     private final List<String> protocols;

--- a/praxiscore-base/src/main/java/org/praxislive/base/AbstractContainer.java
+++ b/praxiscore-base/src/main/java/org/praxislive/base/AbstractContainer.java
@@ -150,6 +150,10 @@ public abstract class AbstractContainer extends AbstractComponent implements Con
         child.hierarchyChanged();
     }
 
+    protected void recordChildType(Component child, ComponentType type) {
+        childTypeMap.put(Objects.requireNonNull(child), Objects.requireNonNull(type));
+    }
+
     protected void notifyChild(Component child) throws VetoException {
         child.parentNotify(this);
     }
@@ -245,11 +249,10 @@ public abstract class AbstractContainer extends AbstractComponent implements Con
                     .flatMap(r -> r.as(Component.class))
                     .orElseThrow();
             Call active = getActiveCall();
-            addChild(active.args().get(0).toString(), child);
+            String id = active.args().get(0).toString();
             ComponentType type = ComponentType.from(active.args().get(1)).orElse(null);
-            if (type != null) {
-                childTypeMap.put(child, type);
-            }
+            addChild(id, child);
+            recordChildType(child, type);
             return active.reply();
         }
     }
@@ -354,6 +357,14 @@ public abstract class AbstractContainer extends AbstractComponent implements Con
         @Override
         protected abstract ComponentAddress getAddress();
 
+        /**
+         * Notify the child of its addition to the container by calling through
+         * to {@link Component#parentNotify(org.praxislive.core.Container)} with
+         * the wrapper instance.
+         *
+         * @param child child being notified
+         * @throws VetoException if child vetoes being added
+         */
         @Override
         protected abstract void notifyChild(Component child) throws VetoException;
 

--- a/praxiscore-code-services/src/main/java/org/praxislive/code/services/ComponentRegistry.java
+++ b/praxiscore-code-services/src/main/java/org/praxislive/code/services/ComponentRegistry.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright 2023 Neil C Smith.
+ * Copyright 2024 Neil C Smith.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3 only, as
@@ -23,56 +23,96 @@ package org.praxislive.code.services;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Optional;
 import org.praxislive.code.CodeComponentFactoryService;
+import org.praxislive.code.CodeDelegate;
+import org.praxislive.code.CodeFactory;
 import org.praxislive.code.CodeRootFactoryService;
 import org.praxislive.core.services.ComponentFactory;
 import org.praxislive.core.services.ComponentFactoryProvider;
 import org.praxislive.core.ComponentType;
 import org.praxislive.core.Lookup;
+import org.praxislive.core.OrderedMap;
 
 /**
  *
  */
 class ComponentRegistry {
 
-    private final Map<ComponentType, ComponentFactory> componentCache;
+    private final OrderedMap<ComponentType, ComponentFactory> componentCache;
+    private final OrderedMap<Class<? extends CodeDelegate>, CodeFactory.Base<CodeDelegate>> baseCache;
 
-    private ComponentRegistry(Map<ComponentType, ComponentFactory> componentCache) {
+    private ComponentRegistry(OrderedMap<ComponentType, ComponentFactory> componentCache,
+            OrderedMap<Class<? extends CodeDelegate>, CodeFactory.Base<CodeDelegate>> baseCache) {
         this.componentCache = componentCache;
+        this.baseCache = baseCache;
     }
 
     ComponentFactory getComponentFactory(ComponentType type) {
         return componentCache.get(type);
     }
 
+    CodeFactory.Base<CodeDelegate> findSuitableBase(Class<? extends CodeDelegate> cls) {
+        Class<?> c = cls;
+        while (c != CodeDelegate.class && c != null) {
+            CodeFactory.Base<CodeDelegate> base = baseCache.get(c);
+            if (base != null) {
+                return base;
+            }
+            c = c.getSuperclass();
+        }
+        return null;
+    }
+
     static ComponentRegistry getInstance() {
-        Map<ComponentType, ComponentFactory> componentCache
+        Map<ComponentType, ComponentFactory> components
+                = new LinkedHashMap<>();
+        Map<Class<? extends CodeDelegate>, CodeFactory.Base<CodeDelegate>> bases
                 = new LinkedHashMap<>();
 
         Lookup.SYSTEM.findAll(ComponentFactoryProvider.class)
                 .map(ComponentFactoryProvider::getFactory)
-                .filter(factory -> factory.componentRedirect()
+                .filter(factory
+                        -> factory.componentRedirect()
                         .filter(r -> r.service() == CodeComponentFactoryService.class)
                         .isPresent())
                 .forEachOrdered(factory -> {
                     factory.componentTypes().forEachOrdered(type -> {
-                        componentCache.put(type, factory);
-                    });
-                }
-                );
-        
-        Lookup.SYSTEM.findAll(ComponentFactoryProvider.class)
-                .map(ComponentFactoryProvider::getFactory)
-                .filter(factory -> factory.rootRedirect()
-                        .filter(r -> r.service() == CodeRootFactoryService.class)
-                        .isPresent())
-                .forEachOrdered(factory -> {
-                    factory.rootTypes().forEachOrdered(type -> {
-                        componentCache.put(type, factory);
+                        components.put(type, factory);
+                        CodeFactory.Base<CodeDelegate> base = findBase(factory, type);
+                        if (base != null) {
+                            bases.putIfAbsent(base.baseClass(), base);
+                        }
                     });
                 }
                 );
 
-        return new ComponentRegistry(componentCache);
+        Lookup.SYSTEM.findAll(ComponentFactoryProvider.class)
+                .map(ComponentFactoryProvider::getFactory)
+                .filter(factory
+                        -> factory.rootRedirect()
+                        .filter(r -> r.service() == CodeRootFactoryService.class)
+                        .isPresent())
+                .forEachOrdered(factory -> {
+                    factory.rootTypes().forEachOrdered(type -> {
+                        components.put(type, factory);
+                        CodeFactory.Base<CodeDelegate> base = findBase(factory, type);
+                        if (base != null) {
+                            bases.putIfAbsent(base.baseClass(), base);
+                        }
+                    });
+                }
+                );
+
+        return new ComponentRegistry(OrderedMap.copyOf(components), OrderedMap.copyOf(bases));
     }
+
+    private static CodeFactory.Base<CodeDelegate> findBase(ComponentFactory factory, ComponentType type) {
+        return Optional.ofNullable(factory.componentData(type))
+                .flatMap(data -> data.find(CodeFactory.class))
+                .map(CodeFactory::lookup)
+                .flatMap(data -> data.find(CodeFactory.Base.class))
+                .orElse(null);
+    }
+
 }

--- a/praxiscore-code/src/main/java/org/praxislive/code/CodeChildFactoryService.java
+++ b/praxiscore-code/src/main/java/org/praxislive/code/CodeChildFactoryService.java
@@ -1,0 +1,84 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright 2024 Neil C Smith.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License version 3 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * version 3 for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License version 3
+ * along with this work; if not, see http://www.gnu.org/licenses/
+ *
+ *
+ * Please visit https://www.praxislive.org if you need additional information or
+ * have any questions.
+ */
+package org.praxislive.code;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Stream;
+import org.praxislive.core.ComponentType;
+import org.praxislive.core.ControlInfo;
+import org.praxislive.core.services.LogBuilder;
+import org.praxislive.core.services.LogLevel;
+import org.praxislive.core.services.Service;
+import org.praxislive.core.types.PMap;
+import org.praxislive.core.types.PReference;
+
+/**
+ *
+ */
+public class CodeChildFactoryService implements Service {
+    
+    public static final String NEW_CHILD_INSTANCE = "new-child-instance";
+    
+    public static final ControlInfo NEW_CHILD_INSTANCE_INFO
+            = ControlInfo.createFunctionInfo(
+                    List.of(PReference.info(Task.class)),
+                    List.of(PReference.info(Result.class)),
+                    PMap.EMPTY);
+
+    @Override
+    public Stream<String> controls() {
+        return Stream.of(NEW_CHILD_INSTANCE);
+    }
+
+    @Override
+    public ControlInfo getControlInfo(String control) {
+        return switch (control) {
+            case NEW_CHILD_INSTANCE -> NEW_CHILD_INSTANCE_INFO;
+            default -> throw new IllegalArgumentException();
+        };
+    }
+    
+    public static record Task(ComponentType componentType,
+        Class<? extends CodeDelegate> baseDelegate,
+        LogLevel logLevel) {
+        
+        public Task(ComponentType componentType,
+                Class<? extends CodeDelegate> baseDelegate,
+                LogLevel logLevel) {
+            this.componentType = Objects.requireNonNull(componentType);
+            this.baseDelegate = Objects.requireNonNull(baseDelegate);
+            this.logLevel = Objects.requireNonNull(logLevel);
+        }
+        
+    }
+    
+    public static record Result(CodeComponent<?> component, LogBuilder log) {
+        
+        public Result(CodeComponent<?> component, LogBuilder log) {
+            this.component = Objects.requireNonNull(component);
+            this.log = Objects.requireNonNull(log);
+        }
+        
+    }
+    
+}

--- a/praxiscore-code/src/main/java/org/praxislive/code/CodeComponent.java
+++ b/praxiscore-code/src/main/java/org/praxislive/code/CodeComponent.java
@@ -35,14 +35,11 @@ import org.praxislive.core.Port;
 import org.praxislive.core.VetoException;
 import org.praxislive.core.ComponentInfo;
 import org.praxislive.core.ComponentType;
-import org.praxislive.core.ControlInfo;
 import org.praxislive.core.ThreadContext;
 import org.praxislive.core.TreeWriter;
-import org.praxislive.core.protocols.ComponentProtocol;
 import org.praxislive.core.services.Services;
 import org.praxislive.core.services.LogLevel;
 import org.praxislive.core.services.LogService;
-import org.praxislive.core.types.PMap;
 
 /**
  * A CodeComponent is a Component instance that is rewritable at runtime. The
@@ -206,6 +203,14 @@ public class CodeComponent<D extends CodeDelegate> implements Component {
         }
         return logInfo.toAddress;
     }
+    
+    Control infoProperty() {
+        return infoProperty;
+    }
+    
+    MetaProperty metaProperty() {
+        return metaProperty;
+    }
 
     private void initLogInfo() {
         ControlAddress toAddress = getLookup().find(Services.class)
@@ -220,64 +225,6 @@ public class CodeComponent<D extends CodeDelegate> implements Component {
         }
 
         logInfo = new LogInfo(level, toAddress);
-    }
-
-    static class ControlWrapper extends ControlDescriptor<ControlWrapper> {
-
-        private final String controlID;
-
-        private CodeComponent<?> component;
-
-        ControlWrapper(String controlID, int index) {
-            super(ControlWrapper.class, controlID, Category.Internal, index);
-            this.controlID = controlID;
-        }
-
-        @Override
-        public void attach(CodeContext<?> context, ControlWrapper previous) {
-            component = context.getComponent();
-        }
-
-        @Override
-        public Control control() {
-            return switch (controlID) {
-                case ComponentProtocol.INFO ->
-                    component.infoProperty;
-                case ComponentProtocol.META ->
-                    component.metaProperty;
-                case ComponentProtocol.META_MERGE ->
-                    component.metaProperty.getMergeControl();
-                default ->
-                    null;
-            };
-        }
-
-        @Override
-        public ControlInfo controlInfo() {
-            return switch (controlID) {
-                case ComponentProtocol.INFO ->
-                    ComponentProtocol.INFO_INFO;
-                case ComponentProtocol.META ->
-                    ComponentProtocol.META_INFO;
-                case ComponentProtocol.META_MERGE ->
-                    ComponentProtocol.META_MERGE_INFO;
-                default ->
-                    null;
-            };
-        }
-
-        @Override
-        public void write(TreeWriter writer) {
-            switch (controlID) {
-                case ComponentProtocol.META -> {
-                    PMap value = component.metaProperty.getValue();
-                    if (!value.isEmpty()) {
-                        writer.writeProperty(ComponentProtocol.META, value);
-                    }
-                }
-            }
-        }
-
     }
 
     private static class LogInfo {

--- a/praxiscore-code/src/main/java/org/praxislive/code/CodeComponent.java
+++ b/praxiscore-code/src/main/java/org/praxislive/code/CodeComponent.java
@@ -40,6 +40,8 @@ import org.praxislive.core.TreeWriter;
 import org.praxislive.core.services.Services;
 import org.praxislive.core.services.LogLevel;
 import org.praxislive.core.services.LogService;
+import org.praxislive.core.services.Service;
+import org.praxislive.core.services.ServiceUnavailableException;
 
 /**
  * A CodeComponent is a Component instance that is rewritable at runtime. The
@@ -141,14 +143,6 @@ public class CodeComponent<D extends CodeDelegate> implements Component {
         codeCtxt.writeDescriptors(writer);
     }
 
-    Lookup getLookup() {
-        if (parent != null) {
-            return parent.getLookup();
-        } else {
-            return Lookup.EMPTY;
-        }
-    }
-
     void install(CodeContext<D> cc) {
         cc.setComponent(this);
         cc.handleConfigure(this, codeCtxt);
@@ -157,6 +151,21 @@ public class CodeComponent<D extends CodeDelegate> implements Component {
         }
         codeCtxt = cc;
         codeCtxt.handleHierarchyChanged();
+    }
+
+    Lookup getLookup() {
+        if (parent != null) {
+            return parent.getLookup();
+        } else {
+            return Lookup.EMPTY;
+        }
+    }
+
+    ComponentAddress findService(Class<? extends Service> service)
+            throws ServiceUnavailableException {
+        return getLookup().find(Services.class)
+                .flatMap(sm -> sm.locate(service))
+                .orElseThrow(ServiceUnavailableException::new);
     }
 
     CodeContext<D> getCodeContext() {
@@ -203,11 +212,11 @@ public class CodeComponent<D extends CodeDelegate> implements Component {
         }
         return logInfo.toAddress;
     }
-    
+
     Control infoProperty() {
         return infoProperty;
     }
-    
+
     MetaProperty metaProperty() {
         return metaProperty;
     }

--- a/praxiscore-code/src/main/java/org/praxislive/code/CodeConnector.java
+++ b/praxiscore-code/src/main/java/org/praxislive/code/CodeConnector.java
@@ -365,7 +365,11 @@ public abstract class CodeConnector<D extends CodeDelegate> {
      * @return info control descriptor
      */
     protected final ControlDescriptor createInfoControl(int index) {
-        return new CodeComponent.ControlWrapper(ComponentProtocol.INFO, index);
+        return new WrapperControlDescriptor(ComponentProtocol.INFO,
+                ComponentProtocol.INFO_INFO,
+                index,
+                context -> context.getComponent().infoProperty()
+        );
     }
 
     /**
@@ -385,7 +389,17 @@ public abstract class CodeConnector<D extends CodeDelegate> {
      * @return code control descriptor
      */
     protected final ControlDescriptor<?> createMetaControl(int index) {
-        return new CodeComponent.ControlWrapper(ComponentProtocol.META, index);
+        return new WrapperControlDescriptor(ComponentProtocol.META,
+                ComponentProtocol.META_INFO,
+                index,
+                context -> context.getComponent().metaProperty(),
+                (context, writer) -> {
+                    PMap value = context.getComponent().metaProperty().getValue();
+                    if (!value.isEmpty()) {
+                        writer.writeProperty(ComponentProtocol.META, value);
+                    }
+                }
+        );
     }
 
     /**
@@ -395,7 +409,11 @@ public abstract class CodeConnector<D extends CodeDelegate> {
      * @return code control descriptor
      */
     protected final ControlDescriptor<?> createMetaMergeControl(int index) {
-        return new CodeComponent.ControlWrapper(ComponentProtocol.META_MERGE, index);
+        return new WrapperControlDescriptor(ComponentProtocol.META_MERGE,
+                ComponentProtocol.META_MERGE_INFO,
+                index,
+                context -> context.getComponent().metaProperty().getMergeControl()
+        );
     }
 
     /**

--- a/praxiscore-code/src/main/java/org/praxislive/code/CodeContainer.java
+++ b/praxiscore-code/src/main/java/org/praxislive/code/CodeContainer.java
@@ -28,9 +28,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 import org.praxislive.base.*;
+import org.praxislive.code.CodeContainerSupport.ChildControl;
 import org.praxislive.core.Component;
 import org.praxislive.core.ComponentAddress;
 import org.praxislive.core.ComponentInfo;
+import org.praxislive.core.ComponentType;
 import org.praxislive.core.Container;
 import org.praxislive.core.Control;
 import org.praxislive.core.ControlInfo;
@@ -70,9 +72,12 @@ public class CodeContainer<D extends CodeContainerDelegate> extends CodeComponen
             = PortInfo.create(ControlPort.class, PortInfo.Direction.BIDI, PMap.EMPTY);
 
     private final ContainerImpl container;
+    private final ChildControl childControl;
     private final Map<String, PortProxy> proxies;
     private final Control proxyProperty;
+    private final FilteredTypes filteredTypes;
 
+    private Lookup lookup;
     private PMap portMap;
     private ComponentInfo baseInfo;
     private ComponentInfo info;
@@ -80,6 +85,7 @@ public class CodeContainer<D extends CodeContainerDelegate> extends CodeComponen
 
     CodeContainer() {
         container = new ContainerImpl(this);
+        childControl = new ChildControl(this, container::addChild, container::recordChildType);
         proxies = new LinkedHashMap<>();
         portMap = PMap.EMPTY;
         proxyProperty = new AbstractProperty() {
@@ -93,6 +99,10 @@ public class CodeContainer<D extends CodeContainerDelegate> extends CodeComponen
                 setPortMap(PMap.from(arg).orElseThrow(IllegalArgumentException::new));
             }
         };
+        filteredTypes = FilteredTypes.create(this,
+                t -> childControl.supportedSystemType(t),
+                () -> childControl.additionalTypes(),
+                false);
     }
 
     @Override
@@ -154,11 +164,16 @@ public class CodeContainer<D extends CodeContainerDelegate> extends CodeComponen
 
     @Override
     public Lookup getLookup() {
-        return super.getLookup();
+        if (lookup == null) {
+            lookup = Lookup.of(super.getLookup(), filteredTypes);
+        }
+        return lookup;
     }
 
     @Override
     public void hierarchyChanged() {
+        lookup = null;
+        filteredTypes.reset();
         super.hierarchyChanged();
         container.hierarchyChanged();
     }
@@ -170,6 +185,25 @@ public class CodeContainer<D extends CodeContainerDelegate> extends CodeComponen
             writer.writeProperty("ports", portMap);
         }
         container.write(writer);
+    }
+
+    @Override
+    Context<D> getCodeContext() {
+        return (Context<D>) super.getCodeContext();
+    }
+
+    @Override
+    void install(CodeContext<D> cc) {
+        if (cc instanceof Context<D> pending) {
+            if (!childControl.isCompatible(pending.typesInfo)) {
+                throw new IllegalStateException("Supported types is not compatible");
+            }
+            super.install(cc);
+            childControl.install(pending.typesInfo);
+            filteredTypes.reset();
+        } else {
+            throw new IllegalArgumentException();
+        }
     }
 
     Control getContainerControl(String id) {
@@ -299,10 +333,14 @@ public class CodeContainer<D extends CodeContainerDelegate> extends CodeComponen
     public static class Context<D extends CodeContainerDelegate> extends CodeContext<D> {
 
         private final boolean hasPortProxies;
+        private final CodeContainerSupport.TypesInfo typesInfo;
 
         public Context(CodeContainer.Connector<D> connector) {
             super(connector);
             hasPortProxies = connector.hasPortProxies;
+            typesInfo = connector.typesInfo == null
+                    ? CodeContainerSupport.defaultContainerTypesInfo()
+                    : connector.typesInfo;
         }
 
         @Override
@@ -332,6 +370,7 @@ public class CodeContainer<D extends CodeContainerDelegate> extends CodeComponen
     public static class Connector<D extends CodeContainerDelegate> extends CodeConnector<D> {
 
         private boolean hasPortProxies;
+        private CodeContainerSupport.TypesInfo typesInfo;
 
         public Connector(CodeFactory.Task<D> task, D delegate) {
             super(task, delegate);
@@ -340,8 +379,11 @@ public class CodeContainer<D extends CodeContainerDelegate> extends CodeComponen
         @Override
         protected void addDefaultControls() {
             super.addDefaultControls();
-            addControl(containerControl(ContainerProtocol.ADD_CHILD,
-                    ContainerProtocol.ADD_CHILD_INFO));
+            addControl(new WrapperControlDescriptor(
+                    ContainerProtocol.ADD_CHILD,
+                    ContainerProtocol.ADD_CHILD_INFO,
+                    getInternalIndex(),
+                    ctxt -> ctxt instanceof Context c ? c.getComponent().childControl : null));
             addControl(containerControl(ContainerProtocol.REMOVE_CHILD,
                     ContainerProtocol.REMOVE_CHILD_INFO));
             addControl(containerControl(ContainerProtocol.CHILDREN,
@@ -370,8 +412,11 @@ public class CodeContainer<D extends CodeContainerDelegate> extends CodeComponen
                 addControl(new PortProxiesControlDescriptor("ports", getInternalIndex()));
                 hasPortProxies = true;
             }
+            if (typesInfo == null) {
+                typesInfo = CodeContainerSupport.analyseMethod(method, true);
+            }
         }
-        
+
         private ControlDescriptor<?> containerControl(String id, ControlInfo info) {
             return new WrapperControlDescriptor(id, info, getInternalIndex(),
                     ctxt -> ctxt instanceof Context c ? c.getComponent().getContainerControl(id) : null
@@ -410,9 +455,18 @@ public class CodeContainer<D extends CodeContainerDelegate> extends CodeComponen
         }
 
         @Override
+        protected void recordChildType(Component child, ComponentType type) {
+            super.recordChildType(child, type);
+        }
+
+        @Override
         protected Component removeChild(String id) {
             wrapper.info = null;
-            return super.removeChild(id);
+            Component child = super.removeChild(id);
+            if (child != null) {
+                wrapper.childControl.notifyChildRemoved(id);
+            }
+            return child;
         }
 
         @Override

--- a/praxiscore-code/src/main/java/org/praxislive/code/CodeContainer.java
+++ b/praxiscore-code/src/main/java/org/praxislive/code/CodeContainer.java
@@ -340,20 +340,20 @@ public class CodeContainer<D extends CodeContainerDelegate> extends CodeComponen
         @Override
         protected void addDefaultControls() {
             super.addDefaultControls();
-            addControl(new ContainerControlDescriptor(ContainerProtocol.ADD_CHILD,
-                    ContainerProtocol.ADD_CHILD_INFO, getInternalIndex()));
-            addControl(new ContainerControlDescriptor(ContainerProtocol.REMOVE_CHILD,
-                    ContainerProtocol.REMOVE_CHILD_INFO, getInternalIndex()));
-            addControl(new ContainerControlDescriptor(ContainerProtocol.CHILDREN,
-                    ContainerProtocol.CHILDREN_INFO, getInternalIndex()));
-            addControl(new ContainerControlDescriptor(ContainerProtocol.CONNECT,
-                    ContainerProtocol.CONNECT_INFO, getInternalIndex()));
-            addControl(new ContainerControlDescriptor(ContainerProtocol.DISCONNECT,
-                    ContainerProtocol.DISCONNECT_INFO, getInternalIndex()));
-            addControl(new ContainerControlDescriptor(ContainerProtocol.CONNECTIONS,
-                    ContainerProtocol.CONNECTIONS_INFO, getInternalIndex()));
-            addControl(new ContainerControlDescriptor(ContainerProtocol.SUPPORTED_TYPES,
-                    ContainerProtocol.SUPPORTED_TYPES_INFO, getInternalIndex()));
+            addControl(containerControl(ContainerProtocol.ADD_CHILD,
+                    ContainerProtocol.ADD_CHILD_INFO));
+            addControl(containerControl(ContainerProtocol.REMOVE_CHILD,
+                    ContainerProtocol.REMOVE_CHILD_INFO));
+            addControl(containerControl(ContainerProtocol.CHILDREN,
+                    ContainerProtocol.CHILDREN_INFO));
+            addControl(containerControl(ContainerProtocol.CONNECT,
+                    ContainerProtocol.CONNECT_INFO));
+            addControl(containerControl(ContainerProtocol.DISCONNECT,
+                    ContainerProtocol.DISCONNECT_INFO));
+            addControl(containerControl(ContainerProtocol.CONNECTIONS,
+                    ContainerProtocol.CONNECTIONS_INFO));
+            addControl(containerControl(ContainerProtocol.SUPPORTED_TYPES,
+                    ContainerProtocol.SUPPORTED_TYPES_INFO));
         }
 
         @Override
@@ -370,6 +370,12 @@ public class CodeContainer<D extends CodeContainerDelegate> extends CodeComponen
                 addControl(new PortProxiesControlDescriptor("ports", getInternalIndex()));
                 hasPortProxies = true;
             }
+        }
+        
+        private ControlDescriptor<?> containerControl(String id, ControlInfo info) {
+            return new WrapperControlDescriptor(id, info, getInternalIndex(),
+                    ctxt -> ctxt instanceof Context c ? c.getComponent().getContainerControl(id) : null
+            );
         }
 
     }
@@ -418,35 +424,6 @@ public class CodeContainer<D extends CodeContainerDelegate> extends CodeComponen
         public void write(TreeWriter writer) {
             writeChildren(writer);
             writeConnections(writer);
-        }
-
-    }
-
-    private static class ContainerControlDescriptor
-            extends ControlDescriptor<ContainerControlDescriptor> {
-
-        private final ControlInfo info;
-
-        private Control control;
-
-        ContainerControlDescriptor(String id, ControlInfo info, int index) {
-            super(ContainerControlDescriptor.class, id, Category.Internal, index);
-            this.info = info;
-        }
-
-        @Override
-        public void attach(CodeContext<?> context, ContainerControlDescriptor previous) {
-            control = ((CodeContainer) context.getComponent()).getContainerControl(id());
-        }
-
-        @Override
-        public Control control() {
-            return control;
-        }
-
-        @Override
-        public ControlInfo controlInfo() {
-            return info;
         }
 
     }

--- a/praxiscore-code/src/main/java/org/praxislive/code/CodeContainerDelegate.java
+++ b/praxiscore-code/src/main/java/org/praxislive/code/CodeContainerDelegate.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright 2022 Neil C Smith.
+ * Copyright 2024 Neil C Smith.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3 only, as
@@ -30,7 +30,7 @@ import java.util.stream.Stream;
 /**
  * Base class for user rewritable container code.
  */
-public class CodeContainerDelegate extends CodeDelegate {
+public class CodeContainerDelegate extends CodeDelegate implements ContainerDelegateAPI {
 
     public void init() {
     }

--- a/praxiscore-code/src/main/java/org/praxislive/code/CodeContainerSupport.java
+++ b/praxiscore-code/src/main/java/org/praxislive/code/CodeContainerSupport.java
@@ -1,0 +1,309 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright 2024 Neil C Smith.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License version 3 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * version 3 for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License version 3
+ * along with this work; if not, see http://www.gnu.org/licenses/
+ *
+ *
+ * Please visit https://www.praxislive.org if you need additional information or
+ * have any questions.
+ */
+package org.praxislive.code;
+
+import java.lang.reflect.Method;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
+import org.praxislive.base.AbstractAsyncControl;
+import org.praxislive.core.Call;
+import org.praxislive.core.Component;
+import org.praxislive.core.ComponentAddress;
+import org.praxislive.core.ComponentType;
+import org.praxislive.core.Control;
+import org.praxislive.core.ControlAddress;
+import org.praxislive.core.OrderedMap;
+import org.praxislive.core.Value;
+import org.praxislive.core.VetoException;
+import org.praxislive.core.services.ComponentFactoryService;
+import org.praxislive.core.types.PReference;
+
+/**
+ *
+ */
+final class CodeContainerSupport {
+
+    private CodeContainerSupport() {
+    }
+
+    static Predicate<ComponentType> globTypeFilter(String glob) {
+        StringBuilder regex = new StringBuilder();
+        for (char c : glob.toCharArray()) {
+            switch (c) {
+                case '*' ->
+                    regex.append(".*");
+                case '?' ->
+                    regex.append('.');
+                case '|' ->
+                    regex.append('|');
+                case '_' ->
+                    regex.append('_');
+                case '-' ->
+                    regex.append("\\-");
+                case ':' ->
+                    regex.append(':');
+                default -> {
+                    if (Character.isJavaIdentifierPart(c)) {
+                        regex.append(c);
+                    } else {
+                        throw new IllegalArgumentException();
+                    }
+                }
+            }
+        }
+        Pattern pattern = Pattern.compile(regex.toString());
+        return type -> pattern.matcher(type.toString()).matches();
+    }
+
+    static TypesInfo defaultRootTypesInfo() {
+        return TypesInfo.DEFAULT_ROOT_INFO;
+    }
+
+    static TypesInfo defaultContainerTypesInfo() {
+        return TypesInfo.DEFAULT_CONTAINER_INFO;
+    }
+
+    static TypesInfo analyseMethod(Method method, boolean isRoot) {
+        var typesInfoAnn = method.getAnnotation(ContainerDelegateAPI.SupportedTypes.class);
+        if (typesInfoAnn != null) {
+            String filter = typesInfoAnn.filter();
+            if (isRoot && filter.isBlank()) {
+                filter = "core:*";
+            }
+            boolean system = typesInfoAnn.system();
+            OrderedMap<ComponentType, Class<? extends CodeDelegate>> custom;
+            if (typesInfoAnn.custom().length == 0) {
+                custom = OrderedMap.of();
+            } else {
+                Map<ComponentType, Class<? extends CodeDelegate>> customMap
+                        = new LinkedHashMap<>();
+                for (var customAnn : typesInfoAnn.custom()) {
+                    customMap.put(ComponentType.of(customAnn.type()), customAnn.base());
+                }
+                custom = OrderedMap.copyOf(customMap);
+            }
+            return new TypesInfo(filter, system, custom);
+        }
+        return null;
+    }
+
+    static final class TypesInfo {
+
+        private static final TypesInfo DEFAULT_ROOT_INFO = new TypesInfo("core:*", true, OrderedMap.of());
+        private static final TypesInfo DEFAULT_CONTAINER_INFO = new TypesInfo("", true, OrderedMap.of());
+
+        private final String filterDefinition;
+        private final Predicate<ComponentType> filter;
+        private final boolean includeSystem;
+        private final OrderedMap<ComponentType, Class<? extends CodeDelegate>> customTypes;
+
+        private TypesInfo(String filterDefinition,
+                boolean includeSystem,
+                OrderedMap<ComponentType, Class<? extends CodeDelegate>> customTypes) {
+            this.filterDefinition = filterDefinition.strip();
+            this.filter = filterDefinition.isBlank() || "*".equals(this.filterDefinition)
+                    ? t -> true : globTypeFilter(filterDefinition);
+            this.includeSystem = includeSystem;
+            this.customTypes = customTypes;
+        }
+
+        String filterDefinition() {
+            return filterDefinition;
+        }
+
+        Predicate<ComponentType> filter() {
+            return filter;
+        }
+
+        OrderedMap<ComponentType, Class<? extends CodeDelegate>> customTypes() {
+            return customTypes;
+        }
+
+        boolean includeSystem() {
+            return includeSystem;
+        }
+
+    }
+
+    static final class ChildControl extends AbstractAsyncControl {
+
+        private final CodeComponent<?> component;
+        private final AddChildLink childLink;
+        private final RecordChildTypeLink recordLink;
+        private final LinkedHashMap<String, ComponentType> customChildren;
+
+        private TypesInfo typesInfo;
+
+        ChildControl(CodeComponent<?> component,
+                AddChildLink childLink,
+                RecordChildTypeLink recordLink) {
+            this.component = Objects.requireNonNull(component);
+            this.childLink = Objects.requireNonNull(childLink);
+            this.recordLink = Objects.requireNonNull(recordLink);
+            this.customChildren = new LinkedHashMap<>();
+            typesInfo = defaultContainerTypesInfo();
+        }
+
+        @Override
+        protected Call processInvoke(Call call) throws Exception {
+            List<Value> args = call.args();
+            if (args.size() < 2) {
+                throw new IllegalArgumentException("Invalid arguments");
+            }
+            String id = args.get(0).toString();
+            if (!ComponentAddress.isValidID(id)) {
+                throw new IllegalArgumentException("Invalid Component ID");
+            }
+            ComponentType type = ComponentType.from(args.get(1))
+                    .orElseThrow(() -> new IllegalArgumentException("Invalid component type"));
+            if (typesInfo.customTypes().containsKey(type)) {
+                Class<? extends CodeDelegate> baseDelegate = typesInfo.customTypes().get(type);
+                ControlAddress to = ControlAddress.of(
+                        component.findService(CodeChildFactoryService.class),
+                        CodeChildFactoryService.NEW_CHILD_INSTANCE
+                );
+                CodeChildFactoryService.Task task
+                        = new CodeChildFactoryService.Task(type, baseDelegate,
+                                component.getCodeContext().getLogLevel());
+                customChildren.put(id, type);
+                return Call.create(to, call.to(), call.time(), PReference.of(task));
+            } else {
+                ControlAddress to = ControlAddress.of(
+                        component.findService(ComponentFactoryService.class),
+                        ComponentFactoryService.NEW_INSTANCE);
+                return Call.create(to, call.to(), call.time(), args.get(1));
+            }
+
+        }
+
+        @Override
+        protected Call processResponse(Call call) throws Exception {
+            List<Value> args = call.args();
+            if (args.size() < 1) {
+                throw new IllegalArgumentException("Invalid response");
+            }
+            Component child;
+            boolean checkShared = false;
+            if (CodeChildFactoryService.NEW_CHILD_INSTANCE.equals(call.from().controlID())) {
+                CodeChildFactoryService.Result result = PReference.from(args.get(0))
+                        .flatMap(r -> r.as(CodeChildFactoryService.Result.class))
+                        .orElseThrow();
+                if (!result.log().isEmpty()) {
+                    component.getCodeContext().log(result.log());
+                }
+                child = result.component();
+                checkShared = true;
+            } else {
+                child = PReference.from(args.get(0))
+                        .flatMap(r -> r.as(Component.class))
+                        .orElseThrow();
+            }
+            Call active = getActiveCall();
+            String id = active.args().get(0).toString();
+            ComponentType type = ComponentType.from(active.args().get(1)).orElse(null);
+            childLink.addChild(id, child);
+            recordLink.recordChildType(child, type);
+            if (checkShared && child instanceof CodeComponent<?> cc) {
+                checkAndRegisterShared(cc);
+            }
+            return active.reply();
+        }
+
+        @Override
+        protected Call processError(Call call) throws Exception {
+            if (CodeChildFactoryService.NEW_CHILD_INSTANCE.equals(call.from().controlID())) {
+                ComponentType.from(getActiveCall().args().get(1))
+                        .ifPresent(customChildren::remove);
+            }
+            return super.processError(call);
+        }
+
+        void notifyChildRemoved(String child) {
+            customChildren.remove(child);
+        }
+
+        void install(TypesInfo typesInfo) {
+            this.typesInfo = typesInfo;
+        }
+
+        boolean isCompatible(TypesInfo typesInfo) {
+            if (customChildren.isEmpty()) {
+                return true;
+            }
+            var currentCustomTypes = this.typesInfo.customTypes();
+            var proposedCustomTypes = typesInfo.customTypes();
+
+            Set<ComponentType> removedOrChanged = new HashSet<>();
+            currentCustomTypes.forEach((type, cls) -> {
+                var proposedCls = proposedCustomTypes.get(type);
+                if (proposedCls == null || !cls.getName().equals(proposedCls.getName())) {
+                    removedOrChanged.add(type);
+                }
+            });
+            for (ComponentType type : removedOrChanged) {
+                if (customChildren.values().contains(type)) {
+                    return false;
+                }
+            }
+            return true;
+
+        }
+
+        boolean supportedSystemType(ComponentType type) {
+            return typesInfo.includeSystem() && typesInfo.filter().test(type);
+        }
+
+        List<ComponentType> additionalTypes() {
+            return typesInfo.customTypes.keys();
+        }
+
+        void checkAndRegisterShared(CodeComponent<?> child) {
+            Control control = child.getControl("code");
+            if (control instanceof CodeProperty<?> code) {
+                ControlAddress ad = ControlAddress.of(child.getAddress(), "code");
+                code.checkSharedContext(ad);
+            }
+        }
+
+    }
+
+    @FunctionalInterface
+    static interface AddChildLink {
+
+        void addChild(String id, Component child) throws VetoException;
+
+    }
+
+    @FunctionalInterface
+    static interface RecordChildTypeLink {
+
+        void recordChildType(Component child, ComponentType type);
+
+    }
+
+}

--- a/praxiscore-code/src/main/java/org/praxislive/code/CodeProperty.java
+++ b/praxiscore-code/src/main/java/org/praxislive/code/CodeProperty.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright 2023 Neil C Smith.
+ * Copyright 2024 Neil C Smith.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3 only, as
@@ -183,6 +183,10 @@ class CodeProperty<D extends CodeDelegate>
     void installContext(ControlAddress address, CodeContext<?> context) {
         this.context.getComponent().install((CodeContext<D>) context);
         // shared code context is now null!
+        checkSharedContext(address);
+    }
+
+    void checkSharedContext(ControlAddress address) {
         sharedCodeCtxt = context.getLookup().find(SharedCodeContext.class).orElse(null);
         if (sharedCodeCtxt != null) {
             sharedCodeCtxt.checkDependency(address, this);
@@ -190,8 +194,11 @@ class CodeProperty<D extends CodeDelegate>
     }
 
     SharedCodeService.DependentTask<D> createSharedCodeReloadTask() {
-        return new SharedCodeService.DependentTask<>(factory,
-                sourceArgs.get(0).toString(), getDelegateClass());
+        String code = sourceArgs.get(0).toString();
+        if (code.isEmpty()) {
+            code = factory.sourceTemplate();
+        }
+        return new SharedCodeService.DependentTask<>(factory, code, getDelegateClass());
     }
 
     static class Descriptor extends ControlDescriptor<CodeProperty.Descriptor> {

--- a/praxiscore-code/src/main/java/org/praxislive/code/CodeRoot.java
+++ b/praxiscore-code/src/main/java/org/praxislive/code/CodeRoot.java
@@ -149,10 +149,9 @@ public class CodeRoot<D extends CodeRootDelegate> extends CodeComponent<D> imple
 
     @Override
     void install(CodeContext<D> cc) {
-        if (cc instanceof Context) {
+        if (cc instanceof Context<D> pending) {
             if (root.isRunning()) {
-                Context<?> existing = (Context<?>) getCodeContext();
-                Context<?> pending = (Context<?>) cc;
+                Context<D> existing = getCodeContext();
                 boolean compatible = (existing.driverDesc == null && pending.driverDesc == null)
                         || (existing.driverDesc != null && pending.driverDesc != null
                         && existing.driverDesc.isCompatible(pending.driverDesc));
@@ -315,7 +314,7 @@ public class CodeRoot<D extends CodeRootDelegate> extends CodeComponent<D> imple
 
             return true;
         }
-        
+
         private ControlDescriptor<?> sharedCodeControl() {
             return new WrapperControlDescriptor(SHARED_CODE,
                     SharedCodeProperty.INFO,
@@ -331,7 +330,7 @@ public class CodeRoot<D extends CodeRootDelegate> extends CodeComponent<D> imple
                     }
             );
         }
-        
+
     }
 
     private static class RootImpl extends AbstractRoot {

--- a/praxiscore-code/src/main/java/org/praxislive/code/CodeRoot.java
+++ b/praxiscore-code/src/main/java/org/praxislive/code/CodeRoot.java
@@ -32,14 +32,11 @@ import org.praxislive.core.ComponentAddress;
 import org.praxislive.core.Container;
 import org.praxislive.core.Control;
 import org.praxislive.core.ControlAddress;
-import org.praxislive.core.ControlInfo;
 import org.praxislive.core.Info;
 import org.praxislive.core.Lookup;
 import org.praxislive.core.PacketRouter;
 import org.praxislive.core.Root;
 import org.praxislive.core.RootHub;
-import org.praxislive.core.TreeWriter;
-import org.praxislive.core.Value;
 import org.praxislive.core.VetoException;
 import org.praxislive.core.protocols.SerializableProtocol;
 import org.praxislive.core.protocols.StartableProtocol;
@@ -255,13 +252,29 @@ public class CodeRoot<D extends CodeRootDelegate> extends CodeComponent<D> imple
             addControl(createInfoControl(getInternalIndex()));
             addControl(createMetaControl(getInternalIndex()));
             addControl(createMetaMergeControl(getInternalIndex()));
-            addControl(new RootControlDescriptor(SHARED_CODE, getInternalIndex()));
+            addControl(sharedCodeControl());
             addControl(createCodeControl(getInternalIndex()));
             addControl(new ResponseHandler(getInternalIndex()));
-            addControl(new RootControlDescriptor(StartableProtocol.START, getInternalIndex()));
-            addControl(new RootControlDescriptor(StartableProtocol.STOP, getInternalIndex()));
-            addControl(new RootControlDescriptor(StartableProtocol.IS_RUNNING, getInternalIndex()));
-            addControl(new RootControlDescriptor(SerializableProtocol.SERIALIZE, getInternalIndex()));
+            addControl(new WrapperControlDescriptor(StartableProtocol.START,
+                    StartableProtocol.START_INFO,
+                    getInternalIndex(),
+                    ctxt -> ctxt instanceof Context c ? c.getComponent().startControl : null
+            ));
+            addControl(new WrapperControlDescriptor(StartableProtocol.STOP,
+                    StartableProtocol.STOP_INFO,
+                    getInternalIndex(),
+                    ctxt -> ctxt instanceof Context c ? c.getComponent().stopControl : null
+            ));
+            addControl(new WrapperControlDescriptor(StartableProtocol.IS_RUNNING,
+                    StartableProtocol.IS_RUNNING_INFO,
+                    getInternalIndex(),
+                    ctxt -> ctxt instanceof Context c ? c.getComponent().isRunningControl : null
+            ));
+            addControl(new WrapperControlDescriptor(SerializableProtocol.SERIALIZE,
+                    SerializableProtocol.SERIALIZE_INFO,
+                    getInternalIndex(),
+                    ctxt -> ctxt instanceof Context c ? c.getComponent().serializeControl : null
+            ));
         }
 
         @Override
@@ -302,7 +315,23 @@ public class CodeRoot<D extends CodeRootDelegate> extends CodeComponent<D> imple
 
             return true;
         }
-
+        
+        private ControlDescriptor<?> sharedCodeControl() {
+            return new WrapperControlDescriptor(SHARED_CODE,
+                    SharedCodeProperty.INFO,
+                    getInternalIndex(),
+                    ctxt -> ctxt instanceof Context c ? c.getComponent().sharedCode : null,
+                    (ctxt, writer) -> {
+                        if (ctxt instanceof Context c) {
+                            PMap value = c.getComponent().sharedCode.getValue();
+                            if (!value.isEmpty()) {
+                                writer.writeProperty(SHARED_CODE, value);
+                            }
+                        }
+                    }
+            );
+        }
+        
     }
 
     private static class RootImpl extends AbstractRoot {
@@ -367,71 +396,6 @@ public class CodeRoot<D extends CodeRootDelegate> extends CodeComponent<D> imple
                 doUpdate(time);
             }
 
-        }
-
-    }
-
-    private static class RootControlDescriptor
-            extends ControlDescriptor<RootControlDescriptor> {
-
-        private final String controlID;
-
-        private CodeRoot<?> root;
-
-        private RootControlDescriptor(String controlID, int index) {
-            super(RootControlDescriptor.class, controlID, Category.Internal, index);
-            this.controlID = controlID;
-        }
-
-        @Override
-        public void attach(CodeContext<?> context, RootControlDescriptor previous) {
-            root = (CodeRoot<?>) context.getComponent();
-        }
-
-        @Override
-        public Control control() {
-            return switch (controlID) {
-                case StartableProtocol.START ->
-                    root.startControl;
-                case StartableProtocol.STOP ->
-                    root.stopControl;
-                case StartableProtocol.IS_RUNNING ->
-                    root.isRunningControl;
-                case SerializableProtocol.SERIALIZE ->
-                    root.serializeControl;
-                case SHARED_CODE ->
-                    root.sharedCode;
-                default ->
-                    null;
-            };
-        }
-
-        @Override
-        public ControlInfo controlInfo() {
-            return switch (controlID) {
-                case StartableProtocol.START ->
-                    StartableProtocol.START_INFO;
-                case StartableProtocol.STOP ->
-                    StartableProtocol.STOP_INFO;
-                case StartableProtocol.IS_RUNNING ->
-                    StartableProtocol.IS_RUNNING_INFO;
-                case SerializableProtocol.SERIALIZE ->
-                    SerializableProtocol.SERIALIZE_INFO;
-                case SHARED_CODE ->
-                    SharedCodeProperty.INFO;
-                default ->
-                    null;
-            };
-        }
-
-        @Override
-        public void write(TreeWriter writer) {
-            if (SHARED_CODE.equals(id())) {
-                Value v = root.sharedCode.getValue();
-                if (!v.isEmpty()) {
-                    writer.writeProperty(SHARED_CODE, v);
-                }
-            }
         }
 
     }

--- a/praxiscore-code/src/main/java/org/praxislive/code/CodeRootContainer.java
+++ b/praxiscore-code/src/main/java/org/praxislive/code/CodeRootContainer.java
@@ -21,14 +21,17 @@
  */
 package org.praxislive.code;
 
+import java.lang.reflect.Method;
 import java.util.Optional;
 import java.util.stream.Stream;
 import org.praxislive.base.AbstractContainer;
 import org.praxislive.base.FilteredTypes;
 import org.praxislive.base.MapTreeWriter;
+import org.praxislive.code.CodeContainerSupport.ChildControl;
 import org.praxislive.core.Component;
 import org.praxislive.core.ComponentAddress;
 import org.praxislive.core.ComponentInfo;
+import org.praxislive.core.ComponentType;
 import org.praxislive.core.Container;
 import org.praxislive.core.Control;
 import org.praxislive.core.ControlAddress;
@@ -54,6 +57,7 @@ public class CodeRootContainer<D extends CodeRootContainerDelegate> extends Code
         implements Container {
 
     private final ContainerImpl container;
+    private final ChildControl childControl;
     private final FilteredTypes filteredTypes;
 
     private Lookup lookup;
@@ -61,7 +65,10 @@ public class CodeRootContainer<D extends CodeRootContainerDelegate> extends Code
 
     CodeRootContainer() {
         container = new ContainerImpl(this);
-        filteredTypes = FilteredTypes.create(this, type -> type.toString().startsWith("core:"));
+        childControl = new ChildControl(this, container::addChild, container::recordChildType);
+        filteredTypes = FilteredTypes.create(this,
+                t -> childControl.supportedSystemType(t),
+                () -> childControl.additionalTypes());
     }
 
     @Override
@@ -99,6 +106,25 @@ public class CodeRootContainer<D extends CodeRootContainerDelegate> extends Code
     public void write(TreeWriter writer) {
         super.write(writer);
         container.write(writer);
+    }
+
+    @Override
+    Context<D> getCodeContext() {
+        return (Context<D>) super.getCodeContext();
+    }
+
+    @Override
+    void install(CodeContext<D> cc) {
+        if (cc instanceof Context<D> pending) {
+            if (!childControl.isCompatible(pending.typesInfo)) {
+                throw new IllegalStateException("Supported types is not compatible");
+            }
+            super.install(cc);
+            childControl.install(pending.typesInfo);
+            filteredTypes.reset();
+        } else {
+            throw new IllegalArgumentException();
+        }
     }
 
     Control getContainerControl(String id) {
@@ -163,8 +189,13 @@ public class CodeRootContainer<D extends CodeRootContainerDelegate> extends Code
      */
     public static class Context<D extends CodeRootContainerDelegate> extends CodeRoot.Context<D> {
 
+        private final CodeContainerSupport.TypesInfo typesInfo;
+
         public Context(Connector<D> connector) {
             super(connector);
+            typesInfo = connector.typesInfo == null
+                    ? CodeContainerSupport.defaultRootTypesInfo()
+                    : connector.typesInfo;
         }
 
         @Override
@@ -190,6 +221,8 @@ public class CodeRootContainer<D extends CodeRootContainerDelegate> extends Code
      */
     public static class Connector<D extends CodeRootContainerDelegate> extends CodeRoot.Connector<D> {
 
+        private CodeContainerSupport.TypesInfo typesInfo;
+
         public Connector(CodeFactory.Task<D> task, D delegate) {
             super(task, delegate);
         }
@@ -197,8 +230,11 @@ public class CodeRootContainer<D extends CodeRootContainerDelegate> extends Code
         @Override
         protected void addDefaultControls() {
             super.addDefaultControls();
-            addControl(containerControl(ContainerProtocol.ADD_CHILD,
-                    ContainerProtocol.ADD_CHILD_INFO));
+            addControl(new WrapperControlDescriptor(
+                    ContainerProtocol.ADD_CHILD,
+                    ContainerProtocol.ADD_CHILD_INFO,
+                    getInternalIndex(),
+                    ctxt -> ctxt instanceof Context c ? c.getComponent().childControl : null));
             addControl(containerControl(ContainerProtocol.REMOVE_CHILD,
                     ContainerProtocol.REMOVE_CHILD_INFO));
             addControl(containerControl(ContainerProtocol.CHILDREN,
@@ -214,11 +250,19 @@ public class CodeRootContainer<D extends CodeRootContainerDelegate> extends Code
         }
 
         @Override
+        protected void analyseMethod(Method method) {
+            super.analyseMethod(method);
+            if (typesInfo == null) {
+                typesInfo = CodeContainerSupport.analyseMethod(method, true);
+            }
+        }
+
+        @Override
         protected void buildBaseComponentInfo(Info.ComponentInfoBuilder cmp) {
             super.buildBaseComponentInfo(cmp);
             cmp.merge(ContainerProtocol.API_INFO);
         }
-        
+
         private ControlDescriptor containerControl(String id, ControlInfo info) {
             return new WrapperControlDescriptor(id, info, getInternalIndex(),
                     ctxt -> ctxt instanceof Context c ? c.getComponent().getContainerControl(id) : null
@@ -248,6 +292,25 @@ public class CodeRootContainer<D extends CodeRootContainerDelegate> extends Code
         @Override
         protected ComponentAddress getAddress() {
             return wrapper.getAddress();
+        }
+
+        @Override
+        protected void addChild(String id, Component child) throws VetoException {
+            super.addChild(id, child);
+        }
+
+        @Override
+        protected void recordChildType(Component child, ComponentType type) {
+            super.recordChildType(child, type);
+        }
+
+        @Override
+        protected Component removeChild(String id) {
+            Component child = super.removeChild(id);
+            if (child != null) {
+                wrapper.childControl.notifyChildRemoved(id);
+            }
+            return child;
         }
 
         @Override

--- a/praxiscore-code/src/main/java/org/praxislive/code/CodeRootContainer.java
+++ b/praxiscore-code/src/main/java/org/praxislive/code/CodeRootContainer.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright 2023 Neil C Smith.
+ * Copyright 2024 Neil C Smith.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3 only, as
@@ -197,26 +197,32 @@ public class CodeRootContainer<D extends CodeRootContainerDelegate> extends Code
         @Override
         protected void addDefaultControls() {
             super.addDefaultControls();
-            addControl(new ContainerControlDescriptor(ContainerProtocol.ADD_CHILD,
-                    ContainerProtocol.ADD_CHILD_INFO, getInternalIndex()));
-            addControl(new ContainerControlDescriptor(ContainerProtocol.REMOVE_CHILD,
-                    ContainerProtocol.REMOVE_CHILD_INFO, getInternalIndex()));
-            addControl(new ContainerControlDescriptor(ContainerProtocol.CHILDREN,
-                    ContainerProtocol.CHILDREN_INFO, getInternalIndex()));
-            addControl(new ContainerControlDescriptor(ContainerProtocol.CONNECT,
-                    ContainerProtocol.CONNECT_INFO, getInternalIndex()));
-            addControl(new ContainerControlDescriptor(ContainerProtocol.DISCONNECT,
-                    ContainerProtocol.DISCONNECT_INFO, getInternalIndex()));
-            addControl(new ContainerControlDescriptor(ContainerProtocol.CONNECTIONS,
-                    ContainerProtocol.CONNECTIONS_INFO, getInternalIndex()));
-            addControl(new ContainerControlDescriptor(ContainerProtocol.SUPPORTED_TYPES,
-                    ContainerProtocol.SUPPORTED_TYPES_INFO, getInternalIndex()));
+            addControl(containerControl(ContainerProtocol.ADD_CHILD,
+                    ContainerProtocol.ADD_CHILD_INFO));
+            addControl(containerControl(ContainerProtocol.REMOVE_CHILD,
+                    ContainerProtocol.REMOVE_CHILD_INFO));
+            addControl(containerControl(ContainerProtocol.CHILDREN,
+                    ContainerProtocol.CHILDREN_INFO));
+            addControl(containerControl(ContainerProtocol.CONNECT,
+                    ContainerProtocol.CONNECT_INFO));
+            addControl(containerControl(ContainerProtocol.DISCONNECT,
+                    ContainerProtocol.DISCONNECT_INFO));
+            addControl(containerControl(ContainerProtocol.CONNECTIONS,
+                    ContainerProtocol.CONNECTIONS_INFO));
+            addControl(containerControl(ContainerProtocol.SUPPORTED_TYPES,
+                    ContainerProtocol.SUPPORTED_TYPES_INFO));
         }
 
         @Override
         protected void buildBaseComponentInfo(Info.ComponentInfoBuilder cmp) {
             super.buildBaseComponentInfo(cmp);
             cmp.merge(ContainerProtocol.API_INFO);
+        }
+        
+        private ControlDescriptor containerControl(String id, ControlInfo info) {
+            return new WrapperControlDescriptor(id, info, getInternalIndex(),
+                    ctxt -> ctxt instanceof Context c ? c.getComponent().getContainerControl(id) : null
+            );
         }
 
     }
@@ -247,36 +253,6 @@ public class CodeRootContainer<D extends CodeRootContainerDelegate> extends Code
         @Override
         protected void notifyChild(Component child) throws VetoException {
             child.parentNotify(wrapper);
-        }
-
-    }
-
-    private static class ContainerControlDescriptor
-            extends ControlDescriptor<ContainerControlDescriptor> {
-
-        private final ControlInfo info;
-
-        private Control control;
-
-        ContainerControlDescriptor(String id, ControlInfo info, int index) {
-            super(ContainerControlDescriptor.class, id, ControlDescriptor.Category.Internal, index);
-            this.info = info;
-        }
-
-        @Override
-        public void attach(CodeContext<?> context, ContainerControlDescriptor previous) {
-            control = ((CodeRootContainer<?>) context.getComponent())
-                    .getContainerControl(id());
-        }
-
-        @Override
-        public Control control() {
-            return control;
-        }
-
-        @Override
-        public ControlInfo controlInfo() {
-            return info;
         }
 
     }

--- a/praxiscore-code/src/main/java/org/praxislive/code/CodeRootContainerDelegate.java
+++ b/praxiscore-code/src/main/java/org/praxislive/code/CodeRootContainerDelegate.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright 2023 Neil C Smith.
+ * Copyright 2024 Neil C Smith.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3 only, as
@@ -26,7 +26,7 @@ import java.util.stream.Stream;
 /**
  * Base class for user rewritable Root container code.
  */
-public class CodeRootContainerDelegate extends CodeRootDelegate {
+public class CodeRootContainerDelegate extends CodeRootDelegate implements ContainerDelegateAPI {
 
     @Override
     public void init() {
@@ -45,5 +45,5 @@ public class CodeRootContainerDelegate extends CodeRootDelegate {
             return Stream.empty();
         }
     }
-    
+
 }

--- a/praxiscore-code/src/main/java/org/praxislive/code/CodeRootContainerDelegate.java
+++ b/praxiscore-code/src/main/java/org/praxislive/code/CodeRootContainerDelegate.java
@@ -21,6 +21,10 @@
  */
 package org.praxislive.code;
 
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 import java.util.stream.Stream;
 
 /**
@@ -44,6 +48,23 @@ public class CodeRootContainerDelegate extends CodeRootDelegate implements Conta
         } else {
             return Stream.empty();
         }
+    }
+
+    /**
+     * Annotation to add hint to display the component and its children in a
+     * table when editing.
+     */
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.METHOD)
+    public @interface DisplayTable {
+
+        /**
+         * Array of properties to display as table columns.
+         *
+         * @return property columns
+         */
+        String[] properties();
+
     }
 
 }

--- a/praxiscore-code/src/main/java/org/praxislive/code/ContainerDelegateAPI.java
+++ b/praxiscore-code/src/main/java/org/praxislive/code/ContainerDelegateAPI.java
@@ -1,0 +1,94 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright 2024 Neil C Smith.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License version 3 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * version 3 for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License version 3
+ * along with this work; if not, see http://www.gnu.org/licenses/
+ *
+ *
+ * Please visit https://www.praxislive.org if you need additional information or
+ * have any questions.
+ */
+package org.praxislive.code;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.praxislive.core.ComponentType;
+
+/**
+ * Shared APIs for code root containers and code containers.
+ */
+public interface ContainerDelegateAPI {
+
+    /**
+     * Annotation to filter available child types and register custom child
+     * types.
+     */
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.METHOD)
+    public @interface SupportedTypes {
+
+        /**
+         * Filter to apply to available types. The filter is a glob style String
+         * pattern supporting wildcards - eg.
+         * {@code core:container|core:math:*}.
+         * <p>
+         * If {@link #system()} is {@code false} then this filter had no effect.
+         *
+         * @return type filter
+         */
+        String filter() default "";
+
+        /**
+         * Whether to include system registered component types.
+         *
+         * @return include system registered types
+         */
+        boolean system() default true;
+
+        /**
+         * Registered custom component types.
+         *
+         * @return custom types
+         */
+        CustomType[] custom() default {};
+
+    }
+
+    /**
+     * Register a custom component type. The type must be a valid String
+     * representation of a {@link ComponentType}. The base must be a suitable
+     * {@link CodeDelegate} subclass. The base may be included in shared code.
+     */
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface CustomType {
+
+        /**
+         * Component type as String. The value must be a valid representation of
+         * a {@link ComponentType}.
+         *
+         * @return component type
+         */
+        String type();
+
+        /**
+         * The base code delegate. The base may be included in shared code.
+         *
+         * @return base delegate
+         */
+        Class<? extends CodeDelegate> base();
+    }
+
+}

--- a/praxiscore-code/src/main/java/org/praxislive/code/WrapperControlDescriptor.java
+++ b/praxiscore-code/src/main/java/org/praxislive/code/WrapperControlDescriptor.java
@@ -1,0 +1,84 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright 2024 Neil C Smith.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License version 3 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * version 3 for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License version 3
+ * along with this work; if not, see http://www.gnu.org/licenses/
+ *
+ *
+ * Please visit https://www.praxislive.org if you need additional information or
+ * have any questions.
+ */
+package org.praxislive.code;
+
+import java.util.Objects;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+import org.praxislive.core.Control;
+import org.praxislive.core.ControlInfo;
+import org.praxislive.core.TreeWriter;
+
+/**
+ *
+ */
+final class WrapperControlDescriptor extends ControlDescriptor<WrapperControlDescriptor> {
+
+    private final Function<CodeContext<?>, Control> attacher;
+    private final BiConsumer<CodeContext<?>, TreeWriter> writer;
+    private final ControlInfo info;
+
+    private CodeContext<?> context;
+    private Control control;
+
+    WrapperControlDescriptor(String id,
+            ControlInfo info,
+            int index,
+            Function<CodeContext<?>, Control> attacher) {
+        this(id, info, index, attacher, null);
+    }
+    
+    WrapperControlDescriptor(String id,
+            ControlInfo info,
+            int index,
+            Function<CodeContext<?>, Control> attacher,
+            BiConsumer<CodeContext<?>, TreeWriter> writer) {
+        super(WrapperControlDescriptor.class, id, Category.Internal, index);
+        this.info = Objects.requireNonNull(info);
+        this.attacher = Objects.requireNonNull(attacher);
+        this.writer = writer;
+    }
+
+    @Override
+    public void attach(CodeContext<?> context, WrapperControlDescriptor previous) {
+        this.context = context;
+        this.control = attacher.apply(context);
+    }
+
+    @Override
+    public Control control() {
+        return control;
+    }
+
+    @Override
+    public ControlInfo controlInfo() {
+        return info;
+    }
+
+    @Override
+    public void write(TreeWriter treewriter) {
+        if (writer != null) {
+            writer.accept(context, treewriter);
+        }
+    }
+
+}

--- a/praxiscore-code/src/main/java/org/praxislive/code/internal/CodeProtocolsProvider.java
+++ b/praxiscore-code/src/main/java/org/praxislive/code/internal/CodeProtocolsProvider.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright 2023 Neil C Smith.
+ * Copyright 2024 Neil C Smith.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3 only, as
@@ -22,6 +22,7 @@
 package org.praxislive.code.internal;
 
 import java.util.stream.Stream;
+import org.praxislive.code.CodeChildFactoryService;
 import org.praxislive.code.CodeCompilerService;
 import org.praxislive.code.CodeComponentFactoryService;
 import org.praxislive.code.CodeContextFactoryService;
@@ -31,19 +32,20 @@ import org.praxislive.core.Protocol;
 
 /**
  *
- * 
+ *
  */
 public class CodeProtocolsProvider implements Protocol.TypeProvider {
 
     @Override
     public Stream<Protocol.Type> types() {
         return Stream.of(
+                new Protocol.Type<>(CodeChildFactoryService.class),
                 new Protocol.Type<>(CodeCompilerService.class),
                 new Protocol.Type<>(CodeComponentFactoryService.class),
-                new Protocol.Type<>(CodeRootFactoryService.class),
                 new Protocol.Type<>(CodeContextFactoryService.class),
+                new Protocol.Type<>(CodeRootFactoryService.class),
                 new Protocol.Type<>(SharedCodeService.class)
         );
     }
-    
+
 }

--- a/testsuite/tests/config
+++ b/testsuite/tests/config
@@ -8,3 +8,4 @@ core/async-functions
 core/code-roots
 core/refs
 core/libraries
+core/custom-types

--- a/testsuite/tests/core/custom-types/custom.pxr
+++ b/testsuite/tests/core/custom-types/custom.pxr
@@ -1,0 +1,168 @@
+@ /custom root:custom {
+  .shared-code [map SHARED.Custom1 {package SHARED;
+import java.util.*;
+import java.util.function.*;
+import java.util.stream.*;
+import org.praxislive.core.*;
+import org.praxislive.core.types.*;
+import org.praxislive.code.userapi.*;
+import static org.praxislive.code.userapi.Constants.*;
+public class Custom1 extends org.praxislive.core.code.CoreCodeDelegate {
+    
+    @P String message;
+    
+    @Out Output out;
+
+    @Override
+    public void starting() {
+        out.send(message);
+    }
+    
+}
+} SHARED.Custom2 {package SHARED;
+import java.util.*;
+import java.util.function.*;
+import java.util.stream.*;
+import org.praxislive.core.*;
+import org.praxislive.core.types.*;
+import org.praxislive.code.userapi.*;
+import static org.praxislive.code.userapi.Constants.*;
+public class Custom2 extends org.praxislive.core.code.CoreCodeDelegate {
+    
+    @In Input in;
+    @Out Output out;
+
+    @Override
+    public void init() {
+        in.valuesAs(PString.class)
+                .map(PString::toString)
+                .map(this::transform)
+                .link(out::send);
+    }
+    
+    protected String transform(String str) {
+        return str;
+    }
+    
+}
+}]
+  .code {    
+    @Override
+    @SupportedTypes(
+            custom = {
+                @CustomType(type = "core:custom1", base = SHARED.Custom1.class)
+            }
+    )
+    public void init() {
+
+    }
+    
+}
+  @ ./exit core:custom {
+    .meta [map graph.x 716 graph.y 50]
+    .code {import org.praxislive.core.services.Services;
+import org.praxislive.core.services.SystemManagerService;
+
+
+    @T(1)
+    void exitOK() {
+        exit(0);
+    }
+
+    @T(2)
+    void exitFail() {
+        exit(1);
+    }
+
+    private void exit(int exitValue) {
+        find(Services.class)
+                .flatMap(s -> s.locate(SystemManagerService.class))
+                .ifPresent(s -> tell(ControlAddress.of(s, "system-exit"), exitValue));
+    }
+
+}
+  }
+  @ ./container core:container {
+    .meta [map graph.x 378 graph.y 50]
+    .code {    
+    @Override
+    @ProxyPorts
+    @SupportedTypes(
+            system = false,
+            custom = {
+                @CustomType(type = "core:custom2", base = SHARED.Custom2.class)
+            }
+    )
+    public void init() {
+
+    }
+    
+}
+    .ports [map in do-nothing!in out universe!out]
+    @ ./do-nothing core:custom2 {
+      .meta [map graph.x 141 graph.y 236]
+    }
+    @ ./uppercase core:custom2 {
+      .meta [map graph.x 363 graph.y 236]
+      .code {extends SHARED.Custom2;
+
+    @Override
+    protected String transform(String str) {
+        return str.toUpperCase(Locale.ENGLISH);
+    }
+    
+}
+    }
+    @ ./universe core:custom2 {
+      .meta [map graph.x 594 graph.y 236]
+      .code {extends SHARED.Custom2;
+
+    @P @Config.Port(false) String match, replacement;
+    
+    @Override
+    protected String transform(String str) {
+        return str.replace(match, replacement);
+    }
+
+}
+      .match WORLD
+      .replacement UNIVERSE
+    }
+    ~ ./do-nothing!out ./uppercase!in
+    ~ ./uppercase!out ./universe!in
+  }
+  @ ./custom1 core:custom1 {
+    .meta [map graph.x 50 graph.y 50]
+    .message "Hello World!"
+  }
+  @ ./test core:custom {
+    .meta [map graph.x 573 graph.y 50]
+    .code {
+    @Out(1) Output ok;
+    @Out(2) Output error;
+
+    @P @Config.Port(false) String comparison;
+
+    @In
+    void test(String msg) {
+        if (comparison.equals(msg)) {
+            ok.send();
+        } else {
+            log(ERROR, "<FAIL> : Expected " + comparison + " but received " + msg);
+            error.send();
+        }
+    }
+
+}
+    .comparison "HELLO UNIVERSE!"
+  }
+  @ ./delay core:timing:delay {
+    .meta [map graph.x 225 graph.y 50]
+    .time 0.01
+  }
+  ~ ./custom1!out ./delay!in
+  ~ ./delay!out ./container!in
+  ~ ./container!out ./test!test
+  ~ ./test!ok ./exit!exit-ok
+  ~ ./test!error ./exit!exit-fail
+}

--- a/testsuite/tests/core/custom-types/project.pxp
+++ b/testsuite/tests/core/custom-types/project.pxp
@@ -1,0 +1,13 @@
+hub {
+
+}
+compiler {
+  release 11
+}
+libraries {}
+
+# <<<BUILD>>>
+include [file "custom.pxr"]
+
+# <<<RUN>>>
+/custom.start


### PR DESCRIPTION
Add support for registering custom types for containers based on a type and delegate subclass.  Also adds in support for filtering the available system components by glob patterns.  Also adds display hint for table display (for use by custom OSC / MIDI replacements, etc.)