### PR TITLE
Add initial support for watch functions

### DIFF
--- a/praxiscore-api/src/main/java/org/praxislive/core/Watch.java
+++ b/praxiscore-api/src/main/java/org/praxislive/core/Watch.java
@@ -1,0 +1,89 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ * 
+ * Copyright 2025 Neil C Smith.
+ * 
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License version 3 only, as
+ * published by the Free Software Foundation.
+ * 
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * version 3 for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License version 3
+ * along with this work; if not, see http://www.gnu.org/licenses/
+ * 
+ * 
+ * Please visit https://www.praxislive.org if you need additional information or
+ * have any questions.
+ */
+package org.praxislive.core;
+
+import org.praxislive.core.types.PMap;
+
+/**
+ * Utilities related to Watch controls. A Watch control is a
+ * {@link ControlInfo.Type#Function} control for accessing data of a component.
+ * It is similar to a read-only property, but designed for data that should only
+ * be calculated on demand, perhaps asynchronously.
+ * <p>
+ * Watch controls have a {@code watch} attribute in their info, with a map value
+ * of information about the available data. The map should include the mime type
+ * of the returned data. The response value type of the control will usually be
+ * {@link PString} for textual mime types and {@link PBytes} for binary mime
+ * types. Specifically defined private mime types may specify other value types.
+ * <p>
+ * Watch controls may accept an optional query argument as a map of attributes
+ * for the requested data (eg. size).
+ */
+public final class Watch {
+
+    /**
+     * The key under which the Watch information is stored in the control info.
+     */
+    public static final String WATCH_KEY = "watch";
+
+    /**
+     * The key for the mime type inside the Watch information.
+     */
+    public static final String MIME_KEY = "mime";
+
+    /**
+     * Optional Watch information key for relating a Watch to a port. The value,
+     * if present, should be the ID of a port on the component.
+     */
+    public static final String RELATED_PORT_KEY = "related-port";
+
+    private Watch() {
+    }
+
+    /**
+     * Create info for a simple Watch function that accepts no query argument,
+     * and returns data with the provided mime type wrapped in the provided
+     * response type.
+     *
+     * @param mimeType mime type of response
+     * @param responseType value type of response
+     * @return watch control info
+     */
+    public static ControlInfo info(String mimeType,
+            Class<? extends Value> responseType) {
+        return Info.control().function()
+                .outputs(Info.argument().type(responseType).build())
+                .property(WATCH_KEY, PMap.of(MIME_KEY, mimeType))
+                .build();
+    }
+
+    /**
+     * Check whether a control info reflects a Watch control.
+     *
+     * @param info control info
+     * @return true if a Watch control
+     */
+    public static boolean isWatch(ControlInfo info) {
+        return info.properties().get(WATCH_KEY) != null;
+    }
+
+}

--- a/praxiscore-code/src/main/java/org/praxislive/code/CodeConnector.java
+++ b/praxiscore-code/src/main/java/org/praxislive/code/CodeConnector.java
@@ -135,7 +135,7 @@ public abstract class CodeConnector<D extends CodeDelegate> {
         analyseMethods(extractMethodsToBase(delegate, factory.baseClass()));
         addDefaultControls();
         addDefaultPorts();
-        addControl(new ResponseHandler(getInternalIndex()));
+        addControl(new AsyncHandler(getInternalIndex()));
         buildExternalData();
     }
 

--- a/praxiscore-code/src/main/java/org/praxislive/code/CodeConnector.java
+++ b/praxiscore-code/src/main/java/org/praxislive/code/CodeConnector.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright 2024 Neil C Smith.
+ * Copyright 2025 Neil C Smith.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3 only, as
@@ -576,6 +576,10 @@ public abstract class CodeConnector<D extends CodeDelegate> {
         if (fn != null && analyseFunctionMethod(fn, method)) {
             return;
         }
+        FN.Watch fnWatch = method.getAnnotation(FN.Watch.class);
+        if (fnWatch != null && analyseWatchFunctionMethod(fnWatch, method)) {
+            return;
+        }
     }
 
     private boolean analyseInputField(In ann, Field field) {
@@ -835,6 +839,17 @@ public abstract class CodeConnector<D extends CodeDelegate> {
     private boolean analyseFunctionMethod(FN ann, Method method) {
         FunctionDescriptor desc
                 = FunctionDescriptor.create(this, ann, method);
+        if (desc != null) {
+            addControl(desc);
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    private boolean analyseWatchFunctionMethod(FN.Watch ann, Method method) {
+        FunctionDescriptor desc
+                = FunctionDescriptor.createWatch(this, ann, method);
         if (desc != null) {
             addControl(desc);
             return true;

--- a/praxiscore-code/src/main/java/org/praxislive/code/CodeDelegate.java
+++ b/praxiscore-code/src/main/java/org/praxislive/code/CodeDelegate.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright 2022 Neil C Smith.
+ * Copyright 2025 Neil C Smith.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3 only, as
@@ -288,6 +288,20 @@ public abstract class CodeDelegate {
      */
     public final <T, R> Async<R> async(T input, Async.Task<T, R> task) {
         return getContext().async(input, task);
+    }
+
+    /**
+     * Timeout the provided async after the given time period if it has not
+     * already been completed.
+     *
+     * @param <T> async type
+     * @param seconds timeout time
+     * @param async async to timeout
+     * @return async reference for convenience
+     */
+    public final <T> Async<T> timeout(double seconds, Async<T> async) {
+        getContext().timeoutAsync(seconds, async);
+        return async;
     }
 
     /**

--- a/praxiscore-code/src/main/java/org/praxislive/code/CodeRoot.java
+++ b/praxiscore-code/src/main/java/org/praxislive/code/CodeRoot.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright 2024 Neil C Smith.
+ * Copyright 2025 Neil C Smith.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3 only, as
@@ -253,7 +253,7 @@ public class CodeRoot<D extends CodeRootDelegate> extends CodeComponent<D> imple
             addControl(createMetaMergeControl(getInternalIndex()));
             addControl(sharedCodeControl());
             addControl(createCodeControl(getInternalIndex()));
-            addControl(new ResponseHandler(getInternalIndex()));
+            addControl(new AsyncHandler(getInternalIndex()));
             addControl(new WrapperControlDescriptor(StartableProtocol.START,
                     StartableProtocol.START_INFO,
                     getInternalIndex(),

--- a/praxiscore-code/src/main/java/org/praxislive/code/userapi/Async.java
+++ b/praxiscore-code/src/main/java/org/praxislive/code/userapi/Async.java
@@ -178,6 +178,32 @@ public final class Async<T> {
     }
 
     /**
+     * Create an Async that is already completed with the given value.
+     *
+     * @param <T> value type
+     * @param value value to complete the Async
+     * @return new completed Async
+     */
+    public static <T> Async<T> completed(T value) {
+        Async<T> async = new Async<>();
+        async.complete(value);
+        return async;
+    }
+
+    /**
+     * Create an Async that is already failed with the given error.
+     *
+     * @param <T> value type
+     * @param error error to fail the Async
+     * @return new failed Async
+     */
+    public static <T> Async<T> failed(PError error) {
+        Async<T> async = new Async<>();
+        async.fail(error);
+        return async;
+    }
+
+    /**
      * Create an Async that will complete when the provided async call
      * completes, by extracting the first call argument and attempting to map to
      * the given type. The returned Async will complete with an error if the

--- a/praxiscore-code/src/main/java/org/praxislive/code/userapi/FN.java
+++ b/praxiscore-code/src/main/java/org/praxislive/code/userapi/FN.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright 2023 Neil C Smith.
+ * Copyright 2025 Neil C Smith.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3 only, as
@@ -42,4 +42,38 @@ public @interface FN {
      * @return weight
      */
     int value() default 0;
+
+    /**
+     * Annotate a method as a {@link Watch} function.
+     */
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.METHOD)
+    public static @interface Watch {
+
+        /**
+         * The mime type of the returned data. Will be included in the Watch
+         * info.
+         *
+         * @return data mime type
+         */
+        String mime();
+
+        /**
+         * Optional name of a port on the component to relate the watch data to.
+         *
+         * @return related port ID
+         */
+        String relatedPort() default "";
+
+        /**
+         * Relative weight compared to other @FN elements. Functions will be
+         * sorted by weight, and then alphabetically. Higher weight elements
+         * will sort after lower weight elements.
+         *
+         * @return weight
+         */
+        int weight() default 0;
+
+    }
+
 }

--- a/praxiscore-components/src/main/java/org/praxislive/core/components/CoreProperty.java
+++ b/praxiscore-components/src/main/java/org/praxislive/core/components/CoreProperty.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright 2018 Neil C Smith.
+ * Copyright 2025 Neil C Smith.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3 only, as
@@ -36,29 +36,32 @@ import static org.praxislive.code.userapi.Constants.*;
 
 /**
  *
- * 
+ *
  */
 @GenerateTemplate(CoreProperty.TEMPLATE_PATH)
 public class CoreProperty extends CoreCodeDelegate {
-    
-    final static String TEMPLATE_PATH = "resources/property.pxj";
 
+    final static String TEMPLATE_PATH = "resources/property.pxj";
     // PXJ-BEGIN:body
 
     @P(1) @Config.Port(false) @OnChange("valueChanged")
     Property value;
 
     @Out(1) Output out;
-    
+
+    @Override
+    @Config.Expose("value")
+    public void init() {
+    }
+
     @Override
     public void starting() {
         out.send(value.get());
     }
-    
+
     void valueChanged() {
         out.send(value.get());
     }
-    
+
     // PXJ-END:body
-    
 }

--- a/praxiscore-components/src/main/java/org/praxislive/core/components/CoreRoutingSend.java
+++ b/praxiscore-components/src/main/java/org/praxislive/core/components/CoreRoutingSend.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright 2019 Neil C Smith.
+ * Copyright 2025 Neil C Smith.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3 only, as
@@ -36,22 +36,25 @@ import static org.praxislive.code.userapi.Constants.*;
 
 /**
  *
- * 
+ *
  */
 @GenerateTemplate(CoreRoutingSend.TEMPLATE_PATH)
 public class CoreRoutingSend extends CoreCodeDelegate {
-    
-    final static String TEMPLATE_PATH = "resources/routing_send.pxj";
 
+    final static String TEMPLATE_PATH = "resources/routing_send.pxj";
     // PXJ-BEGIN:body
-    
-    @P(1) @Config.Port(false) Optional<ControlAddress> address;
-    @P(2) @Transient @Deprecated @Config.Port(false) boolean logErrors;
-    
-    @In(1) void in(Value value) {
+
+    @P @Config.Port(false) Optional<ControlAddress> address;
+
+    @Override
+    @Config.Expose("address")
+    public void init() {
+    }
+
+    @In
+    void in(Value value) {
         address.ifPresent(destination -> tell(destination, value));
     }
-    
+
     // PXJ-END:body
-    
 }

--- a/praxiscore-components/src/main/java/org/praxislive/core/components/CoreVariable.java
+++ b/praxiscore-components/src/main/java/org/praxislive/core/components/CoreVariable.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright 2019 Neil C Smith.
+ * Copyright 2025 Neil C Smith.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3 only, as
@@ -36,23 +36,27 @@ import static org.praxislive.code.userapi.Constants.*;
 
 /**
  *
- * 
+ *
  */
 @GenerateTemplate(CoreVariable.TEMPLATE_PATH)
 public class CoreVariable extends CoreCodeDelegate {
-    
+
     final static String TEMPLATE_PATH = "resources/variable.pxj";
-
     // PXJ-BEGIN:body
-    
-    @P(1) @Config.Preferred Property value;
 
-    @Out(1) Output out;
-        
-    @T(1) void trigger() {
+    @P Property value;
+
+    @Out Output out;
+
+    @Override
+    @Config.Expose("value")
+    public void init() {
+    }
+
+    @T
+    void trigger() {
         out.send(value.get());
     }
-    
+
     // PXJ-END:body
-    
 }

--- a/praxiscore-hub-net/src/main/java/org/praxislive/hub/net/MessageDispatcher.java
+++ b/praxiscore-hub-net/src/main/java/org/praxislive/hub/net/MessageDispatcher.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright 2023 Neil C Smith.
+ * Copyright 2025 Neil C Smith.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3 only, as
@@ -166,7 +166,8 @@ abstract class MessageDispatcher {
     private void handleReplyMessage(SocketAddress sender, Message.Reply msg) throws Exception {
         SentCallInfo info = sentCalls.remove(msg.matchID());
         if (info == null) {
-            throw new IllegalArgumentException("Unexpected response");
+            LOG.log(Level.DEBUG, "Unexpected message response\n{0}", msg);
+            return;
         }
         Call call = info.localCall().reply(msg.args());
         dispatchCall(call);
@@ -175,7 +176,8 @@ abstract class MessageDispatcher {
     private void handleErrorMessage(SocketAddress sender, Message.Error msg) throws Exception {
         SentCallInfo info = sentCalls.remove(msg.matchID());
         if (info == null) {
-            throw new IllegalArgumentException("Unexpected response");
+            LOG.log(Level.DEBUG, "Unexpected message response\n{0}", msg);
+            return;
         }
         Call call = info.localCall().error(msg.args());
         dispatchCall(call);

--- a/praxiscore-video-code/src/main/java/org/praxislive/video/code/ImageLoader.java
+++ b/praxiscore-video-code/src/main/java/org/praxislive/video/code/ImageLoader.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright 2018 Neil C Smith.
+ * Copyright 2025 Neil C Smith.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3 only, as
@@ -38,10 +38,10 @@ import org.praxislive.video.render.utils.BufferedImageSurface;
 
 /**
  *
- * 
+ *
  */
 class ImageLoader extends ResourceProperty.Loader<PImage> {
-    
+
     private final static ImageLoader INSTANCE = new ImageLoader();
 
     private ImageLoader() {
@@ -57,8 +57,8 @@ class ImageLoader extends ResourceProperty.Loader<PImage> {
     static ImageLoader getDefault() {
         return INSTANCE;
     }
-    
-    private static class PImageImpl extends PImage {
+
+    private static class PImageImpl extends PImage implements SurfaceBackedImage {
 
         private final Surface surface;
 
@@ -68,7 +68,7 @@ class ImageLoader extends ResourceProperty.Loader<PImage> {
         }
 
         @Override
-        protected Surface getSurface() {
+        public Surface getSurface() {
             return surface;
         }
 

--- a/praxiscore-video-code/src/main/java/org/praxislive/video/code/OffScreenGraphicsInfo.java
+++ b/praxiscore-video-code/src/main/java/org/praxislive/video/code/OffScreenGraphicsInfo.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright 2023 Neil C Smith.
+ * Copyright 2025 Neil C Smith.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3 only, as
@@ -30,7 +30,7 @@ import org.praxislive.video.render.Surface;
 
 /**
  *
- * 
+ *
  */
 class OffScreenGraphicsInfo {
 
@@ -133,13 +133,33 @@ class OffScreenGraphicsInfo {
     }
 
     private int calculateWidth(Surface output) {
-        int w = width < 1 ? output.getWidth() : width;
+        int w;
+        if (width < 1) {
+            if (height < 1) {
+                w = output.getWidth();
+            } else {
+                double ratio = (double) height / output.getHeight();
+                w = (int) (ratio * output.getWidth() + 0.5);
+            }
+        } else {
+            w = width;
+        }
         w *= scaleWidth;
         return Math.max(w, 1);
     }
 
     private int calculateHeight(Surface output) {
-        int h = height < 1 ? output.getHeight() : height;
+        int h;
+        if (height < 1) {
+            if (width < 1) {
+                h = output.getHeight();
+            } else {
+                double ratio = (double) width / output.getWidth();
+                h = (int) (ratio * output.getHeight() + 0.5);
+            }
+        } else {
+            h = height;
+        }
         h *= scaleHeight;
         return Math.max(h, 1);
     }
@@ -175,7 +195,7 @@ class OffScreenGraphicsInfo {
                 format);
     }
 
-    private static class OffScreenGraphics extends PGraphics {
+    private static class OffScreenGraphics extends PGraphics implements SurfaceBackedImage {
 
         private final Surface surface;
 
@@ -185,7 +205,7 @@ class OffScreenGraphicsInfo {
         }
 
         @Override
-        protected Surface getSurface() {
+        public Surface getSurface() {
             return surface;
         }
 

--- a/praxiscore-video-code/src/main/java/org/praxislive/video/code/SurfaceBackedImage.java
+++ b/praxiscore-video-code/src/main/java/org/praxislive/video/code/SurfaceBackedImage.java
@@ -1,0 +1,31 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright 2025 Neil C Smith.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License version 3 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * version 3 for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License version 3
+ * along with this work; if not, see http://www.gnu.org/licenses/
+ *
+ *
+ * Please visit https://www.praxislive.org if you need additional information or
+ * have any questions.
+ *
+ */
+package org.praxislive.video.code;
+
+import org.praxislive.video.render.Surface;
+
+interface SurfaceBackedImage {
+
+    public Surface getSurface();
+
+}

--- a/praxiscore-video-code/src/main/java/org/praxislive/video/code/VideoCodeContext.java
+++ b/praxiscore-video-code/src/main/java/org/praxislive/video/code/VideoCodeContext.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright 2023 Neil C Smith.
+ * Copyright 2025 Neil C Smith.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3 only, as
@@ -255,7 +255,7 @@ public class VideoCodeContext extends CodeContext<VideoCodeDelegate> {
 
     }
 
-    private static class SurfacePGraphics extends PGraphics {
+    private static class SurfacePGraphics extends PGraphics implements SurfaceBackedImage {
 
         private final Surface surface;
 
@@ -265,13 +265,13 @@ public class VideoCodeContext extends CodeContext<VideoCodeDelegate> {
         }
 
         @Override
-        protected Surface getSurface() {
+        public Surface getSurface() {
             return surface;
         }
 
     }
 
-    private static class SurfacePImage extends PImage {
+    private static class SurfacePImage extends PImage implements SurfaceBackedImage {
 
         private final Surface surface;
 
@@ -281,7 +281,7 @@ public class VideoCodeContext extends CodeContext<VideoCodeDelegate> {
         }
 
         @Override
-        protected Surface getSurface() {
+        public Surface getSurface() {
             return surface;
         }
 

--- a/praxiscore-video-code/src/main/java/org/praxislive/video/code/VideoCodeDelegate.java
+++ b/praxiscore-video-code/src/main/java/org/praxislive/video/code/VideoCodeDelegate.java
@@ -102,14 +102,12 @@ public class VideoCodeDelegate extends DefaultCodeDelegate {
      *
      * @param mimeType mime type of image format
      * @param image image to write
-     * @param width output width
-     * @param height output height
+     * @param scale output scale (1.0 == normal size)
      * @return async bytes
      */
-    public final Async<PBytes> write(String mimeType, PImage image,
-            double width, double height) {
+    public final Async<PBytes> write(String mimeType, PImage image, double scale) {
         return context.writeImpl(mimeType, image,
-                (int) (width + 0.5), (int) (height + 0.5));
+                (int) (image.width * scale), (int) (image.height * scale));
     }
 
     // Start generated PGraphics 

--- a/praxiscore-video-pgl-code/src/main/java/org/praxislive/video/pgl/code/P2DOffScreenGraphicsInfo.java
+++ b/praxiscore-video-pgl-code/src/main/java/org/praxislive/video/pgl/code/P2DOffScreenGraphicsInfo.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright 2018 Neil C Smith.
+ * Copyright 2025 Neil C Smith.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3 only, as
@@ -33,7 +33,7 @@ import processing.core.PStyle;
 
 /**
  *
- * 
+ *
  */
 class P2DOffScreenGraphicsInfo {
 
@@ -83,7 +83,7 @@ class P2DOffScreenGraphicsInfo {
             }
             surface = output.createSurface(calculateWidth(output), calculateHeight(output), true);
         }
-        
+
         PGLGraphics p2d = surface.getGraphics();
         if (graphics == null || graphics.width != p2d.width || graphics.height != p2d.height) {
             graphics = new PGraphics(p2d.width, p2d.height);
@@ -130,13 +130,33 @@ class P2DOffScreenGraphicsInfo {
     }
 
     private int calculateWidth(Surface output) {
-        int w = width < 1 ? output.getWidth() : width;
+        int w;
+        if (width < 1) {
+            if (height < 1) {
+                w = output.getWidth();
+            } else {
+                double ratio = (double) height / output.getHeight();
+                w = (int) (ratio * output.getWidth() + 0.5);
+            }
+        } else {
+            w = width;
+        }
         w *= scaleWidth;
         return Math.max(w, 1);
     }
 
     private int calculateHeight(Surface output) {
-        int h = height < 1 ? output.getHeight() : height;
+        int h;
+        if (height < 1) {
+            if (width < 1) {
+                h = output.getHeight();
+            } else {
+                double ratio = (double) width / output.getWidth();
+                h = (int) (ratio * output.getHeight() + 0.5);
+            }
+        } else {
+            h = height;
+        }
         h *= scaleHeight;
         return Math.max(h, 1);
     }
@@ -166,7 +186,7 @@ class P2DOffScreenGraphicsInfo {
         private int matrixStackDepth;
         private PStyle styles;
         private PGLGraphics pgl;
-        
+
         private PGraphics(int width, int height) {
             super(width, height);
         }

--- a/praxiscore-video-pgl-code/src/main/java/org/praxislive/video/pgl/code/P3DOffScreenGraphicsInfo.java
+++ b/praxiscore-video-pgl-code/src/main/java/org/praxislive/video/pgl/code/P3DOffScreenGraphicsInfo.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright 2018 Neil C Smith.
+ * Copyright 2025 Neil C Smith.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3 only, as
@@ -32,7 +32,7 @@ import org.praxislive.video.render.Surface;
 
 /**
  *
- * 
+ *
  */
 class P3DOffScreenGraphicsInfo {
 
@@ -122,16 +122,35 @@ class P3DOffScreenGraphicsInfo {
     }
 
     private int calculateWidth(Surface output) {
-        int w = width < 1 ? output.getWidth() : width;
+        int w;
+        if (width < 1) {
+            if (height < 1) {
+                w = output.getWidth();
+            } else {
+                double ratio = (double) height / output.getHeight();
+                w = (int) (ratio * output.getWidth() + 0.5);
+            }
+        } else {
+            w = width;
+        }
         w *= scaleWidth;
         return Math.max(w, 1);
     }
 
     private int calculateHeight(Surface output) {
-        int h = height < 1 ? output.getHeight() : height;
+        int h;
+        if (height < 1) {
+            if (width < 1) {
+                h = output.getHeight();
+            } else {
+                double ratio = (double) width / output.getWidth();
+                h = (int) (ratio * output.getHeight() + 0.5);
+            }
+        } else {
+            h = height;
+        }
         h *= scaleHeight;
         return Math.max(h, 1);
-
     }
 
     static P3DOffScreenGraphicsInfo create(Field field) {

--- a/testsuite/tests/core/async-functions/data1.pxr
+++ b/testsuite/tests/core/async-functions/data1.pxr
@@ -287,7 +287,7 @@ import org.praxislive.core.services.SystemManagerService;
                     log(ERROR, "<FAIL> expected " + uppercase + " but got " + result);
                     error.send();
                 } else {
-                    log(INFO, "Test 1 : OK");
+                    log(INFO, "Test 7 : OK");
                     ok.send();
                 }
             }
@@ -305,6 +305,48 @@ import org.praxislive.core.services.SystemManagerService;
 
 }
   }
+  @ ./test8 core:custom {
+    .meta [map graph.x 433 graph.y 555 graph.comment "Call async watch function"]
+    .code {
+    String text = "TEST";
+    int count = 4;
+
+    @Out(1) Output ok;
+    @Out(2) Output error;
+
+    @Persist Async<Call> response;
+
+    @Override
+    public void update() {
+        if (response != null && response.done()) {
+            if (response.failed()) {
+                log(ERROR, "<FAIL> " + response.error());
+                error.send();
+            } else {
+                String result = response.result().args().get(0).toString();
+                String expected = text.repeat(count);
+                if (!result.equals(expected)) {
+                    log(ERROR, "<FAIL> expected " + expected + " but got " + result);
+                    error.send();
+                } else {
+                    log(INFO, "Test 8 : OK");
+                    ok.send();
+                }
+            }
+            response = null;
+        }
+    }
+
+    @T(1)
+    void test() {
+        log(INFO, "Test 8 : Calling /data2/functions.watch-repeat");
+        response = ask(ControlAddress.of("/data2/functions.watch-repeat"),
+                List.of(PMap.of("text", text, "count", count)));
+    }
+
+
+}
+  }
   ~ ./test1!error ./exit!exit-fail
   ~ ./test2!error ./exit!exit-fail
   ~ ./test1!ok ./test2!test
@@ -317,6 +359,8 @@ import org.praxislive.core.services.SystemManagerService;
   ~ ./test5!ok ./test6!test
   ~ ./test6!error ./exit!exit-fail
   ~ ./test6!ok ./test7!test
-  ~ ./test7!ok ./exit!exit-ok
   ~ ./test7!error ./exit!exit-fail
+  ~ ./test7!ok ./test8!test
+  ~ ./test8!ok ./exit!exit-ok
+  ~ ./test8!error ./exit!exit-fail
 }

--- a/testsuite/tests/core/async-functions/data2.pxr
+++ b/testsuite/tests/core/async-functions/data2.pxr
@@ -17,6 +17,15 @@
         throw new UnsupportedOperationException();
     }
     
+    @FN.Watch(mime = "text/plain")
+    Async<String> watchRepeat(PMap query) {
+        return async(query, q -> {
+            int count = q.getInt("count", 0);
+            String text = q.getString("text", "???");
+            return text.repeat(count);
+        });
+    }
+
 }
   }
   @ ./start-trigger core:start-trigger {


### PR DESCRIPTION
Add initial support for watch functions.  A watch function is a function control for accessing data about a component.  They are somewhat similar to read-only properties, but for data that should only be calculated on demand, and perhaps asynchronously.  Watch functions have a mime type and other metadata, and may support an optional query map as input to control the returned data.

This PR also adds support for video components to write surfaces to PNG data, and adds watches for the input ports of composite and xfader, as well as the image of still.