### PR TITLE
Echo command should return single argument as existing value type.

### DIFF
--- a/praxiscore-script/src/main/java/org/praxislive/script/commands/BaseCmds.java
+++ b/praxiscore-script/src/main/java/org/praxislive/script/commands/BaseCmds.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright 2025 Neil C Smith.
+ * Copyright 2026 Neil C Smith.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3 only, as
@@ -113,10 +113,16 @@ class BaseCmds {
 
         @Override
         public List<Value> process(Env context, Namespace namespace, List<Value> args) throws Exception {
-            return List.of(PString.of(
-                    args.stream()
-                            .map(Value::toString)
-                            .collect(Collectors.joining())));
+            if (args.isEmpty()) {
+                return List.of(PString.EMPTY);
+            } else if (args.size() == 1) {
+                return List.of(args.get(0));
+            } else {
+                return List.of(PString.of(
+                        args.stream()
+                                .map(Value::toString)
+                                .collect(Collectors.joining())));
+            }
         }
 
     }


### PR DESCRIPTION
If the echo command is passed a single argument, return it as is rather than converting to a String.

Fixes #123