### PR TITLE
Fix Ref issues

### DIFF
--- a/praxiscore-code/src/main/java/org/praxislive/code/CodeContext.java
+++ b/praxiscore-code/src/main/java/org/praxislive/code/CodeContext.java
@@ -213,15 +213,16 @@ public abstract class CodeContext<D extends CodeDelegate> {
         if (execState == source.getState()) {
             return;
         }
-        if (full && source.getState() == ExecutionContext.State.IDLE
-                && execState != ExecutionContext.State.NEW) {
+        ExecutionContext.State oldExecState = execState;
+        execState = source.getState();
+        if (full && execState == ExecutionContext.State.IDLE
+                && oldExecState != ExecutionContext.State.NEW) {
             onStop();
             descriptors.forEach(Descriptor::onStop);
         }
         onReset();
         descriptors.forEach(Descriptor::onReset);
         update(source.getTime());
-        execState = source.getState();
         if (execState == ExecutionContext.State.ACTIVE) {
             descriptors.forEach(Descriptor::onInit);
             if (full) {

--- a/praxiscore-code/src/main/java/org/praxislive/code/RefImpl.java
+++ b/praxiscore-code/src/main/java/org/praxislive/code/RefImpl.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright 2023 Neil C Smith.
+ * Copyright 2025 Neil C Smith.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3 only, as
@@ -145,9 +145,6 @@ class RefImpl<T> extends Ref<T> {
             } catch (Exception ex) {
                 context.getLog().log(LogLevel.ERROR, ex);
             }
-
-            checkPublishing();
-            checkSubscription();
 
         }
 


### PR DESCRIPTION
Fix subscribed Refs being marked as uninitialized after code change. Leave the publish and subscribe handling to the `init()` method, after `reset()` has cleared the Ref.

Protect against potential stack overflow in handling state changes.  Cache the changed state value earlier. Calls into `handleStateChange()` might trigger handlers that call into `checkActive()` leading to a potential stack overflow.