### PR TITLE
Update Netty and JLine, and suppress warnings on Java 24.

### DIFF
--- a/praxiscore-bin/src/assembly/_dist.xml
+++ b/praxiscore-bin/src/assembly/_dist.xml
@@ -19,5 +19,10 @@
       <outputDirectory>bin</outputDirectory>
       <lineEnding>dos</lineEnding>
     </file>
+    <file>
+      <source>src/assembly/etc/java.cfg</source>
+      <outputDirectory>etc</outputDirectory>
+      <lineEnding>unix</lineEnding>
+    </file>
   </files>
 </component>

--- a/praxiscore-bin/src/assembly/bin/praxis
+++ b/praxiscore-bin/src/assembly/bin/praxis
@@ -111,8 +111,7 @@ if $cygwin; then
   [ -n "$REPO" ] && REPO=`cygpath --path --windows "$REPO"`
 fi
 
-exec "$JAVACMD" $JAVA_OPTS  \
-  --add-modules=ALL-DEFAULT \
+exec "$JAVACMD" "@$BASEDIR/etc/java.cfg" $JAVA_OPTS \
   -p "$REPO" \
   -Dapp.name="praxis" \
   -Dapp.pid="$$" \

--- a/praxiscore-bin/src/assembly/bin/praxis.cmd
+++ b/praxiscore-bin/src/assembly/bin/praxis.cmd
@@ -68,18 +68,18 @@ for %%i in ("%~dp0..") do set "BASEDIR=%%~fi"
 set REPO=
 
 
-if exist %BASEDIR%\jdk set JAVA_HOME=%BASEDIR%\jdk
+if exist "%BASEDIR%\jdk" set JAVA_HOME="%BASEDIR%\jdk"
 
-if not "%JAVA_HOME%"=="" set JAVACMD=%JAVA_HOME%\bin\java
+if not "%JAVA_HOME%"=="" set JAVACMD="%JAVA_HOME%\bin\java"
 
 if "%JAVACMD%"=="" set JAVACMD=java
 
-if "%REPO%"=="" set REPO=%BASEDIR%\mods
+if "%REPO%"=="" set REPO="%BASEDIR%\mods"
 
 @REM Reaching here means variables are defined and arguments have been captured
 :endInit
 
-"%JAVACMD%" %JAVA_OPTS% --add-modules=ALL-DEFAULT -p "%REPO%" -Dapp.name="praxis" -Dapp.repo="%REPO%" -Dapp.home="%BASEDIR%" -Dbasedir="%BASEDIR%" -m "org.praxislive.bin/org.praxislive.bin.Main" %CMD_LINE_ARGS%
+"%JAVACMD%" "@%BASEDIR%\etc\java.cfg" %JAVA_OPTS% -p "%REPO%" -Dapp.name="praxis" -Dapp.repo="%REPO%" -Dapp.home="%BASEDIR%" -Dbasedir="%BASEDIR%" -m "org.praxislive.bin/org.praxislive.bin.Main" %CMD_LINE_ARGS%
 if %ERRORLEVEL% NEQ 0 goto error
 goto end
 

--- a/praxiscore-bin/src/assembly/etc/java.cfg
+++ b/praxiscore-bin/src/assembly/etc/java.cfg
@@ -1,0 +1,3 @@
+-XX:+IgnoreUnrecognizedVMOptions
+--add-modules=ALL-DEFAULT
+--enable-native-access=com.sun.jna,org.jline.nativ,org.lwjgl,org.lwjgl.opengl

--- a/praxiscore-bin/src/assembly/etc/java.cfg
+++ b/praxiscore-bin/src/assembly/etc/java.cfg
@@ -1,3 +1,4 @@
 -XX:+IgnoreUnrecognizedVMOptions
 --add-modules=ALL-DEFAULT
 --enable-native-access=com.sun.jna,org.jline.nativ,org.lwjgl,org.lwjgl.opengl
+--sun-misc-unsafe-memory-access=allow

--- a/praxiscore-hub-net/pom.xml
+++ b/praxiscore-hub-net/pom.xml
@@ -24,27 +24,27 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-common</artifactId>
-      <version>4.1.118.Final</version>
+      <version>4.2.1.Final</version>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-buffer</artifactId>
-      <version>4.1.118.Final</version>
+      <version>4.2.1.Final</version>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-transport</artifactId>
-      <version>4.1.118.Final</version>
+      <version>4.2.1.Final</version>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-codec</artifactId>
-      <version>4.1.118.Final</version>
+      <version>4.2.1.Final</version>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-codec-http</artifactId>
-      <version>4.1.118.Final</version>
+      <version>4.2.1.Final</version>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/praxiscore-launcher-jline/pom.xml
+++ b/praxiscore-launcher-jline/pom.xml
@@ -29,17 +29,12 @@
     <dependency>
       <groupId>org.jline</groupId>
       <artifactId>jline-terminal</artifactId>
-      <version>3.29.0</version>
-    </dependency>
-    <dependency>
-      <groupId>org.jline</groupId>
-      <artifactId>jline-terminal-jna</artifactId>
-      <version>3.29.0</version>
+      <version>3.30.3</version>
     </dependency>
     <dependency>
       <groupId>org.jline</groupId>
       <artifactId>jline-reader</artifactId>
-      <version>3.29.0</version>
+      <version>3.30.3</version>
     </dependency>
   </dependencies>
     

--- a/praxiscore-launcher-jline/src/main/java/module-info.java
+++ b/praxiscore-launcher-jline/src/main/java/module-info.java
@@ -5,9 +5,7 @@ module org.praxislive.launcher.jline {
     requires org.praxislive.base;
     requires org.praxislive.launcher;
     requires org.jline.terminal;
-    requires org.jline.terminal.jna;
     requires org.jline.reader;
-    requires com.sun.jna;
 
     provides org.praxislive.launcher.TerminalIOProvider with
             org.praxislive.launcher.jline.JLineTerminalIOProvider;

--- a/praxiscore-launcher-jline/src/main/java/org/praxislive/launcher/jline/TerminalImpl.java
+++ b/praxiscore-launcher-jline/src/main/java/org/praxislive/launcher/jline/TerminalImpl.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright 2024 Neil C Smith.
+ * Copyright 2025 Neil C Smith.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3 only, as
@@ -70,7 +70,7 @@ class TerminalImpl {
             try {
                 terminal = TerminalBuilder
                         .builder()
-                        .jna(true)
+                        .jni(true)
                         .dumb(true)
                         .build();
                 reader = LineReaderBuilder.builder()


### PR DESCRIPTION
Upgrade Netty to 4.2.1 and JLine to 3.30.3.

Move JVM launcher arguments to an argfile at `etc/java.cfg`.  Update child launcher to use script rather than direct Java invocation.

Suppress native and unsafe warnings on Java 24.