### PR TITLE
Ensure previous property is reset during attachment.

### DIFF
--- a/praxiscore-code/src/main/java/org/praxislive/code/userapi/Property.java
+++ b/praxiscore-code/src/main/java/org/praxislive/code/userapi/Property.java
@@ -62,13 +62,16 @@ public abstract class Property {
 
     protected void attach(CodeContext<?> context, Property previous) {
         this.context = context;
-        if (previous != null && previous.animator != null) {
-            animator = previous.animator;
-            previous.animator = null;
-            animator.attach(this);
-            if (animator.isAnimating()) {
-                previous.stopClock();
-                this.startClock();
+        if (previous != null) {
+            previous.reset();
+            if (previous.animator != null) {
+                animator = previous.animator;
+                previous.animator = null;
+                animator.attach(this);
+                if (animator.isAnimating()) {
+                    previous.stopClock();
+                    this.startClock();
+                }
             }
         }
     }


### PR DESCRIPTION
Fix issue in sync where old property needs to be reset on attachment to ensure sync is unbound.