### PR TITLE
Increase network hub timeout and add system property

### DIFF
--- a/praxiscore-hub-net/src/main/java/org/praxislive/hub/net/NetworkCoreRoot.java
+++ b/praxiscore-hub-net/src/main/java/org/praxislive/hub/net/NetworkCoreRoot.java
@@ -52,7 +52,9 @@ import org.praxislive.hub.Hub;
  */
 class NetworkCoreRoot extends BasicCoreRoot {
 
-    private final static String PROXY_PREFIX = Hub.SYS_PREFIX + "proxy_";
+    static final int TIMEOUT = Integer.getInteger("praxis.hub.network.timeout", 60);
+
+    private static final String PROXY_PREFIX = Hub.SYS_PREFIX + "proxy_";
 
     private final Hub.Accessor hubAccess;
     private final List<ProxyData> proxies;
@@ -136,8 +138,8 @@ class NetworkCoreRoot extends BasicCoreRoot {
                 var ctrl = installRoot(id, new ProxyClientRoot(info, clientEventLoopGroup,
                         services, childLauncher, serverInfo));
                 info.services().forEach(cls -> {
-                    var address = ComponentAddress.of("/" + id + "/services/" +
-                            Protocol.Type.of(cls).name());
+                    var address = ComponentAddress.of("/" + id + "/services/"
+                            + Protocol.Type.of(cls).name());
                     hubAccess.registerService(cls, address);
                 });
                 proxies.add(new ProxyData(info, ComponentAddress.of("/" + id), ctrl));
@@ -161,8 +163,9 @@ class NetworkCoreRoot extends BasicCoreRoot {
         return null;
     }
 
-    private record ProxyData(ProxyInfo info, ComponentAddress address, Root.Controller controller) {}
+    private record ProxyData(ProxyInfo info, ComponentAddress address, Root.Controller controller) {
 
+    }
 
     private class AddRootControl extends AbstractAsyncControl {
 

--- a/praxiscore-hub-net/src/main/java/org/praxislive/hub/net/ProxyClientRoot.java
+++ b/praxiscore-hub-net/src/main/java/org/praxislive/hub/net/ProxyClientRoot.java
@@ -161,7 +161,7 @@ class ProxyClientRoot extends AbstractRoot {
         var source = getExecutionContext();
         if ((source.getTime() - lastPurgeTime) > TimeUnit.SECONDS.toNanos(1)) {
 //            LOG.fine("Triggering dispatcher purge");
-            dispatcher.purge(10, TimeUnit.SECONDS);
+            dispatcher.purge(NetworkCoreRoot.TIMEOUT, TimeUnit.SECONDS);
             lastPurgeTime = source.getTime();
         }
     }

--- a/praxiscore-hub-net/src/main/java/org/praxislive/hub/net/ServerCoreRoot.java
+++ b/praxiscore-hub-net/src/main/java/org/praxislive/hub/net/ServerCoreRoot.java
@@ -174,7 +174,7 @@ class ServerCoreRoot extends NetworkCoreRoot {
         long time = getExecutionContext().getTime();
         if ((time - lastPurgeTime) > TimeUnit.SECONDS.toNanos(1)) {
             LOG.log(Level.TRACE, "Triggering dispatcher purge");
-            dispatcher.purge(10, TimeUnit.SECONDS);
+            dispatcher.purge(NetworkCoreRoot.TIMEOUT, TimeUnit.SECONDS);
             lastPurgeTime = time;
         }
     }


### PR DESCRIPTION
Increase default network hub timeout to 60 seconds. Add system property to configure - `praxis.hub.network.timeout`.