### PR TITLE
Fix issue with OnChange and OnError not working in shared code.

### DIFF
--- a/praxiscore-code/src/main/java/org/praxislive/code/PropertyControl.java
+++ b/praxiscore-code/src/main/java/org/praxislive/code/PropertyControl.java
@@ -470,15 +470,16 @@ public class PropertyControl extends Property implements Control {
 
         private static Method extractMethod(CodeConnector<?> connector, String methodName) {
             try {
-                Method m = connector.getDelegate().getClass().getDeclaredMethod(methodName);
-                m.setAccessible(true);
-                return m;
-            } catch (NoSuchMethodException ex) {
-
+                Method method = connector.methods().stream()
+                        .filter(m -> m.getName().equals(methodName) && m.getParameterCount() == 0)
+                        .findFirst().orElse(null);
+                if (method != null) {
+                    method.setAccessible(true);
+                }
+                return method;
             } catch (Exception ex) {
-
+                return null;
             }
-            return null;
         }
 
     }


### PR DESCRIPTION
Fix #103 where the OnChange and OnError annotations do not work for methods in shared delegate superclasses, because the descriptor only looks up declared methods in the delegate class itself.

Added API methods in CodeConnector to expose the fields and methods extracted from the delegate up to, but not including, the factory base class.

Update PropertyControl to search the connector method list for the methods to use for OnChange or OnError.