### PR TITLE
Add Property.Sync for binding to another property

### DIFF
--- a/praxiscore-base/src/main/java/org/praxislive/base/Binding.java
+++ b/praxiscore-base/src/main/java/org/praxislive/base/Binding.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  * 
- * Copyright 2019 Neil C Smith.
+ * Copyright 2025 Neil C Smith.
  * 
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3 only, as
@@ -33,10 +33,28 @@ import org.praxislive.core.Value;
 public abstract class Binding {
 
     /**
-     * Possible rates for syncing.
+     * Rates for perdiodic syncing. Except for {@code None}, how these values
+     * translate to a sync period in milliseconds is governed by the
+     * {@link BindingContext} implementation.
      */
     public static enum SyncRate {
-        None, Low, Medium, High;
+
+        /**
+         * No periodic sync.
+         */
+        None,
+        /**
+         * Sync at a low periodic rate.
+         */
+        Low,
+        /**
+         * Sync at a medium periodic rate.
+         */
+        Medium,
+        /**
+         * Sync at a high periodic rate.
+         */
+        High;
     }
 
     /**
@@ -53,14 +71,36 @@ public abstract class Binding {
      */
     public abstract List<Value> getValues();
 
+    /**
+     * Method called by adaptors to send a call to the bound control.
+     *
+     * @param adaptor sending adaptor
+     * @param args argument list
+     */
     protected abstract void send(Adaptor adaptor, List<Value> args);
 
+    /**
+     * Method called by adaptors on configuration changes such as activity or
+     * sync rate to allow bindings to recalculate their configuration.
+     *
+     * @param adaptor changed adaptor
+     */
     protected abstract void updateAdaptorConfiguration(Adaptor adaptor);
 
+    /**
+     * Method for Binding implementations to connect to an adaptor.
+     *
+     * @param adaptor adaptor to connect
+     */
     protected void bind(Adaptor adaptor) {
         adaptor.setBinding(this);
     }
 
+    /**
+     * Method for Binding implementations to disconnect from an adaptor.
+     *
+     * @param adaptor adaptor to disconnect
+     */
     protected void unbind(Adaptor adaptor) {
         adaptor.setBinding(null);
     }
@@ -75,6 +115,9 @@ public abstract class Binding {
         private boolean active;
 
         private void setBinding(Binding binding) {
+            if (this.binding != null && binding != null) {
+                throw new IllegalStateException("Binding adaptor already connected");
+            }
             this.binding = binding;
             updateBindingConfiguration();
         }
@@ -158,7 +201,7 @@ public abstract class Binding {
          * will normally send quiet calls in such cases as the values are
          * expected to be superseded before a reply is received.
          *
-         * @return value currently being adjuested
+         * @return value currently being adjusted
          */
         protected boolean getValueIsAdjusting() {
             return false;

--- a/praxiscore-base/src/main/java/org/praxislive/base/BindingContext.java
+++ b/praxiscore-base/src/main/java/org/praxislive/base/BindingContext.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  * 
- * Copyright 2019 Neil C Smith.
+ * Copyright 2025 Neil C Smith.
  * 
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3 only, as
@@ -31,7 +31,8 @@ import org.praxislive.core.ControlAddress;
 public interface BindingContext {
 
     /**
-     * Bind adaptor to the binding for the given ControlAddress.
+     * Bind adaptor to the binding for the given ControlAddress. An adaptor may
+     * only be bound to one address at a time.
      *
      * @param address control to bind to
      * @param adaptor to send / receive values

--- a/praxiscore-base/src/main/java/org/praxislive/base/BindingContextControl.java
+++ b/praxiscore-base/src/main/java/org/praxislive/base/BindingContextControl.java
@@ -153,7 +153,7 @@ public class BindingContextControl implements Control, BindingContext {
         private BindingImpl(ControlAddress boundAddress) {
             adaptors = new ArrayList<>();
             this.boundAddress = boundAddress;
-            values = Collections.emptyList();
+            values = List.of();
             if (ComponentProtocol.INFO.equals(boundAddress.controlID())) {
                 infoAdaptor = null;
                 bindingInfo = ComponentProtocol.INFO_INFO;
@@ -196,15 +196,12 @@ public class BindingContextControl implements Control, BindingContext {
             activeCall = call;
             activeAdaptor = adaptor;
             if (isWritableProperty) {
-                List<Value> oldValues = values;
                 values = call.args();
-                if (!Objects.equals(oldValues, values)) {
-                    adaptors.forEach(ad -> {
-                        if (ad != adaptor) {
-                            ad.update();
-                        }
-                    });
-                }
+                adaptors.forEach(ad -> {
+                    if (ad != adaptor) {
+                        ad.update();
+                    }
+                });
             }
         }
 
@@ -295,6 +292,9 @@ public class BindingContextControl implements Control, BindingContext {
                 isSyncable = false;
                 isWritableProperty = false;
             }
+            if (!isSyncable) {
+                values = List.of();
+            }
             bindingInfo = info;
             for (Adaptor a : adaptors) {
                 a.updateBindingConfiguration();
@@ -317,11 +317,8 @@ public class BindingContextControl implements Control, BindingContext {
                     activeAdaptor = null;
                 }
                 if (isSyncable) {
-                    List<Value> oldValues = values;
                     values = call.args();
-                    if (!Objects.equals(oldValues, values)) {
-                        adaptors.forEach(Adaptor::update);
-                    }
+                    adaptors.forEach(Adaptor::update);
                 }
                 activeCall = null;
             }

--- a/praxiscore-base/src/main/java/org/praxislive/base/BindingContextControl.java
+++ b/praxiscore-base/src/main/java/org/praxislive/base/BindingContextControl.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  * 
- * Copyright 2024 Neil C Smith.
+ * Copyright 2025 Neil C Smith.
  * 
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3 only, as
@@ -28,7 +28,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.PriorityQueue;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.TimeUnit;
 import org.praxislive.core.Call;
 import org.praxislive.core.ComponentAddress;
@@ -60,7 +61,7 @@ public class BindingContextControl implements Control, BindingContext {
     private final PacketRouter router;
     private final ControlAddress controlAddress;
     private final Map<ControlAddress, BindingImpl> bindings;
-    private final BindingSyncQueue syncQueue;
+    private final Set<BindingImpl> syncing;
 
     /**
      * Create a BindingContextControl.
@@ -79,7 +80,7 @@ public class BindingContextControl implements Control, BindingContext {
         this.context = Objects.requireNonNull(context);
         this.router = Objects.requireNonNull(router);
         bindings = new LinkedHashMap<>();
-        syncQueue = new BindingSyncQueue(context.getTime());
+        syncing = new CopyOnWriteArraySet<>();
         context.addClockListener(this::tick);
     }
 
@@ -87,7 +88,11 @@ public class BindingContextControl implements Control, BindingContext {
     public void bind(ControlAddress address, Binding.Adaptor adaptor) {
         Objects.requireNonNull(address);
         Objects.requireNonNull(adaptor);
-        BindingImpl binding = bindings.computeIfAbsent(address, BindingImpl::new);
+        BindingImpl binding = bindings.get(address);
+        if (binding == null) {
+            binding = new BindingImpl(address);
+            bindings.put(address, binding);
+        }
         binding.addAdaptor(adaptor);
     }
 
@@ -98,6 +103,7 @@ public class BindingContextControl implements Control, BindingContext {
             binding.removeAdaptor(adaptor);
             if (binding.isEmpty()) {
                 bindings.remove(address);
+                binding.dispose();
             }
         }
     }
@@ -121,75 +127,23 @@ public class BindingContextControl implements Control, BindingContext {
         } else {
             throw new UnsupportedOperationException();
         }
-
     }
 
     private void tick(ExecutionContext source) {
-        syncQueue.setTime(source.getTime());
-        BindingImpl b;
-        while ((b = syncQueue.poll()) != null) {
-            b.processSync();
-        }
-    }
-
-    private static class BindingSyncQueue {
-
-        private final PriorityQueue<BindingSyncElement> q;
-        private long time;
-
-        private BindingSyncQueue(long time) {
-            q = new PriorityQueue<>();
-            this.time = time;
-        }
-
-        private void setTime(long time) {
-            this.time = time;
-        }
-
-        private void add(BindingImpl binding, long time) {
-            q.add(new BindingSyncElement(binding, time));
-        }
-
-        private BindingImpl poll() {
-            if (!q.isEmpty() && q.peek().time - time <= 0) {
-                var element = q.poll();
-                return element != null ? element.binding : null;
-            }
-            return null;
-        }
-
-    }
-
-    private static class BindingSyncElement
-            implements Comparable<BindingSyncElement> {
-
-        private final BindingImpl binding;
-        private final long time;
-
-        private BindingSyncElement(BindingImpl binding, long time) {
-            this.binding = binding;
-            this.time = time;
-        }
-
-        @Override
-        public int compareTo(BindingSyncElement o) {
-            long timeDiff = time - o.time;
-            if (timeDiff == 0) {
-                return hashCode() - o.hashCode();
-            }
-            return timeDiff < 0 ? -1 : 1;
-        }
-
+        long time = source.getTime();
+        syncing.forEach(b -> b.processSync(time));
     }
 
     private class BindingImpl extends Binding {
 
         private final List<Binding.Adaptor> adaptors;
         private final ControlAddress boundAddress;
+        private final InfoAdaptor infoAdaptor;
+
         private ControlInfo bindingInfo;
+        private long nextSyncTime;
         private long syncPeriod;
 
-        private int infoMatchID;
         private boolean isSyncable;
         private boolean isWritableProperty;
         private Call activeCall;
@@ -200,32 +154,32 @@ public class BindingContextControl implements Control, BindingContext {
             adaptors = new ArrayList<>();
             this.boundAddress = boundAddress;
             values = Collections.emptyList();
-        }
-
-        private void addAdaptor(Adaptor adaptor) {
-            if (adaptor == null) {
-                throw new NullPointerException();
-            }
-            if (adaptors.contains(adaptor)) {
-                return;
-            }
-            adaptors.add(adaptor);
-            bind(adaptor);
-            updateAdaptorConfiguration(adaptor); // duplicate functionality
-            if (bindingInfo == null) {
-                sendInfoRequest();
+            if (ComponentProtocol.INFO.equals(boundAddress.controlID())) {
+                infoAdaptor = null;
+                bindingInfo = ComponentProtocol.INFO_INFO;
+                isSyncable = true;
+            } else {
+                ControlAddress infoAddress = boundAddress.component()
+                        .control(ComponentProtocol.INFO);
+                infoAdaptor = new InfoAdaptor();
+                infoAdaptor.setSyncRate(SyncRate.Low);
+                BindingContextControl.this.bind(infoAddress, infoAdaptor);
             }
         }
 
-        private void removeAdaptor(Adaptor adaptor) {
-            if (adaptors.remove(adaptor)) {
-                unbind(adaptor);
-            }
-            updateSyncConfiguration();
+        @Override
+        public Optional<ControlInfo> getControlInfo() {
+            return Optional.ofNullable(bindingInfo);
         }
 
-        private boolean isEmpty() {
-            return adaptors.isEmpty();
+        @Override
+        public List<Value> getValues() {
+            return values;
+        }
+
+        @Override
+        public String toString() {
+            return "BindingImpl : " + boundAddress;
         }
 
         @Override
@@ -256,30 +210,61 @@ public class BindingContextControl implements Control, BindingContext {
             updateSyncConfiguration();
         }
 
+        private void addAdaptor(Adaptor adaptor) {
+            if (adaptor == null) {
+                throw new NullPointerException();
+            }
+            if (adaptors.contains(adaptor)) {
+                return;
+            }
+            adaptors.add(adaptor);
+            bind(adaptor);
+            updateAdaptorConfiguration(adaptor); // duplicate functionality
+        }
+
+        private void removeAdaptor(Adaptor adaptor) {
+            if (adaptors.remove(adaptor)) {
+                unbind(adaptor);
+            }
+            updateSyncConfiguration();
+        }
+
+        private void dispose() {
+            if (infoAdaptor != null) {
+                ControlAddress infoAddress = boundAddress.component()
+                        .control(ComponentProtocol.INFO);
+                BindingContextControl.this.unbind(infoAddress, infoAdaptor);
+            }
+        }
+
+        private boolean isEmpty() {
+            return adaptors.isEmpty();
+        }
+
         private void updateSyncConfiguration() {
-            if (isSyncable) {
-                LOG.log(System.Logger.Level.DEBUG, "Updating sync configuration on {0}", boundAddress);
-                boolean active = false;
-                SyncRate highRate = SyncRate.None;
-                for (Adaptor a : adaptors) {
-                    if (a.isActive()) {
-                        active = true;
-                        SyncRate aRate = a.getSyncRate();
-                        if (aRate.compareTo(highRate) > 0) {
-                            highRate = aRate;
-                        }
+            LOG.log(System.Logger.Level.DEBUG, "Updating sync configuration on {0}", boundAddress);
+            boolean active = false;
+            SyncRate highRate = SyncRate.None;
+            for (Adaptor a : adaptors) {
+                if (a.isActive()) {
+                    active = true;
+                    SyncRate aRate = a.getSyncRate();
+                    if (aRate.compareTo(highRate) > 0) {
+                        highRate = aRate;
                     }
                 }
-                if (!active || highRate == SyncRate.None) {
-                    syncPeriod = 0;
-                } else {
-                    syncPeriod = delayForRate(highRate);
-                    processSync();
-                }
-            } else {
-                syncPeriod = 0;
             }
-
+            if (infoAdaptor != null) {
+                infoAdaptor.setActive(active);
+            }
+            if (!isSyncable || !active || highRate == SyncRate.None) {
+                syncPeriod = 0;
+                syncing.remove(this);
+            } else {
+                syncPeriod = delayForRate(highRate);
+                nextSyncTime = 0;
+                syncing.add(this);
+            }
         }
 
         private long delayForRate(SyncRate rate) {
@@ -295,44 +280,19 @@ public class BindingContextControl implements Control, BindingContext {
             };
         }
 
-        private void sendInfoRequest() {
-            ControlAddress toAddress = ControlAddress.of(boundAddress.component(),
-                    ComponentProtocol.INFO);
-            Call call = Call.create(toAddress, controlAddress, context.getTime());
-            infoMatchID = call.matchID();
-            router.route(call);
-        }
-
-        private void processInfo(Call call) {
-            if (call.matchID() == infoMatchID) {
-                List<Value> args = call.args();
-                if (!args.isEmpty()) {
-                    ComponentInfo compInfo = null;
-                    try {
-                        compInfo = ComponentInfo.from(args.get(0)).get();
-                        // @TODO on null?
-                        bindingInfo = compInfo.controlInfo(boundAddress.controlID());
-                        ControlInfo.Type type = bindingInfo.controlType();
-                        isSyncable = (type == ControlInfo.Type.Property)
-                                || (type == ControlInfo.Type.ReadOnlyProperty);
-                        isWritableProperty = (type == ControlInfo.Type.Property);
-                    } catch (Exception ex) {
-                        isSyncable = false;
-                        bindingInfo = null;
-                        LOG.log(System.Logger.Level.WARNING, "" + call + "\n" + compInfo, ex);
-                    }
-                    for (Adaptor a : adaptors) {
-                        a.updateBindingConfiguration();
-                    }
-                    updateSyncConfiguration();
-                }
+        private void updateInfo(ControlInfo info) {
+            if (Objects.equals(bindingInfo, info)) {
+                return;
             }
-        }
-
-        private void processInfoError(Call call) {
-            isSyncable = false;
-            bindingInfo = null;
-            LOG.log(System.Logger.Level.WARNING, "Couldn't get info for {0}", boundAddress);
+            if (info != null) {
+                ControlInfo.Type type = info.controlType();
+                isSyncable = (type == ControlInfo.Type.Property || type == ControlInfo.Type.ReadOnlyProperty);
+                isWritableProperty = (type == ControlInfo.Type.Property);
+            } else {
+                isSyncable = false;
+                isWritableProperty = false;
+            }
+            bindingInfo = info;
             for (Adaptor a : adaptors) {
                 a.updateBindingConfiguration();
             }
@@ -360,8 +320,6 @@ public class BindingContextControl implements Control, BindingContext {
                     }
                 }
                 activeCall = null;
-            } else if (call.matchID() == infoMatchID) {
-                processInfo(call);
             }
         }
 
@@ -374,30 +332,27 @@ public class BindingContextControl implements Control, BindingContext {
                     LOG.log(System.Logger.Level.DEBUG, "Error on sync call - {0}", call.from());
                 }
                 activeCall = null;
-            } else if (call.matchID() == infoMatchID) {
-                processInfoError(call);
             }
         }
 
-        private void processSync() {
-            long now = context.getTime();
-            if (syncPeriod > 0) {
-                syncQueue.add(this, now + syncPeriod);
+        private void processSync(long time) {
+            if (nextSyncTime == 0 || nextSyncTime - time < 0) {
+                nextSyncTime = time + syncPeriod;
             }
 
             if (activeCall != null) {
                 if (activeCall.isReplyRequired()) {
-                    if ((now - activeCall.time()) < INVOKE_TIMEOUT) {
+                    if ((time - activeCall.time()) < INVOKE_TIMEOUT) {
                         return;
                     }
                 } else {
-                    if ((now - activeCall.time()) < QUIET_TIMEOUT) {
+                    if ((time - activeCall.time()) < QUIET_TIMEOUT) {
                         return;
                     }
                 }
             }
             if (isSyncable) {
-                Call call = Call.create(boundAddress, controlAddress, now);
+                Call call = Call.create(boundAddress, controlAddress, time);
                 router.route(call);
                 activeCall = call;
                 activeAdaptor = null;
@@ -405,14 +360,18 @@ public class BindingContextControl implements Control, BindingContext {
 
         }
 
-        @Override
-        public Optional<ControlInfo> getControlInfo() {
-            return Optional.ofNullable(bindingInfo);
-        }
+        private class InfoAdaptor extends Binding.Adaptor {
 
-        @Override
-        public List<Value> getValues() {
-            return values;
+            @Override
+            protected void update() {
+                List<Value> args = getBinding().getValues();
+                if (!args.isEmpty()) {
+                    updateInfo(ComponentInfo.from(args.get(0))
+                            .map(cmp -> cmp.controlInfo(boundAddress.controlID()))
+                            .orElse(null));
+                }
+            }
+
         }
 
     }

--- a/praxiscore-base/src/main/java/org/praxislive/base/BindingContextControl.java
+++ b/praxiscore-base/src/main/java/org/praxislive/base/BindingContextControl.java
@@ -196,11 +196,14 @@ public class BindingContextControl implements Control, BindingContext {
             activeCall = call;
             activeAdaptor = adaptor;
             if (isWritableProperty) {
+                List<Value> oldValues = values;
                 values = call.args();
-                for (Adaptor ad : adaptors) {
-                    if (ad != adaptor) {
-                        ad.update();
-                    }
+                if (!Objects.equals(oldValues, values)) {
+                    adaptors.forEach(ad -> {
+                        if (ad != adaptor) {
+                            ad.update();
+                        }
+                    });
                 }
             }
         }
@@ -314,9 +317,10 @@ public class BindingContextControl implements Control, BindingContext {
                     activeAdaptor = null;
                 }
                 if (isSyncable) {
+                    List<Value> oldValues = values;
                     values = call.args();
-                    for (Adaptor a : adaptors) {
-                        a.update();
+                    if (!Objects.equals(oldValues, values)) {
+                        adaptors.forEach(Adaptor::update);
                     }
                 }
                 activeCall = null;

--- a/praxiscore-code/src/main/java/org/praxislive/code/PropertyControl.java
+++ b/praxiscore-code/src/main/java/org/praxislive/code/PropertyControl.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright 2023 Neil C Smith.
+ * Copyright 2025 Neil C Smith.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3 only, as
@@ -329,6 +329,11 @@ public class PropertyControl extends Property implements Control {
 
         public PortDescriptor createPortDescriptor() {
             return new PortDescImpl(id(), index(), control);
+        }
+
+        @Override
+        public void dispose() {
+            control.reset();
         }
 
         @Override

--- a/praxiscore-code/src/main/java/org/praxislive/code/WrapperControlDescriptor.java
+++ b/praxiscore-code/src/main/java/org/praxislive/code/WrapperControlDescriptor.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright 2024 Neil C Smith.
+ * Copyright 2025 Neil C Smith.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3 only, as
@@ -53,7 +53,7 @@ final class WrapperControlDescriptor extends ControlDescriptor<WrapperControlDes
             Function<CodeContext<?>, Control> attacher,
             BiConsumer<CodeContext<?>, TreeWriter> writer) {
         super(WrapperControlDescriptor.class, id, Category.Internal, index);
-        this.info = Objects.requireNonNull(info);
+        this.info = info;
         this.attacher = Objects.requireNonNull(attacher);
         this.writer = writer;
     }


### PR DESCRIPTION
Add `Property.Sync` for binding a property to the value of another property.

Updates `BindingContextControl` with info syncing and replaced sync queue, and adds to root types.
Adds `BindingContext.PropertyAdaptor` as alternative to extending the abstract adaptor.
Improves documentation.