### PR TITLE
Remove -Xlint:all from default compiler task options

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        java: [ '21' ]
+        java: [ '21', '25' ]
         os: [ 'ubuntu-24.04', 'windows-2022', 'macos-15' ]
       fail-fast: false
 

--- a/praxiscore-code-services/src/main/java/org/praxislive/code/services/DefaultCompilerService.java
+++ b/praxiscore-code-services/src/main/java/org/praxislive/code/services/DefaultCompilerService.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright 2023 Neil C Smith.
+ * Copyright 2025 Neil C Smith.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3 only, as
@@ -197,7 +197,7 @@ public class DefaultCompilerService extends AbstractRoot
 
             LogBuilder log = new LogBuilder(getLogLevel(map));
 
-            List<String> options = List.of("-Xlint:all", "-proc:none",
+            List<String> options = List.of("-proc:none",
                     "--release", String.valueOf(release.ordinal()),
                     "--add-modules", "ALL-MODULE-PATH",
                     "--module-path", defModulepath,

--- a/praxiscore-code-services/src/main/java/org/praxislive/code/services/tools/CompilerTask.java
+++ b/praxiscore-code-services/src/main/java/org/praxislive/code/services/tools/CompilerTask.java
@@ -1,6 +1,6 @@
 
 /*
- * Copyright 2021 Neil C Smith
+ * Copyright 2025 Neil C Smith
  *
  * Forked from Janino - An embedded Java[TM] compiler
  *
@@ -65,7 +65,7 @@ public class CompilerTask {
         this.sources = Map.copyOf(sources);
         existingClasses = Map.of();
         messageHandler = DEFAULT_MESSAGE_HANDLER;
-        options = List.of("-Xlint:all");
+        options = List.of("");
     }
 
     public CompilerTask existingClasses(Map<String, Supplier<InputStream>> existing) {


### PR DESCRIPTION
Remove `-Xlint:all` from the default options passed in to the compiler task.

Also updates the test matrix to test on JDK 25 as well as JDK 21.