### PR TITLE
Support shared code in subgraphs

### DIFF
--- a/praxiscore-audio-components/src/main/java/org/praxislive/audio/impl/components/DefaultAudioRoot.java
+++ b/praxiscore-audio-components/src/main/java/org/praxislive/audio/impl/components/DefaultAudioRoot.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  * 
- * Copyright 2024 Neil C Smith.
+ * Copyright 2025 Neil C Smith.
  * 
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3 only, as
@@ -41,6 +41,7 @@ import org.praxislive.base.AbstractProperty;
 import org.praxislive.base.AbstractRootContainer;
 import org.praxislive.base.DefaultExecutionContext;
 import org.praxislive.code.SharedCodeProperty;
+import org.praxislive.code.SharedCodeProtocol;
 import org.praxislive.core.ArgumentInfo;
 import org.praxislive.core.Call;
 import org.praxislive.core.Clock;
@@ -103,7 +104,9 @@ public class DefaultAudioRoot extends AbstractRootContainer {
 
     public DefaultAudioRoot() {
         sharedCode = new SharedCodeProperty(this, this::handleLog);
-        registerControl("shared-code", sharedCode);
+        registerControl(SharedCodeProtocol.SHARED_CODE, sharedCode);
+        registerControl(SharedCodeProtocol.SHARED_CODE_ADD, sharedCode.getAddControl());
+        registerControl(SharedCodeProtocol.SHARED_CODE_MERGE, sharedCode.getMergeControl());
 
         extractLibraryInfo();
 
@@ -128,7 +131,7 @@ public class DefaultAudioRoot extends AbstractRootContainer {
                 .merge(ContainerProtocol.API_INFO)
                 .control(ContainerProtocol.SUPPORTED_TYPES, ContainerProtocol.SUPPORTED_TYPES_INFO)
                 .merge(StartableProtocol.API_INFO)
-                .control("shared-code", SharedCodeProperty.INFO)
+                .merge(SharedCodeProtocol.API_INFO)
                 .control("sample-rate", c -> c.property()
                     .defaultValue(PNumber.of(DEFAULT_SAMPLERATE))
                     .input(a -> a.number()

--- a/praxiscore-code/src/main/java/org/praxislive/code/CodeRoot.java
+++ b/praxiscore-code/src/main/java/org/praxislive/code/CodeRoot.java
@@ -56,8 +56,6 @@ import org.praxislive.core.types.PMap;
  */
 public class CodeRoot<D extends CodeRootDelegate> extends CodeComponent<D> implements Root {
 
-    private static final String SHARED_CODE = "shared-code";
-
     private final RootImpl root;
     private final Control startControl;
     private final Control stopControl;
@@ -252,6 +250,8 @@ public class CodeRoot<D extends CodeRootDelegate> extends CodeComponent<D> imple
             addControl(createMetaControl(getInternalIndex()));
             addControl(createMetaMergeControl(getInternalIndex()));
             addControl(sharedCodeControl());
+            addControl(sharedCodeAddControl());
+            addControl(sharedCodeMergeControl());
             addControl(createCodeControl(getInternalIndex()));
             addControl(new AsyncHandler(getInternalIndex()));
             addControl(new WrapperControlDescriptor(StartableProtocol.START,
@@ -281,6 +281,7 @@ public class CodeRoot<D extends CodeRootDelegate> extends CodeComponent<D> imple
             super.buildBaseComponentInfo(cmp);
             cmp.merge(StartableProtocol.API_INFO);
             cmp.merge(SerializableProtocol.API_INFO);
+            cmp.merge(SharedCodeProtocol.API_INFO);
         }
 
         @Override
@@ -316,18 +317,36 @@ public class CodeRoot<D extends CodeRootDelegate> extends CodeComponent<D> imple
         }
 
         private ControlDescriptor<?> sharedCodeControl() {
-            return new WrapperControlDescriptor(SHARED_CODE,
-                    SharedCodeProperty.INFO,
+            return new WrapperControlDescriptor(SharedCodeProtocol.SHARED_CODE,
+                    SharedCodeProtocol.SHARED_CODE_INFO,
                     getInternalIndex(),
                     ctxt -> ctxt instanceof Context c ? c.getComponent().sharedCode : null,
                     (ctxt, writer) -> {
                         if (ctxt instanceof Context c) {
                             PMap value = c.getComponent().sharedCode.getValue();
                             if (!value.isEmpty()) {
-                                writer.writeProperty(SHARED_CODE, value);
+                                writer.writeProperty(SharedCodeProtocol.SHARED_CODE, value);
                             }
                         }
                     }
+            );
+        }
+
+        private ControlDescriptor<?> sharedCodeAddControl() {
+            return new WrapperControlDescriptor(SharedCodeProtocol.SHARED_CODE_ADD,
+                    SharedCodeProtocol.SHARED_CODE_ADD_INFO,
+                    getInternalIndex(),
+                    ctxt -> ctxt instanceof Context c
+                            ? c.getComponent().sharedCode.getAddControl() : null
+            );
+        }
+
+        private ControlDescriptor<?> sharedCodeMergeControl() {
+            return new WrapperControlDescriptor(SharedCodeProtocol.SHARED_CODE_MERGE,
+                    SharedCodeProtocol.SHARED_CODE_MERGE_INFO,
+                    getInternalIndex(),
+                    ctxt -> ctxt instanceof Context c
+                            ? c.getComponent().sharedCode.getMergeControl() : null
             );
         }
 

--- a/praxiscore-code/src/main/java/org/praxislive/code/SharedCodeProtocol.java
+++ b/praxiscore-code/src/main/java/org/praxislive/code/SharedCodeProtocol.java
@@ -1,0 +1,106 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright 2025 Neil C Smith.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License version 3 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * version 3 for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License version 3
+ * along with this work; if not, see http://www.gnu.org/licenses/
+ *
+ *
+ * Please visit https://www.praxislive.org if you need additional information or
+ * have any questions.
+ */
+package org.praxislive.code;
+
+import java.util.stream.Stream;
+import org.praxislive.core.ComponentInfo;
+import org.praxislive.core.ControlInfo;
+import org.praxislive.core.Info;
+import org.praxislive.core.Protocol;
+import org.praxislive.core.types.PMap;
+
+/**
+ * Protocol for a container that provides shared code that can be used by code
+ * in child components. The {@code shared-code} property wraps a map of full
+ * class names to Java source code. The {@code shared-code-add} and
+ * {@code shared-code-merge} functions allow for updating the property with a
+ * partial map.
+ */
+public class SharedCodeProtocol implements Protocol {
+
+    /**
+     * Standard control ID for shared code property.
+     */
+    public static final String SHARED_CODE = "shared-code";
+    /**
+     * Standard control ID for shared code add function.
+     */
+    public static final String SHARED_CODE_ADD = "shared-code-add";
+
+    /**
+     * Standard control ID for shared code merge function.
+     */
+    public static final String SHARED_CODE_MERGE = "shared-code-merge";
+
+    /**
+     * Control info for the shared code property control.
+     */
+    public static final ControlInfo SHARED_CODE_INFO
+            = Info.control(c -> c.property()
+            .input(PMap.class)
+            .defaultValue(PMap.EMPTY));
+
+    /**
+     * Control info for the shared code add control. The input map is merged
+     * with the existing shared code using the rules of {@link PMap#IF_ABSENT}.
+     */
+    public static final ControlInfo SHARED_CODE_ADD_INFO
+            = Info.control(c -> c.function()
+            .inputs(a -> a.type(PMap.class))
+            .outputs(a -> a.type(PMap.class)));
+
+    /**
+     * Control info for the shared code merge control. The input map is merged
+     * with the existing shared code using the rules of {@link PMap#REPLACE}.
+     */
+    public static final ControlInfo SHARED_CODE_MERGE_INFO
+            = Info.control(c -> c.function()
+            .inputs(a -> a.type(PMap.class))
+            .outputs(a -> a.type(PMap.class)));
+
+    public static final ComponentInfo API_INFO = Info.component(cmp -> cmp
+            .protocol(SharedCodeProtocol.class)
+            .control(SHARED_CODE, SHARED_CODE_INFO)
+            .control(SHARED_CODE_ADD, SHARED_CODE_ADD_INFO)
+            .control(SHARED_CODE_MERGE, SHARED_CODE_MERGE_INFO)
+    );
+
+    @Override
+    public Stream<String> controls() {
+        return Stream.of(SHARED_CODE, SHARED_CODE_ADD, SHARED_CODE_MERGE);
+    }
+
+    @Override
+    public ControlInfo getControlInfo(String control) {
+        return switch (control) {
+            case SHARED_CODE ->
+                SHARED_CODE_INFO;
+            case SHARED_CODE_ADD ->
+                SHARED_CODE_ADD_INFO;
+            case SHARED_CODE_MERGE ->
+                SHARED_CODE_MERGE_INFO;
+            default ->
+                throw new IllegalArgumentException(control);
+        };
+    }
+
+}

--- a/praxiscore-code/src/main/java/org/praxislive/code/internal/CodeProtocolsProvider.java
+++ b/praxiscore-code/src/main/java/org/praxislive/code/internal/CodeProtocolsProvider.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright 2024 Neil C Smith.
+ * Copyright 2025 Neil C Smith.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3 only, as
@@ -27,6 +27,7 @@ import org.praxislive.code.CodeCompilerService;
 import org.praxislive.code.CodeComponentFactoryService;
 import org.praxislive.code.CodeContextFactoryService;
 import org.praxislive.code.CodeRootFactoryService;
+import org.praxislive.code.SharedCodeProtocol;
 import org.praxislive.code.SharedCodeService;
 import org.praxislive.core.Protocol;
 
@@ -39,6 +40,7 @@ public class CodeProtocolsProvider implements Protocol.TypeProvider {
     @Override
     public Stream<Protocol.Type> types() {
         return Stream.of(
+                new Protocol.Type<>(SharedCodeProtocol.class),
                 new Protocol.Type<>(CodeChildFactoryService.class),
                 new Protocol.Type<>(CodeCompilerService.class),
                 new Protocol.Type<>(CodeComponentFactoryService.class),

--- a/praxiscore-video-components/src/main/java/org/praxislive/video/impl/components/DefaultVideoRoot.java
+++ b/praxiscore-video-components/src/main/java/org/praxislive/video/impl/components/DefaultVideoRoot.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  * 
- * Copyright 2024 Neil C Smith.
+ * Copyright 2025 Neil C Smith.
  * 
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3 only, as
@@ -27,6 +27,7 @@ import java.util.concurrent.TimeUnit;
 import org.praxislive.base.AbstractProperty;
 import org.praxislive.base.AbstractRootContainer;
 import org.praxislive.code.SharedCodeProperty;
+import org.praxislive.code.SharedCodeProtocol;
 import org.praxislive.core.Call;
 import org.praxislive.core.ComponentInfo;
 import org.praxislive.core.ComponentType;
@@ -92,7 +93,9 @@ public class DefaultVideoRoot extends AbstractRootContainer {
     public DefaultVideoRoot() {
 
         sharedCode = new SharedCodeProperty(this, this::handleLog);
-        registerControl("shared-code", sharedCode);
+        registerControl(SharedCodeProtocol.SHARED_CODE, sharedCode);
+        registerControl(SharedCodeProtocol.SHARED_CODE_ADD, sharedCode.getAddControl());
+        registerControl(SharedCodeProtocol.SHARED_CODE_MERGE, sharedCode.getMergeControl());
 
         registerControl("renderer", new RendererProperty());
         registerControl("width", new WidthProperty());
@@ -105,7 +108,7 @@ public class DefaultVideoRoot extends AbstractRootContainer {
                 .merge(ContainerProtocol.API_INFO)
                 .control(ContainerProtocol.SUPPORTED_TYPES, ContainerProtocol.SUPPORTED_TYPES_INFO)
                 .merge(StartableProtocol.API_INFO)
-                .control("shared-code", SharedCodeProperty.INFO)
+                .merge(SharedCodeProtocol.API_INFO)
                 .control("renderer", c -> c.property()
                     .defaultValue(PString.of(SOFTWARE))
                     .input(a -> a.string().allowed(RENDERERS.toArray(String[]::new))))


### PR DESCRIPTION
Various changes to support shared code in subgraphs.

Add try / catch script command. Used to support introspection of possibly missing property.

Add shared code protocol, and additional merge (replace) and add (if-empty) controls.