### PR TITLE
Add @Config.Expose and related component info key.

### DIFF
--- a/praxiscore-api/src/main/java/org/praxislive/core/ComponentInfo.java
+++ b/praxiscore-api/src/main/java/org/praxislive/core/ComponentInfo.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  * 
- * Copyright 2023 Neil C Smith.
+ * Copyright 2024 Neil C Smith.
  * 
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3 only, as
@@ -75,6 +75,18 @@ public class ComponentInfo extends PMap.MapBasedValue {
      * is mandatory. Other keys may be used to provide additional configuration.
      */
     public static final String KEY_DISPLAY_HINT = "display-hint";
+
+    /**
+     * Optional key for adding a default list of control IDs to give extra
+     * priority to exposing to the user. Value must be an array.
+     * <p>
+     * It is up to any editor whether to use or ignore this property (eg. the
+     * PraxisLIVE graph editor will show exposed controls on the graph itself).
+     * If the editor supports overriding the default list of exposed controls,
+     * it should add the altered list under the same key in the
+     * {@link ComponentProtocol#META} property.
+     */
+    public static final String KEY_EXPOSE = "expose";
 
     private final OrderedMap<String, ControlInfo> controls;
     private final OrderedMap<String, PortInfo> ports;

--- a/praxiscore-code/src/main/java/org/praxislive/code/PropertyControl.java
+++ b/praxiscore-code/src/main/java/org/praxislive/code/PropertyControl.java
@@ -397,6 +397,9 @@ public class PropertyControl extends Property implements Control {
                         binding.getDefaultValue(),
                         buildProperties(field));
             }
+            if (info.properties().getBoolean("preferred", false)) {
+                connector.exposeForPreferred(id);
+            }
             return new Descriptor(id, index, info, binding, propertyField, onChange, onError);
         }
 

--- a/praxiscore-code/src/main/java/org/praxislive/code/userapi/Config.java
+++ b/praxiscore-code/src/main/java/org/praxislive/code/userapi/Config.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright 2020 Neil C Smith.
+ * Copyright 2024 Neil C Smith.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3 only, as
@@ -21,17 +21,21 @@
  */
 package org.praxislive.code.userapi;
 
+import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.praxislive.core.ComponentInfo;
 
 /**
+ * Various annotations and support to control component configuration.
  *
- * 
  */
 public final class Config {
 
-    private Config() {}
-    
+    private Config() {
+    }
+
     /**
      * Control automatic port creation for properties, triggers, etc.
      */
@@ -53,10 +57,32 @@ public final class Config {
      * This will add a key to the info for this feature. It is up to an editor
      * whether to use or ignore this key (eg. the PraxisLIVE graph editor will
      * show properties marked this way on the graph itself).
+     * <p>
+     * This option is deprecated in favour of {@link Expose}.
      */
     @Retention(RetentionPolicy.RUNTIME)
+    @Deprecated(forRemoval = true)
     public @interface Preferred {
 
+    }
+
+    /**
+     * Default list of control IDs to give extra priority to exposing to the
+     * user.
+     * <p>
+     * The list of controls is added under the key
+     * {@link ComponentInfo#KEY_EXPOSE} in the component info.
+     */
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.METHOD)
+    public @interface Expose {
+
+        /**
+         * List of control IDs to expose.
+         *
+         * @return list of IDs
+         */
+        String[] value();
     }
 
 }


### PR DESCRIPTION
Add `@Config.Expose` annotation and related component info key for marking a default set of control IDs to "expose" to the user.  How controls are exposed is editor specific.

Deprecate similar `@Config.Preferred` annotation used on individual elements, and add these values to the exposed control list.