### PR TITLE
Support Async return from functions

### DIFF
--- a/praxiscore-code/src/main/java/org/praxislive/code/CodeComponent.java
+++ b/praxiscore-code/src/main/java/org/praxislive/code/CodeComponent.java
@@ -83,8 +83,9 @@ public class CodeComponent<D extends CodeDelegate> implements Component {
     public void parentNotify(Container parent) throws VetoException {
         if (parent == null) {
             if (this.parent != null) {
-                this.parent = null;
                 disconnectAll();
+                codeCtxt.handleDispose();
+                this.parent = null;
             }
         } else {
             if (this.parent != null) {
@@ -104,9 +105,6 @@ public class CodeComponent<D extends CodeDelegate> implements Component {
         router = null;
         logInfo = null;
         codeCtxt.handleHierarchyChanged();
-        if (getAddress() == null) {
-            codeCtxt.handleDispose();
-        }
     }
 
     @Override

--- a/praxiscore-code/src/main/java/org/praxislive/code/CodeContext.java
+++ b/praxiscore-code/src/main/java/org/praxislive/code/CodeContext.java
@@ -294,8 +294,6 @@ public abstract class CodeContext<D extends CodeDelegate> {
     }
 
     final void handleDispose() {
-        cmp = null;
-        handleHierarchyChanged();
         refs.values().forEach(ReferenceDescriptor::dispose);
         refs.clear();
         controls.values().forEach(ControlDescriptor::dispose);
@@ -303,6 +301,8 @@ public abstract class CodeContext<D extends CodeDelegate> {
         ports.values().forEach(PortDescriptor::dispose);
         ports.clear();
         dispose();
+        cmp = null;
+        handleHierarchyChanged();
     }
 
     /**

--- a/praxiscore-code/src/main/java/org/praxislive/code/FunctionDescriptor.java
+++ b/praxiscore-code/src/main/java/org/praxislive/code/FunctionDescriptor.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright 2023 Neil C Smith.
+ * Copyright 2024 Neil C Smith.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3 only, as
@@ -24,7 +24,13 @@ package org.praxislive.code;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import org.praxislive.code.userapi.Async;
 import org.praxislive.code.userapi.FN;
 import org.praxislive.core.ArgumentInfo;
 import org.praxislive.core.Call;
@@ -32,8 +38,10 @@ import org.praxislive.core.Control;
 import org.praxislive.core.ControlInfo;
 import org.praxislive.core.Info;
 import org.praxislive.core.PacketRouter;
+import org.praxislive.core.Value;
 import org.praxislive.core.ValueMapper;
 import org.praxislive.core.services.LogLevel;
+import org.praxislive.core.types.PError;
 import org.praxislive.core.types.PMap;
 
 /**
@@ -41,26 +49,46 @@ import org.praxislive.core.types.PMap;
  */
 class FunctionDescriptor extends ControlDescriptor<FunctionDescriptor> {
 
+    private final Method method;
     private final ControlInfo info;
-    private final FunctionControl control;
+    private final boolean async;
+    private final List<ValueMapper<?>> parameterMappers;
+    private final ValueMapper<?> returnMapper;
+
+    private FunctionControl control;
 
     private FunctionDescriptor(String id,
             int index,
             Method method,
             ControlInfo info,
             List<ValueMapper<?>> parameterMappers,
-            ValueMapper<?> returnMapper) {
+            ValueMapper<?> returnMapper,
+            boolean async) {
         super(FunctionDescriptor.class, id, Category.Function, index);
+        this.method = method;
         this.info = info;
-        this.control = new DirectFunctionControl(method, parameterMappers, returnMapper);
+        this.parameterMappers = parameterMappers;
+        this.returnMapper = returnMapper;
+        this.async = async;
     }
 
     @Override
     public void attach(CodeContext<?> context, FunctionDescriptor previous) {
         if (previous != null) {
-            previous.control.detach();
+            if (isCompatible(previous)) {
+                control = previous.control;
+            } else {
+                previous.dispose();
+            }
         }
-        control.attach(context);
+        if (control == null) {
+            if (async) {
+                control = new AsyncFunctionControl(parameterMappers, returnMapper);
+            } else {
+                control = new DirectFunctionControl(parameterMappers, returnMapper);
+            }
+        }
+        control.attach(context, method);
     }
 
     @Override
@@ -73,13 +101,33 @@ class FunctionDescriptor extends ControlDescriptor<FunctionDescriptor> {
         return info;
     }
 
+    @Override
+    public void dispose() {
+        if (control != null) {
+            control.dispose();
+        }
+    }
+
+    @Override
+    public void onStop() {
+        if (control != null) {
+            control.onStop();
+        }
+    }
+
+    private boolean isCompatible(FunctionDescriptor other) {
+        return method.getGenericReturnType().equals(other.method.getGenericReturnType())
+                && Arrays.equals(method.getGenericParameterTypes(),
+                        other.method.getGenericParameterTypes());
+    }
+
     static FunctionDescriptor create(CodeConnector<?> connector, FN ann, Method method) {
         method.setAccessible(true);
-        var parameterTypes = method.getParameterTypes();
-        var parameterMappers = new ValueMapper<?>[parameterTypes.length];
+        Class<?>[] parameterTypes = method.getParameterTypes();
+        ValueMapper<?>[] parameterMappers = new ValueMapper<?>[parameterTypes.length];
         for (int i = 0; i < parameterMappers.length; i++) {
-            var type = parameterTypes[i];
-            var mapper = ValueMapper.find(type);
+            Class<?> type = parameterTypes[i];
+            ValueMapper<?> mapper = ValueMapper.find(type);
             if (mapper == null) {
                 connector.getLog().log(LogLevel.ERROR,
                         "Unsupported parameter type " + type.getSimpleName()
@@ -88,10 +136,25 @@ class FunctionDescriptor extends ControlDescriptor<FunctionDescriptor> {
             }
             parameterMappers[i] = mapper;
         }
-        var returnType = method.getReturnType();
+
+        boolean async = false;
+        Class<?> returnType = method.getReturnType();
         ValueMapper<?> returnMapper;
         if (returnType == Void.TYPE) {
             returnMapper = null;
+        } else if (returnType == Async.class) {
+            async = true;
+            Class<?> asyncReturnType = TypeUtils.extractRawType(
+                    TypeUtils.extractTypeParameter(method.getGenericReturnType())
+            );
+            returnMapper = asyncReturnType == null ? null
+                    : ValueMapper.find(asyncReturnType);
+            if (returnMapper == null) {
+                connector.getLog().log(LogLevel.ERROR,
+                        "Unsupported Async type " + method.getGenericReturnType()
+                        + " in method " + method.getName());
+                return null;
+            }
         } else {
             returnMapper = ValueMapper.find(returnType);
             if (returnMapper == null) {
@@ -101,12 +164,12 @@ class FunctionDescriptor extends ControlDescriptor<FunctionDescriptor> {
                 return null;
             }
         }
-        var id = connector.findID(method);
+        String id = connector.findID(method);
 
         ArgumentInfo[] inputArgInfo = new ArgumentInfo[parameterMappers.length];
         for (int i = 0; i < inputArgInfo.length; i++) {
-            var type = parameterMappers[i].valueType();
-            var properties = type.emptyValue()
+            Value.Type<?> type = parameterMappers[i].valueType();
+            PMap properties = type.emptyValue()
                     .map(empty -> PMap.EMPTY)
                     .orElse(PMap.of(ArgumentInfo.KEY_ALLOW_EMPTY, true));
             inputArgInfo[i] = ArgumentInfo.of(type.asClass(), properties);
@@ -114,8 +177,8 @@ class FunctionDescriptor extends ControlDescriptor<FunctionDescriptor> {
 
         ArgumentInfo[] outputArgInfo;
         if (returnMapper != null) {
-            var type = returnMapper.valueType();
-            var properties = type.emptyValue()
+            Value.Type<?> type = returnMapper.valueType();
+            PMap properties = type.emptyValue()
                     .map(empty -> PMap.EMPTY)
                     .orElse(PMap.of(ArgumentInfo.KEY_ALLOW_EMPTY, true));
             outputArgInfo = new ArgumentInfo[]{
@@ -131,37 +194,40 @@ class FunctionDescriptor extends ControlDescriptor<FunctionDescriptor> {
                 .build();
 
         return new FunctionDescriptor(id, ann.value(), method, controlInfo,
-                List.of(parameterMappers), returnMapper);
+                List.of(parameterMappers), returnMapper, async);
     }
 
     private static abstract class FunctionControl implements Control {
 
-        abstract void attach(CodeContext<?> context);
+        abstract void attach(CodeContext<?> context, Method method);
 
-        abstract void detach();
+        abstract void dispose();
+
+        void onStop() {
+
+        }
 
     }
 
     private static class DirectFunctionControl extends FunctionControl {
 
-        private final Method method;
         private final List<ValueMapper<?>> parameterMappers;
-        private final ValueMapper<?> returnMapper;
+        private final ValueMapper<Object> returnMapper;
 
         private CodeContext<?> context;
+        private Method method;
 
-        private DirectFunctionControl(Method method,
-                List<ValueMapper<?>> parameterMappers,
+        @SuppressWarnings("unchecked")
+        private DirectFunctionControl(List<ValueMapper<?>> parameterMappers,
                 ValueMapper<?> returnMapper) {
-            this.method = method;
             this.parameterMappers = parameterMappers;
-            this.returnMapper = returnMapper;
+            this.returnMapper = (ValueMapper<Object>) returnMapper;
         }
 
         @Override
         public void call(Call call, PacketRouter router) throws Exception {
             if (call.isRequest()) {
-                var args = call.args();
+                List<Value> args = call.args();
                 int reqCount = parameterMappers.size();
                 if (args.size() < reqCount) {
                     throw new IllegalArgumentException("Not enough arguments in call");
@@ -175,17 +241,14 @@ class FunctionDescriptor extends ControlDescriptor<FunctionDescriptor> {
                             () -> method.invoke(context.getDelegate(), parameters));
                     if (call.isReplyRequired()) {
                         if (returnMapper != null) {
-                            @SuppressWarnings("unchecked")
-                            var mapper = (ValueMapper<Object>) returnMapper;
-                            router.route(call.reply(mapper.toValue(response)));
+                            router.route(call.reply(returnMapper.toValue(response)));
                         } else {
                             router.route(call.reply());
                         }
                     }
                 } catch (InvocationTargetException ex) {
-                    var cause = ex.getCause();
-                    if (cause instanceof Exception) {
-                        throw (Exception) cause;
+                    if (ex.getCause() instanceof Exception exc) {
+                        throw exc;
                     } else {
                         throw ex;
                     }
@@ -194,14 +257,106 @@ class FunctionDescriptor extends ControlDescriptor<FunctionDescriptor> {
         }
 
         @Override
-        void attach(CodeContext<?> context) {
+        void attach(CodeContext<?> context, Method method) {
             this.context = context;
+            this.method = method;
         }
 
         @Override
-        void detach() {
+        void dispose() {
             this.context = null;
+            this.method = null;
         }
+
+    }
+
+    private static class AsyncFunctionControl extends FunctionControl {
+
+        private final List<ValueMapper<?>> parameterMappers;
+        private final ValueMapper<Object> returnMapper;
+        private final Map<Call, CompletableFuture<?>> pending;
+
+        private CodeContext<?> context;
+        private Method method;
+
+        @SuppressWarnings("unchecked")
+        private AsyncFunctionControl(List<ValueMapper<?>> parameterMappers,
+                ValueMapper<?> returnMapper) {
+            this.parameterMappers = parameterMappers;
+            this.returnMapper = (ValueMapper<Object>) returnMapper;
+            pending = new LinkedHashMap<>();
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public void call(Call call, PacketRouter router) throws Exception {
+            if (call.isRequest()) {
+                List<Value> args = call.args();
+                int reqCount = parameterMappers.size();
+                if (args.size() < reqCount) {
+                    throw new IllegalArgumentException("Not enough arguments in call");
+                }
+                Object[] parameters = new Object[reqCount];
+                for (int i = 0; i < parameters.length; i++) {
+                    parameters[i] = parameterMappers.get(i).fromValue(args.get(i));
+                }
+                try {
+                    Object response = context.invokeCallable(call.time(),
+                            () -> method.invoke(context.getDelegate(), parameters));
+                    if (call.isReplyRequired()) {
+                        Async<Object> async = (Async<Object>) response;
+                        CompletableFuture<Object> future = Async.toCompletableFuture(async);
+                        pending.put(call, future);
+                        future.whenComplete((result, error) -> {
+                            if (pending.remove(call) != null) {
+                                PacketRouter rtr = context.getComponent().getPacketRouter();
+                                if (result != null) {
+                                    try {
+                                        rtr.route(call.reply(returnMapper.toValue(result)));
+                                    } catch (Exception ex) {
+                                        rtr.route(call.error(PError.of(ex)));
+                                    }
+                                } else {
+                                    PError pe = PError.of(error instanceof Exception e
+                                            ? e : new Exception(error));
+                                    rtr.route(call.error(pe));
+                                }
+                            }
+
+                        });
+                    }
+                } catch (InvocationTargetException ex) {
+                    if (ex.getCause() instanceof Exception exc) {
+                        throw exc;
+                    } else {
+                        throw ex;
+                    }
+                }
+            }
+        }
+
+        @Override
+        void attach(CodeContext<?> context, Method method) {
+            this.context = context;
+            this.method = method;
+        }
+
+        @Override
+        void onStop() {
+            if (!pending.isEmpty() && context != null) {
+                List<CompletableFuture<?>> futures = new ArrayList<>(pending.values());
+                futures.forEach(f -> f.cancel(false));
+            }
+            pending.clear();
+        }
+
+        @Override
+        void dispose() {
+            onStop();
+            this.context = null;
+            this.method = null;
+        }
+
     }
 
 }

--- a/praxiscore-code/src/main/java/org/praxislive/code/RefImpl.java
+++ b/praxiscore-code/src/main/java/org/praxislive/code/RefImpl.java
@@ -23,7 +23,6 @@ package org.praxislive.code;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Type;
-import java.util.function.Function;
 import org.praxislive.code.userapi.AuxOut;
 import org.praxislive.code.userapi.Out;
 import org.praxislive.code.userapi.Ref;

--- a/praxiscore-code/src/main/java/org/praxislive/code/TypeUtils.java
+++ b/praxiscore-code/src/main/java/org/praxislive/code/TypeUtils.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright 2023 Neil C Smith.
+ * Copyright 2024 Neil C Smith.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3 only, as
@@ -60,13 +60,47 @@ class TypeUtils {
      */
     static Type extractTypeParameter(Field field, Class<?> baseType) {
         if (field.getType().equals(baseType)) {
-            var fieldType = field.getGenericType();
-            if (fieldType instanceof ParameterizedType) {
-                var paramType = (ParameterizedType) fieldType;
-                var types = paramType.getActualTypeArguments();
-                if (types.length == 1) {
-                    return types[0];
-                }
+            return extractTypeParameter(field.getGenericType());
+        }
+        return null;
+    }
+
+    /**
+     * Extract the type parameter from a type if it is a parameterized type with
+     * single type parameter. eg. for a type of {@code Ref<List<String>>} return
+     * the type of {@code List<String>}.
+     *
+     * @param type generic type
+     * @return extracted parameter type or null
+     */
+    static Type extractTypeParameter(Type type) {
+        if (type instanceof ParameterizedType paramType) {
+            Type[] types = paramType.getActualTypeArguments();
+            if (types.length == 1) {
+                return types[0];
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Extract the raw Class type from a type, if one exists. Supports Class or
+     * ParameterizedType. Supports null input for chaining with other methods.
+     *
+     * @param type type or null
+     * @return class or null
+     */
+    static Class<?> extractRawType(Type type) {
+        if (type == null) {
+            return null;
+        }
+        if (type instanceof Class cls) {
+            return cls;
+        }
+        if (type instanceof ParameterizedType paramType) {
+            Type raw = paramType.getRawType();
+            if (raw instanceof Class cls) {
+                return cls;
             }
         }
         return null;

--- a/praxiscore-code/src/main/java/org/praxislive/code/userapi/Async.java
+++ b/praxiscore-code/src/main/java/org/praxislive/code/userapi/Async.java
@@ -160,6 +160,24 @@ public final class Async<T> {
     }
 
     /**
+     * Bind a target Async to complete when a source Async completes. When the
+     * source Async completes, the target will be completed with the same result
+     * or error.
+     *
+     * @param <T> result type
+     * @param source source async
+     * @param target target async
+     */
+    public static <T> void bind(Async<T> source, Async<? super T> target) {
+        Objects.requireNonNull(target);
+        if (source.done()) {
+            complete(source, target);
+        } else {
+            source.link(handler(async -> complete(async, target)));
+        }
+    }
+
+    /**
      * Create an Async that will complete when the provided async call
      * completes, by extracting the first call argument and attempting to map to
      * the given type. The returned Async will complete with an error if the
@@ -236,6 +254,14 @@ public final class Async<T> {
                     }
             ));
             return future;
+        }
+    }
+
+    private static <T> void complete(Async<T> source, Async<? super T> target) {
+        if (source.failed()) {
+            target.fail(source.error());
+        } else {
+            target.complete(source.result());
         }
     }
 

--- a/praxiscore-code/src/test/java/org/praxislive/code/userapi/AsyncTest.java
+++ b/praxiscore-code/src/test/java/org/praxislive/code/userapi/AsyncTest.java
@@ -50,6 +50,31 @@ public class AsyncTest {
     }
 
     @Test
+    public void testBind() {
+        Async<String> source = new Async<>();
+        Async<Object> target = new Async<>();
+        Async.bind(source, target);
+        source.complete("FOO");
+        assertTrue(target.done());
+        assertEquals("FOO", target.result());
+
+        source = new Async<>();
+        target = new Async<>();
+        source.complete("BAR");
+        Async.bind(source, target);
+        assertTrue(target.done());
+        assertEquals("BAR", target.result());
+
+        source = new Async<>();
+        target = new Async<>();
+        Async.bind(source, target);
+        PError error = PError.of("ERROR");
+        source.fail(error);
+        assertTrue(target.done());
+        assertSame(error, target.error());
+    }
+
+    @Test
     public void testExtractArg() {
         // Test Value extract
         Async<Call> asyncCall = new Async<>();
@@ -144,7 +169,7 @@ public class AsyncTest {
         asyncString.fail(PError.of(ex));
         assertTrue(futureString.isCompletedExceptionally());
         assertSame(ex, futureString.exceptionNow());
-        
+
         // error before link
         asyncString = new Async<>();
         ex = new Exception("FOO");
@@ -152,7 +177,7 @@ public class AsyncTest {
         futureString = Async.toCompletableFuture(asyncString);
         assertTrue(futureString.isCompletedExceptionally());
         assertSame(ex, futureString.exceptionNow());
-        
+
         // test queued and future
         asyncString = new Async<>();
         futureString = Async.toCompletableFuture(asyncString);

--- a/praxiscore-code/src/test/java/org/praxislive/code/userapi/AsyncTest.java
+++ b/praxiscore-code/src/test/java/org/praxislive/code/userapi/AsyncTest.java
@@ -153,15 +153,16 @@ public class AsyncTest {
         assertTrue(futureString.isCompletedExceptionally());
         assertSame(ex, futureString.exceptionNow());
         
-        // cancelled on queued
+        // test queued and future
         asyncString = new Async<>();
         futureString = Async.toCompletableFuture(asyncString);
         Async.Queue<String> queue = new Async.Queue<>();
         queue.add(asyncString);
-        assertTrue(futureString.isCancelled());
         assertNull(queue.poll());
         asyncString.complete("QUEUED");
         assertSame(asyncString, queue.poll());
+        assertTrue(futureString.isDone());
+        assertEquals("QUEUED", futureString.resultNow());
     }
 
     @Test

--- a/testsuite/tests/core/async-functions/data1.pxr
+++ b/testsuite/tests/core/async-functions/data1.pxr
@@ -1,37 +1,34 @@
 @ /data1 root:data {
-  #%praxis.version 5.7.0-SNAPSHOT
+  .meta [map praxis.version 5.7.0-SNAPSHOT]
   @ ./exit core:custom {
-    #%graph.x 680
-    #%graph.y 659
-    .code "import org.praxislive.core.services.Services;
+    .meta [map graph.x 589 graph.y 685]
+    .code {import org.praxislive.core.services.Services;
 import org.praxislive.core.services.SystemManagerService;
 
 
     @T(1)
-    void exitOK() \{
+    void exitOK() {
         exit(0);
-    \}
+    }
 
     @T(2)
-    void exitFail() \{
+    void exitFail() {
         exit(1);
-    \}
+    }
 
-    private void exit(int exitValue) \{
+    private void exit(int exitValue) {
         find(Services.class)
                 .flatMap(s -> s.locate(SystemManagerService.class))
-                .ifPresent(s -> tell(ControlAddress.of(s, \"system-exit\"), exitValue));
-    \}
+                .ifPresent(s -> tell(ControlAddress.of(s, "system-exit"), exitValue));
+    }
 
-"
+}
   }
   @ ./test1 core:custom {
-    #%graph.x 124
-    #%graph.y 74
-    #%graph.comment Call uppercase function
-    .code "
+    .meta [map graph.x 124 graph.y 74 graph.comment "Call uppercase function"]
+    .code {
 
-    String lowercase = \"hello world\";
+    String lowercase = "hello world";
     String uppercase = lowercase.toUpperCase(Locale.ROOT);
 
     @Out(1) Output ok;
@@ -40,42 +37,40 @@ import org.praxislive.core.services.SystemManagerService;
     @Persist Async<Call> response;
 
     @Override
-    public void update() \{
-        if (response != null && response.done()) \{
-            if (response.failed()) \{
-                log(ERROR, \"<FAIL> \" + response.error());
+    public void update() {
+        if (response != null && response.done()) {
+            if (response.failed()) {
+                log(ERROR, "<FAIL> " + response.error());
                 error.send();
-            \} else \{
+            } else {
                 String result = response.result().args().get(0).toString();
-                if (!result.equals(uppercase)) \{
-                    log(ERROR, \"<FAIL> expected \" + uppercase + \" but got \" + result);
+                if (!result.equals(uppercase)) {
+                    log(ERROR, "<FAIL> expected " + uppercase + " but got " + result);
                     error.send();
-                \} else \{
-                    log(INFO, \"Test 1 : OK\");
+                } else {
+                    log(INFO, "Test 1 : OK");
                     ok.send();
-                \}
-            \}
+                }
+            }
             response = null;
-        \}
-    \}
+        }
+    }
 
     @T(1)
-    void test() \{
-        log(INFO, \"Test 1 : Calling /data2/functions.uppercase\");
-        response = ask(ControlAddress.of(\"/data2/functions.uppercase\"),
+    void test() {
+        log(INFO, "Test 1 : Calling /data2/functions.uppercase");
+        response = ask(ControlAddress.of("/data2/functions.uppercase"),
                 List.of(V(lowercase)));
-    \}
+    }
 
 
-"
+}
   }
   @ ./test2 core:custom {
-    #%graph.x 124
-    #%graph.y 231
-    #%graph.comment Call uppercase function with extra args
-    .code "
+    .meta [map graph.x 124 graph.y 231 graph.comment "Call uppercase function with extra args"]
+    .code {
 
-    String lowercase = \"hello world\";
+    String lowercase = "hello world";
     String uppercase = lowercase.toUpperCase(Locale.ROOT);
 
     @Out(1) Output ok;
@@ -84,42 +79,40 @@ import org.praxislive.core.services.SystemManagerService;
     @Persist Async<Call> response;
 
     @Override
-    public void update() \{
-        if (response != null && response.done()) \{
-            if (response.failed()) \{
-                log(ERROR, \"<FAIL> \" + response.error());
+    public void update() {
+        if (response != null && response.done()) {
+            if (response.failed()) {
+                log(ERROR, "<FAIL> " + response.error());
                 error.send();
-            \} else \{
+            } else {
                 String result = response.result().args().get(0).toString();
-                if (!result.equals(uppercase)) \{
-                    log(ERROR, \"<FAIL> expected \" + uppercase + \" but got \" + result);
+                if (!result.equals(uppercase)) {
+                    log(ERROR, "<FAIL> expected " + uppercase + " but got " + result);
                     error.send();
-                \} else \{
-                    log(INFO, \"Test 2 : OK\");
+                } else {
+                    log(INFO, "Test 2 : OK");
                     ok.send();
-                \}
-            \}
+                }
+            }
             response = null;
-        \}
-    \}
+        }
+    }
 
     @T(1)
-    void test() \{
-        log(INFO, \"Test 2 : Calling /data2/functions.uppercase with extra argument\");
-        response = ask(ControlAddress.of(\"/data2/functions.uppercase\"),
-                lowercase, \"extra argument\");
-    \}
+    void test() {
+        log(INFO, "Test 2 : Calling /data2/functions.uppercase with extra argument");
+        response = ask(ControlAddress.of("/data2/functions.uppercase"),
+                lowercase, "extra argument");
+    }
 
 
-"
+}
   }
   @ ./test3 core:custom {
-    #%graph.x 124
-    #%graph.y 391
-    #%graph.comment Call no-op function
-    .code "
+    .meta [map graph.x 124 graph.y 391 graph.comment "Call no-op function"]
+    .code {
 
-    String lowercase = \"hello world\";
+    String lowercase = "hello world";
     String uppercase = lowercase.toUpperCase(Locale.ROOT);
 
     @Out(1) Output ok;
@@ -128,39 +121,37 @@ import org.praxislive.core.services.SystemManagerService;
     @Persist Async<Call> response;
 
     @Override
-    public void update() \{
-        if (response != null && response.done()) \{
-            if (response.failed()) \{
-                log(ERROR, \"<FAIL> \" + response.error());
+    public void update() {
+        if (response != null && response.done()) {
+            if (response.failed()) {
+                log(ERROR, "<FAIL> " + response.error());
                 error.send();
-            \} else \{
-                if (!response.result().args().isEmpty()) \{
-                    log(ERROR, \"<FAIL> expected no response args but received \"
+            } else {
+                if (!response.result().args().isEmpty()) {
+                    log(ERROR, "<FAIL> expected no response args but received "
                             + response.result().args());
                     error.send();
-                \} else \{
-                    log(INFO, \"Test 3 : OK\");
+                } else {
+                    log(INFO, "Test 3 : OK");
                     ok.send();
-                \}
-            \}
+                }
+            }
             response = null;
-        \}
-    \}
+        }
+    }
 
     @T(1)
-    void test() \{
-        log(INFO, \"Test 3 : Calling /data2/functions.no-op\");
-        response = ask(ControlAddress.of(\"/data2/functions.no-op\"));
-    \}
+    void test() {
+        log(INFO, "Test 3 : Calling /data2/functions.no-op");
+        response = ask(ControlAddress.of("/data2/functions.no-op"));
+    }
 
 
-"
+}
   }
   @ ./test4 core:custom {
-    #%graph.x 124
-    #%graph.y 555
-    #%graph.comment Call error function
-    .code "
+    .meta [map graph.x 124 graph.y 555 graph.comment "Call error function"]
+    .code {
 
     @Out(1) Output ok;
     @Out(2) Output error;
@@ -168,42 +159,40 @@ import org.praxislive.core.services.SystemManagerService;
     @Persist Async<Call> response;
 
     @Override
-    public void update() \{
-        if (response != null && response.done()) \{
-            if (!response.failed()) \{
+    public void update() {
+        if (response != null && response.done()) {
+            if (!response.failed()) {
                 log(ERROR,
-                        \"<FAIL> exception expected but call completed successfully with args \"
+                        "<FAIL> exception expected but call completed successfully with args "
                         + response.result().args()
                 );
                 error.send();
-            \} else if (!\"UnsupportedOperationException\".equals(response.error().errorType())) \{
-                log(ERROR, \"<FAIL> wrong exception received : \"
+            } else if (!"UnsupportedOperationException".equals(response.error().errorType())) {
+                log(ERROR, "<FAIL> wrong exception received : "
                         + response.error().errorType());
                 error.send();
-            \} else \{
-                log(INFO, \"Test 4 : OK\");
+            } else {
+                log(INFO, "Test 4 : OK");
                 ok.send();
-            \}
+            }
             response = null;
-        \}
-    \}
+        }
+    }
 
     @T(1)
-    void test() \{
-        log(INFO, \"Test 4 : Calling /data2/functions.error\");
-        response = ask(ControlAddress.of(\"/data2/functions.error\"), \"FOO\");
-    \}
+    void test() {
+        log(INFO, "Test 4 : Calling /data2/functions.error");
+        response = ask(ControlAddress.of("/data2/functions.error"), "FOO");
+    }
 
 
-"
+}
   }
   @ ./test5 core:custom {
-    #%graph.x 433
-    #%graph.y 74
-    #%graph.comment Run async task
-    .code "
+    .meta [map graph.x 433 graph.y 74 graph.comment "Run async task"]
+    .code {
 
-    String lowercase = \"hello world\";
+    String lowercase = "hello world";
     String uppercase = lowercase.toUpperCase(Locale.ROOT);
 
     @Out(1) Output ok;
@@ -212,39 +201,37 @@ import org.praxislive.core.services.SystemManagerService;
     @Persist Async<String> response;
 
     @Override
-    public void update() \{
-        if (response != null && response.done()) \{
-            if (response.failed()) \{
-                log(ERROR, \"<FAIL> \" + response.error());
+    public void update() {
+        if (response != null && response.done()) {
+            if (response.failed()) {
+                log(ERROR, "<FAIL> " + response.error());
                 error.send();
-            \} else \{
+            } else {
                 String result = response.result();
-                if (!result.equals(uppercase)) \{
-                    log(ERROR, \"<FAIL> expected \" + uppercase + \" but got \" + result);
+                if (!result.equals(uppercase)) {
+                    log(ERROR, "<FAIL> expected " + uppercase + " but got " + result);
                     error.send();
-                \} else \{
-                    log(INFO, \"Test 5 : OK\");
+                } else {
+                    log(INFO, "Test 5 : OK");
                     ok.send();
-                \}
-            \}
+                }
+            }
             response = null;
-        \}
-    \}
+        }
+    }
 
     @T(1)
-    void test() \{
-        log(INFO, \"Test 5 : Running async task\");
+    void test() {
+        log(INFO, "Test 5 : Running async task");
         response = async(lowercase, s -> s.toUpperCase(Locale.ROOT));
-    \}
+    }
 
-"
+}
   }
   @ ./test6 core:custom {
-    #%graph.x 433
-    #%graph.y 231
-    #%graph.comment Run async task w/ Async.Queue
-    .code "
-    String lowercase = \"hello world\";
+    .meta [map graph.x 433 graph.y 231 graph.comment "Run async task w/ Async.Queue"]
+    .code {
+    String lowercase = "hello world";
     String uppercase = lowercase.toUpperCase(Locale.ROOT);
 
     @Out(1) Output ok;
@@ -253,28 +240,70 @@ import org.praxislive.core.services.SystemManagerService;
     @Inject Async.Queue<String> queue;
 
     @Override
-    public void init() \{
-        queue.onDone(res -> \{
-            if (!res.equals(uppercase)) \{
-                log(ERROR, \"<FAIL> expected \" + uppercase + \" but got \" + res);
+    public void init() {
+        queue.onDone(res -> {
+            if (!res.equals(uppercase)) {
+                log(ERROR, "<FAIL> expected " + uppercase + " but got " + res);
                 error.send();
-            \} else \{
-                log(INFO, \"Test 6 : OK\");
+            } else {
+                log(INFO, "Test 6 : OK");
                 ok.send();
-            \}
-        \}, err -> \{
-            log(ERROR, \"<FAIL> \" + err);
+            }
+        }, err -> {
+            log(ERROR, "<FAIL> " + err);
             error.send();
-        \});
-    \}
+        });
+    }
 
     @T(1)
-    void test() \{
-        log(INFO, \"Test 6 : Running async task w/ Async.Queue\");
+    void test() {
+        log(INFO, "Test 6 : Running async task w/ Async.Queue");
         queue.add(async(lowercase, s -> s.toUpperCase(Locale.ROOT)));
-    \}
+    }
 
-"
+}
+  }
+  @ ./test7 core:custom {
+    .meta [map graph.x 433 graph.y 391 graph.comment "Call uppercase-async function"]
+    .code {
+
+    String lowercase = "hello world";
+    String uppercase = lowercase.toUpperCase(Locale.ROOT);
+
+    @Out(1) Output ok;
+    @Out(2) Output error;
+
+    @Persist Async<Call> response;
+
+    @Override
+    public void update() {
+        if (response != null && response.done()) {
+            if (response.failed()) {
+                log(ERROR, "<FAIL> " + response.error());
+                error.send();
+            } else {
+                String result = response.result().args().get(0).toString();
+                if (!result.equals(uppercase)) {
+                    log(ERROR, "<FAIL> expected " + uppercase + " but got " + result);
+                    error.send();
+                } else {
+                    log(INFO, "Test 1 : OK");
+                    ok.send();
+                }
+            }
+            response = null;
+        }
+    }
+
+    @T(1)
+    void test() {
+        log(INFO, "Test 7 : Calling /data2/functions.uppercase-async");
+        response = ask(ControlAddress.of("/data2/functions.uppercase-async"),
+                List.of(V(lowercase)));
+    }
+
+
+}
   }
   ~ ./test1!error ./exit!exit-fail
   ~ ./test2!error ./exit!exit-fail
@@ -286,6 +315,8 @@ import org.praxislive.core.services.SystemManagerService;
   ~ ./test4!ok ./test5!test
   ~ ./test5!error ./exit!exit-fail
   ~ ./test5!ok ./test6!test
-  ~ ./test6!ok ./exit!exit-ok
   ~ ./test6!error ./exit!exit-fail
+  ~ ./test6!ok ./test7!test
+  ~ ./test7!ok ./exit!exit-ok
+  ~ ./test7!error ./exit!exit-fail
 }

--- a/testsuite/tests/core/async-functions/data2.pxr
+++ b/testsuite/tests/core/async-functions/data2.pxr
@@ -1,31 +1,29 @@
 @ /data2 root:data {
-  #%praxis.version 5.7.0-SNAPSHOT
+  .meta [map praxis.version 5.7.0-SNAPSHOT]
   @ ./functions core:custom {
-    #%graph.x 264
-    #%graph.y 184
-    .code "
-
-
-    
-    @FN String uppercase(String input) \{
+    .meta [map graph.x 265 graph.y 184]
+    .code {
+    @FN String uppercase(String input) {
         return input.toUpperCase(Locale.ROOT);
-    \}
+    }
     
-    @FN void noOp() \{\}
+    @FN Async<String> uppercaseAsync(String input) {
+        return async(input, s -> s.toUpperCase(Locale.ROOT));
+    }
     
-    @FN String error() \{
+    @FN void noOp() {}
+    
+    @FN String error() {
         throw new UnsupportedOperationException();
-    \}
+    }
     
-"
+}
   }
   @ ./start-trigger core:start-trigger {
-    #%graph.x 70
-    #%graph.y 59
+    .meta [map graph.x 70 graph.y 59]
   }
   @ ./send core:routing:send {
-    #%graph.x 455
-    #%graph.y 76
+    .meta [map graph.x 455 graph.y 76]
     .address /data1/test1.test
   }
   ~ ./start-trigger!out ./send!in


### PR DESCRIPTION
Add support for `Async` responses from coded functions. Various updates to `Async` to support mapping values from `Call`, binding together and binding to `CompletableFuture` for use with external code.

Timeout requirement to be handled in response handler?