### PR TITLE
Add HubProxy model API with internal and external implementations.

### DIFF
--- a/praxiscore-api/src/main/java/org/praxislive/core/HubProxy.java
+++ b/praxiscore-api/src/main/java/org/praxislive/core/HubProxy.java
@@ -1,0 +1,420 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright 2026 Neil C Smith.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License version 3 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * version 3 for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License version 3
+ * along with this work; if not, see http://www.gnu.org/licenses/
+ * 
+ *
+ * Please visit https://www.praxislive.org if you need additional information or
+ * have any questions.
+ */
+package org.praxislive.core;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
+import java.util.stream.Stream;
+import org.praxislive.core.protocols.ContainerProtocol;
+import org.praxislive.core.protocols.StartableProtocol;
+import org.praxislive.core.types.PArray;
+
+/**
+ * A model API for proxying and interacting with components running inside a
+ * {@link RootHub}. Implementations may run internally or externally to the
+ * modelled hub using a common interface.
+ */
+public interface HubProxy {
+
+    /**
+     * Get a component proxy for the provided address. The proxied component
+     * does not have to exist when the proxy is created. Component proxies are
+     * cached by the implementation, and a single instance will be returned for
+     * each distinct address until the HubProxy is cleared or disposed.
+     *
+     * @param address component address
+     * @return component proxy
+     */
+    public Component component(ComponentAddress address);
+
+    /**
+     * Get a component proxy for the provided address. The proxied component
+     * does not have to exist when the proxy is created. Component proxies are
+     * cached by the implementation, and a single instance will be returned for
+     * each distinct address until the HubProxy is cleared or disposed.
+     * <p>
+     * @implNote The default implementation of this method calls
+     * {@link #component(org.praxislive.core.ComponentAddress)} with the result
+     * of {@link ComponentAddress#of(java.lang.String)}.
+     *
+     * @param address component address
+     * @return component proxy
+     */
+    public default Component component(String address) {
+        return component(ComponentAddress.of(address));
+    }
+
+    /**
+     * Get a root proxy for the provided root ID. The proxied root does not have
+     * to exist when the proxy is created. Root proxies are cached by the
+     * implementation, and a single instance will be returned for each distinct
+     * address until the HubProxy is cleared or disposed.
+     * <p>
+     * The hub implementation will ensure that this method and a call to
+     * {@link #component(org.praxislive.core.ComponentAddress)} with the same
+     * root address will return identical instances.
+     *
+     * @param id root ID
+     * @return root proxy
+     */
+    public Root root(String id);
+
+    /**
+     * Get all the cached component proxies created by this hub proxy. The
+     * returned set is an immutable snapshot.
+     *
+     * @return component proxies
+     */
+    public Set<Component> proxies();
+
+    /**
+     * Get a list of root IDs in the proxied hub. The returned list is an
+     * immutable snapshot.
+     *
+     * @return root IDs
+     */
+    public List<String> roots();
+
+    /**
+     * Stop all component proxies syncing. Equivalent to calling
+     * {@link Component#unsync()} on all proxy components from this hub proxy.
+     *
+     * @return this for chaining
+     */
+    public HubProxy unsyncAll();
+
+    /**
+     * Dispose of all proxy components created by this hub proxy. This will
+     * clear the cache. New proxies should be obtained from
+     * {@link #component(org.praxislive.core.ComponentAddress)} or
+     * {@link #root(java.lang.String)} if required.
+     *
+     * @return this for chaining
+     */
+    public HubProxy clear();
+
+    /**
+     * Dispose of this hub proxy. No component proxy or function on this proxy
+     * should be used after disposal.
+     * <p>
+     * @implNote The default implementation of this method just calls
+     * {@link #clear()}.
+     */
+    public default void dispose() {
+        clear();
+    }
+
+    /**
+     * Evaluate the provided Pcl script within the proxied hub and return a
+     * future of the result. This is an optional behaviour. The default
+     * implementation returns a failed future wrapping
+     * {@link UnsupportedOperationException}.
+     *
+     * @param script Pcl script to evaluate
+     * @return future result of script
+     */
+    public default Future<List<Value>> eval(String script) {
+        return CompletableFuture.failedFuture(new UnsupportedOperationException());
+    }
+
+    /**
+     * A proxy for a {@link org.praxislive.core.Component} in the hub. Obtain
+     * from the hub proxy using
+     * {@link #component(org.praxislive.core.ComponentAddress)}.
+     * <p>
+     * A component can sync by polling the real component for property values.
+     * For efficiency, only sync properties when the values are required.
+     */
+    public static interface Component {
+
+        /**
+         * The hub proxy that this component belongs to.
+         *
+         * @return hub proxy
+         */
+        public HubProxy hub();
+
+        /**
+         * Set a property value on the proxied component.
+         *
+         * @param id property control ID
+         * @param value new property value
+         * @return this for chaining
+         */
+        public Component set(String id, Value value);
+
+        /**
+         * Set a property value on the proxied component.
+         * <p>
+         * @implNote the default implementation converts the value using
+         * {@link Value#ofObject(java.lang.Object)} and then calls
+         * {@link #set(java.lang.String, org.praxislive.core.Value)}.
+         *
+         * @param id property control ID
+         * @param value new property value
+         * @return this for chaining
+         */
+        public default Component set(String id, Object value) {
+            return set(id, Value.ofObject(value));
+        }
+
+        /**
+         * Get a property value on the proxied component. If the component is
+         * not syncing, the value may not be available or may be stale. This
+         * method returns an immediate result and does not directly poll the
+         * component.
+         *
+         * @param id property control ID
+         * @return optional property value
+         */
+        public Optional<Value> get(String id);
+
+        /**
+         * Get the address of the proxied component.
+         *
+         * @return proxied address
+         */
+        public ComponentAddress address();
+
+        /**
+         * Get the ID of the proxied component.
+         * <p>
+         * @implNote the default method returns
+         * {@link ComponentAddress#componentID()} on the {@link #address()}.
+         * @return
+         */
+        public default String id() {
+            return address().componentID();
+        }
+
+        /**
+         * Get the {@link ComponentInfo} for the proxied component. If the
+         * component doesn't exist or the proxy isn't syncing, the info might
+         * not exist or be stale. Use {@link #validate()} to directly poll the
+         * component.
+         *
+         * @return optional component info
+         */
+        public Optional<ComponentInfo> info();
+
+        /**
+         * Start the proxy polling the component to sync properties. The rate of
+         * polling is undefined.
+         *
+         * @return this for chaining
+         */
+        public Component sync();
+
+        /**
+         * Start the proxy polling the component to sync the provided
+         * properties. This method may be more efficient if only a selection of
+         * property values are required.
+         * <p>
+         * @implNote the default implementation just calls {@link #sync()}
+         *
+         * @param properties set of properties to sync
+         * @return this for chaining
+         */
+        public default Component sync(Set<String> properties) {
+            return sync();
+        }
+
+        /**
+         * Stop the proxy polling the component.
+         *
+         * @return this for chaining
+         */
+        public Component unsync();
+
+        /**
+         * Validate the proxy by polling the component for its latest info. The
+         * future will return an empty optional when the component does not
+         * exist or cannot be proxied.
+         *
+         * @return future info
+         */
+        public Future<Optional<ComponentInfo>> validate();
+
+        /**
+         * Check whether the proxy is valid.
+         * <p>
+         * @implNote the default implementation checks whether {@link #info()}
+         * is present
+         *
+         * @return true if valid
+         */
+        public default boolean isValid() {
+            return info().isPresent();
+        }
+
+        /**
+         * Check whether the proxied component is a container. If the component
+         * isn't valid or the info is stale, the result might not be accurate.
+         * <p>
+         * @implNote the default implementation checks if the info exists and
+         * has the {@link ContainerProtocol}.
+         *
+         * @return true if container
+         */
+        public default boolean isContainer() {
+            return info()
+                    .map(info -> info.hasProtocol(ContainerProtocol.class))
+                    .orElse(false);
+        }
+
+        /**
+         * Get the proxy for the parent of the proxied component.
+         * <p>
+         * @implNote the default implementation calls
+         * {@link ComponentAddress#parent()} on the component address and
+         * returns the proxy for that address from the hub proxy.
+         * @return parent proxy
+         */
+        public default Component parent() {
+            return hub().component(address().parent());
+        }
+
+        /**
+         * Get the proxy for a descendent of the proxied component by resolving
+         * the provided path against the component address. A direct child can
+         * be obtained by passing in its ID.
+         * <p>
+         * @implNote the default implementation calls
+         * {@link ComponentAddress#resolve(java.lang.String)} on the component
+         * address and returns the proxy for that address from the hub proxy.
+         *
+         * @param path child ID or relative path to descendent
+         * @return descendent component proxy
+         */
+        public default Component resolve(String path) {
+            return hub().component(address().resolve(path));
+        }
+
+        /**
+         * Get a list of the IDs of the proxied component's children. The list
+         * is an immutable snapshot. If the proxy is not syncing then this
+         * result might be stale.
+         * <p>
+         * @implNote the default implementation checks whether the proxy is a
+         * container, and if so returns a list extracted from the
+         * {@link ContainerProtocol#CHILDREN} property.
+         *
+         * @return child IDs or empty list
+         */
+        public default List<String> children() {
+            if (isContainer()) {
+                return get(ContainerProtocol.CHILDREN)
+                        .flatMap(PArray::from)
+                        .map(a -> a.asListOf(String.class))
+                        .orElseGet(() -> List.of());
+            } else {
+                return List.of();
+            }
+        }
+
+        /**
+         * Call a control on the proxied component.
+         * <p>
+         * @implNote the default implementation of this method creates a
+         * one-line script based on the component address and passes it to
+         * {@link #eval(java.lang.String)}.
+         *
+         * @param control ID of control to call
+         * @param args call arguments
+         * @return future result of the call
+         */
+        public default Future<List<Value>> call(String control, List<Value> args) {
+            ControlAddress ctrlAd = ControlAddress.of(address(), control);
+            if (args.isEmpty()) {
+                return hub().eval(ctrlAd.toString());
+            } else {
+                return hub().eval(ctrlAd + " " + PArray.of(args));
+            }
+        }
+
+        /**
+         * Call a control on the proxied component.
+         * <p>
+         * @implNote the default implementation of this method creates a list of
+         * values from the args using {@link Value#ofObject(java.lang.Object)}
+         * and then calls {@link #call(java.lang.String, java.util.List)}.
+         *
+         * @param control ID of control to call
+         * @param args call arguments
+         * @return future result of the call
+         */
+        public default Future<List<Value>> call(String control, Object... args) {
+            return call(control, Stream.of(args).map(Value::ofObject).toList());
+        }
+
+        /**
+         * Dispose the proxy. After disposal the proxy should not be used. A
+         * subsequent call to
+         * {@link #component(org.praxislive.core.ComponentAddress)} with this
+         * proxy's address will return a new proxy.
+         */
+        public void dispose();
+
+    }
+
+    /**
+     * A proxy for a {@link org.praxislive.core.Root} in the hub. Obtain from
+     * the hub proxy using {@link #root(java.lang.String)}.
+     */
+    public static interface Root extends Component {
+
+        /**
+         * The parent of a Root is always {@code null}.
+         *
+         * @return null
+         */
+        @Override
+        public default Component parent() {
+            return null;
+        }
+
+        /**
+         * Convenience method to call {@link StartableProtocol#START} on the
+         * root.
+         *
+         * @return result of call
+         */
+        public default Future<?> start() {
+            return call(StartableProtocol.START, List.of());
+        }
+
+        /**
+         * Convenience method to call {@link StartableProtocol#STOP} on the
+         * root.
+         *
+         * @return result of call
+         */
+        public default Future<?> stop() {
+            return call(StartableProtocol.STOP, List.of());
+        }
+
+    }
+
+}

--- a/praxiscore-base/src/main/java/org/praxislive/base/Binding.java
+++ b/praxiscore-base/src/main/java/org/praxislive/base/Binding.java
@@ -246,6 +246,12 @@ public abstract class Binding {
         protected void update() {
         }
 
+        /**
+         * Optional hook called whenever a sync call fails.
+         */
+        protected void syncError() {
+        }
+
     }
 
     /**
@@ -264,6 +270,7 @@ public abstract class Binding {
         private Consumer<Value> onChangeHandler;
         private Consumer<PropertyAdaptor> onConfigChangeHandler;
         private Consumer<PropertyAdaptor> onSyncHandler;
+        private Consumer<PropertyAdaptor> onSyncErrorHandler;
         private Predicate<PropertyAdaptor> adjustingHandler;
 
         /**
@@ -326,14 +333,27 @@ public abstract class Binding {
         /**
          * Set a handler to be called whenever the binding has received a
          * successful sync response. The value may not have changed. Only one
-         * sync handler may be set at a time. A value of {code null} will remove
-         * the handler.
+         * sync handler may be set at a time. A value of {@code null} will
+         * remove the handler.
          *
          * @param onSyncHandler handler to be called on sync
          * @return this for chaining
          */
         public PropertyAdaptor onSync(Consumer<PropertyAdaptor> onSyncHandler) {
             this.onSyncHandler = onSyncHandler;
+            return this;
+        }
+
+        /**
+         * Set a handler to be called whenever the binding has received an
+         * unsuccessful sync response. Only one sync error handler may be set at
+         * a time. A value of {@code null} will remove the handler.
+         *
+         * @param onSyncErrorHandler handler to be called on sync error
+         * @return this for chaining
+         */
+        public PropertyAdaptor onSyncError(Consumer<PropertyAdaptor> onSyncErrorHandler) {
+            this.onSyncErrorHandler = onSyncErrorHandler;
             return this;
         }
 
@@ -376,6 +396,13 @@ public abstract class Binding {
             }
             if (onSyncHandler != null) {
                 onSyncHandler.accept(this);
+            }
+        }
+
+        @Override
+        protected void syncError() {
+            if (onSyncErrorHandler != null) {
+                onSyncErrorHandler.accept(this);
             }
         }
 

--- a/praxiscore-base/src/main/java/org/praxislive/base/BindingContextControl.java
+++ b/praxiscore-base/src/main/java/org/praxislive/base/BindingContextControl.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  * 
- * Copyright 2025 Neil C Smith.
+ * Copyright 2026 Neil C Smith.
  * 
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3 only, as
@@ -22,7 +22,6 @@
 package org.praxislive.base;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -164,6 +163,7 @@ public class BindingContextControl implements Control, BindingContext {
                 infoAdaptor = new InfoAdaptor();
                 infoAdaptor.setSyncRate(SyncRate.Low);
                 BindingContextControl.this.bind(infoAddress, infoAdaptor);
+                infoAdaptor.update();
             }
         }
 
@@ -264,6 +264,7 @@ public class BindingContextControl implements Control, BindingContext {
                 syncPeriod = delayForRate(highRate);
                 nextSyncTime = 0;
                 syncing.add(this);
+                processSync(context.getTime());
             }
         }
 
@@ -329,8 +330,8 @@ public class BindingContextControl implements Control, BindingContext {
                 if (activeAdaptor != null) {
                     activeAdaptor.onError(call.args());
                     activeAdaptor = null;
-                } else {
-                    LOG.log(System.Logger.Level.DEBUG, "Error on sync call - {0}", call.from());
+                } else if (activeCall.args().isEmpty()) {
+                    adaptors.forEach(Adaptor::syncError);
                 }
                 activeCall = null;
             }

--- a/praxiscore-code/src/main/java/org/praxislive/code/CodeConnector.java
+++ b/praxiscore-code/src/main/java/org/praxislive/code/CodeConnector.java
@@ -61,6 +61,7 @@ import org.praxislive.core.ArgumentInfo;
 import org.praxislive.core.ControlAddress;
 import org.praxislive.core.ComponentInfo;
 import org.praxislive.core.ComponentType;
+import org.praxislive.core.HubProxy;
 import org.praxislive.core.Info;
 import org.praxislive.core.Lookup;
 import org.praxislive.core.Value;
@@ -749,6 +750,16 @@ public abstract class CodeConnector<D extends CodeDelegate> {
             DataSink.Descriptor dsdsc = DataSink.Descriptor.create(this, field);
             if (dsdsc != null) {
                 addReference(dsdsc);
+                return true;
+            } else {
+                return false;
+            }
+        }
+
+        if (HubProxy.class.equals(field.getType())) {
+            HubProxyImpl.Descriptor hbdsc = HubProxyImpl.Descriptor.create(this, field);
+            if (hbdsc != null) {
+                addReference(hbdsc);
                 return true;
             } else {
                 return false;

--- a/praxiscore-code/src/main/java/org/praxislive/code/HubProxyImpl.java
+++ b/praxiscore-code/src/main/java/org/praxislive/code/HubProxyImpl.java
@@ -1,0 +1,462 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright 2026 Neil C Smith.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License version 3 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * version 3 for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License version 3
+ * along with this work; if not, see http://www.gnu.org/licenses/
+ *
+ *
+ * Please visit https://www.praxislive.org if you need additional information or
+ * have any questions.
+ */
+package org.praxislive.code;
+
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
+import org.praxislive.base.Binding;
+import org.praxislive.base.BindingContext;
+import org.praxislive.code.userapi.Async;
+import org.praxislive.core.ComponentAddress;
+import org.praxislive.core.ComponentInfo;
+import org.praxislive.core.ControlAddress;
+import org.praxislive.core.ControlInfo;
+import org.praxislive.core.HubProxy;
+import org.praxislive.core.ThreadContext;
+import org.praxislive.core.Value;
+import org.praxislive.core.protocols.ComponentProtocol;
+import org.praxislive.core.services.LogLevel;
+import org.praxislive.core.services.RootManagerService;
+import org.praxislive.core.services.ScriptService;
+import org.praxislive.core.services.Services;
+import org.praxislive.core.types.PArray;
+
+/**
+ *
+ */
+class HubProxyImpl implements HubProxy {
+
+    private final Map<ComponentAddress, ComponentProxy> components;
+    private final Binding.PropertyAdaptor rootsBinding;
+
+    private CodeContext<?> context;
+    private ThreadContext threadContext;
+    private BindingContext bindingContext;
+    private ControlAddress rootsAddress;
+
+    private HubProxyImpl() {
+        components = new HashMap<>();
+        rootsBinding = new Binding.PropertyAdaptor();
+        rootsBinding.setActive(true);
+        rootsBinding.setSyncRate(Binding.SyncRate.Low);
+    }
+
+    @Override
+    public Component component(ComponentAddress address) {
+        ComponentProxy cmp = components.computeIfAbsent(address,
+                ad -> {
+                    if (ad.depth() == 1) {
+                        return new RootProxy(this, ad);
+                    } else {
+                        return new ComponentProxy(this, ad);
+                    }
+                });
+        return cmp;
+    }
+
+    @Override
+    public Root root(String id) {
+        return (Root) component(ComponentAddress.of("/" + id));
+    }
+
+    @Override
+    public Set<Component> proxies() {
+        return Set.copyOf(components.values());
+    }
+
+    @Override
+    public List<String> roots() {
+        return rootsBinding.value()
+                .flatMap(PArray::from)
+                .map(a -> a.asListOf(String.class))
+                .orElseGet(() -> List.of());
+    }
+
+    @Override
+    public HubProxy unsyncAll() {
+        components.forEach((ad, cmp) -> cmp.unsync());
+        return this;
+    }
+
+    @Override
+    public HubProxy clear() {
+        components.forEach((ad, cmp) -> cmp.disposeImpl());
+        components.clear();
+        return this;
+    }
+
+    @Override
+    public void dispose() {
+        clear();
+    }
+
+    @Override
+    public Future<List<Value>> eval(String script) {
+        return new ThreadAwareFuture<>(
+                Async.toCompletableFuture(
+                        context.getDelegate()
+                                .ask(ScriptService.class, ScriptService.EVAL, script))
+                        .thenApply(call -> call.args()),
+                threadContext);
+    }
+
+    private void attach(CodeContext<?> context) {
+        this.context = context;
+        this.threadContext = context.getLookup().find(ThreadContext.class).orElse(null);
+        this.bindingContext = context.getLookup().find(BindingContext.class).orElse(null);
+        this.rootsAddress = context.getLookup().find(Services.class)
+                .flatMap(srvs -> srvs.locate(RootManagerService.class))
+                .map(ad -> ControlAddress.of(ad, RootManagerService.ROOTS))
+                .orElse(null);
+    }
+
+    private BindingContext bindings() {
+        return bindingContext;
+    }
+
+    private void onDescriptorDispose() {
+        onDescriptorReset();
+        context = null;
+        bindingContext = null;
+        threadContext = null;
+        rootsAddress = null;
+    }
+
+    private void onDescriptorInit() {
+        if (bindingContext != null && rootsAddress != null) {
+            bindingContext.bind(rootsAddress, rootsBinding);
+        }
+    }
+
+    private void onDescriptorReset() {
+        clear();
+        if (bindingContext != null && rootsAddress != null) {
+            bindingContext.unbind(rootsAddress, rootsBinding);
+        }
+    }
+
+    private void removeComponent(ComponentProxy cmp) {
+        components.remove(cmp.address(), cmp);
+    }
+
+    private ThreadContext threadContext() {
+        return threadContext;
+    }
+
+    private static class ComponentProxy implements HubProxy.Component {
+
+        private final HubProxyImpl hub;
+        private final ComponentAddress address;
+        private final Binding.PropertyAdaptor infoBinding;
+        private final Map<String, Binding.PropertyAdaptor> bindings;
+
+        private ComponentInfo info;
+        private Set<String> sync;
+        private CompletableFuture<Optional<ComponentInfo>> pendingInfo;
+
+        private ComponentProxy(HubProxyImpl hub, ComponentAddress address) {
+            this.hub = hub;
+            this.address = address;
+            infoBinding = new Binding.PropertyAdaptor();
+            bindings = new HashMap<>();
+            infoBinding.setSyncRate(Binding.SyncRate.Low);
+            infoBinding.onChange(v -> {
+                updateInfo(ComponentInfo.from(v).orElse(null));
+            }).onSync(a -> {
+                if (sync == null) {
+                    a.setActive(false);
+                }
+                if (pendingInfo != null) {
+                    pendingInfo.complete(info());
+                    pendingInfo = null;
+                }
+            }).onSyncError(a -> {
+                updateInfo(null);
+            });
+            hub.bindings().bind(
+                    ControlAddress.of(address, ComponentProtocol.INFO),
+                    infoBinding);
+            infoBinding.setActive(true);
+        }
+
+        @Override
+        public HubProxy hub() {
+            return hub;
+        }
+
+        @Override
+        public Component set(String id, Value value) {
+            Binding.PropertyAdaptor binding = bindings.get(id);
+            if (binding != null) {
+                binding.send(value);
+            }
+            return this;
+        }
+
+        @Override
+        public Optional<Value> get(String id) {
+            return Optional.ofNullable(bindings.get(id))
+                    .flatMap(Binding.PropertyAdaptor::value);
+        }
+
+        @Override
+        public ComponentAddress address() {
+            return address;
+        }
+
+        @Override
+        public Optional<ComponentInfo> info() {
+            return Optional.ofNullable(info);
+        }
+
+        @Override
+        public void dispose() {
+            hub.removeComponent(this);
+            disposeImpl();
+        }
+
+        @Override
+        public Component sync() {
+            sync = Set.of();
+            checkSyncing();
+            return this;
+        }
+
+        @Override
+        public Component sync(Set<String> properties) {
+            sync = Set.copyOf(properties);
+            checkSyncing();
+            return this;
+        }
+
+        @Override
+        public Component unsync() {
+            sync = null;
+            checkSyncing();
+            return this;
+        }
+
+        @Override
+        public Future<Optional<ComponentInfo>> validate() {
+            if (pendingInfo == null) {
+                pendingInfo = new CompletableFuture<>();
+            }
+            infoBinding.setActive(true);
+            return new ThreadAwareFuture<>(pendingInfo, hub.threadContext());
+        }
+
+        @Override
+        public String toString() {
+            return "ComponentProxy : " + address();
+        }
+
+        private void checkSyncing() {
+            infoBinding.setActive(sync != null);
+            bindings.forEach((id, binding) -> {
+                if (sync != null && (sync.isEmpty() || sync.contains(id))) {
+                    binding.setActive(true);
+                } else {
+                    binding.setActive(false);
+                }
+            });
+        }
+
+        private void disposeImpl() {
+            infoBinding.setActive(false);
+            hub.bindings().unbind(
+                    ControlAddress.of(address(), ComponentProtocol.INFO),
+                    infoBinding);
+            updateInfo(null);
+        }
+
+        private boolean isProperty(ComponentInfo info, String control) {
+            ControlInfo controlInfo = info.controlInfo(control);
+            return controlInfo != null
+                    && (controlInfo.controlType() == ControlInfo.Type.Property
+                    || controlInfo.controlType() == ControlInfo.Type.ReadOnlyProperty);
+        }
+
+        private void updateInfo(ComponentInfo info) {
+            this.info = info;
+            Set<String> props;
+            if (info == null) {
+                props = Set.of();
+            } else {
+                props = info.controls().stream()
+                        .filter(id -> isProperty(info, id))
+                        .collect(Collectors.toSet());
+            }
+            Set<String> working = new HashSet<>(bindings.keySet());
+            working.removeAll(props);
+            working.forEach(id -> {
+                Binding.PropertyAdaptor removed = bindings.remove(id);
+                if (removed != null) {
+                    hub.bindings().unbind(ControlAddress.of(address, id), removed);
+                }
+            });
+            working.clear();
+            working.addAll(bindings.keySet());
+            props.forEach(id -> {
+                if (!working.contains(id)) {
+                    Binding.PropertyAdaptor binding = new Binding.PropertyAdaptor();
+                    binding.setSyncRate(Binding.SyncRate.Medium);
+                    hub.bindings().bind(ControlAddress.of(address, id), binding);
+                    bindings.put(id, binding);
+                }
+            });
+            checkSyncing();
+            if (pendingInfo != null) {
+                pendingInfo.complete(Optional.ofNullable(info));
+                pendingInfo = null;
+            }
+        }
+
+    }
+
+    private static class RootProxy extends ComponentProxy implements HubProxy.Root {
+
+        public RootProxy(HubProxyImpl hub, ComponentAddress address) {
+            super(hub, address);
+        }
+
+        @Override
+        public String toString() {
+            return "RootProxy : " + address();
+        }
+
+    }
+
+    private static class ThreadAwareFuture<T> implements Future<T> {
+
+        private final Future<T> delegate;
+        private final ThreadContext threadContext;
+
+        private ThreadAwareFuture(Future<T> delegate, ThreadContext threadContext) {
+            this.delegate = delegate;
+            this.threadContext = threadContext;
+        }
+
+        @Override
+        public boolean cancel(boolean mayInterruptIfRunning) {
+            return delegate.cancel(mayInterruptIfRunning);
+        }
+
+        @Override
+        public boolean isCancelled() {
+            return delegate.isCancelled();
+        }
+
+        @Override
+        public boolean isDone() {
+            return delegate.isDone();
+        }
+
+        @Override
+        public T get() throws InterruptedException, ExecutionException {
+            checkThread();
+            return delegate.get();
+        }
+
+        @Override
+        public T get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+            checkThread();
+            return delegate.get(timeout, unit);
+        }
+
+        private void checkThread() {
+            if (threadContext != null && threadContext.isRootThread() && !isDone()) {
+                throw new UnsupportedOperationException(
+                        "Calling get() on root thread when not done will deadlock");
+            }
+        }
+
+    }
+
+    static class Descriptor extends ReferenceDescriptor<Descriptor> {
+
+        private final Field hubField;
+
+        private HubProxyImpl hub;
+
+        private Descriptor(CodeConnector<?> connector, String id, Field field) {
+            super(Descriptor.class, id);
+            this.hubField = field;
+        }
+
+        @Override
+        public void attach(CodeContext<?> context, Descriptor previous) {
+            if (previous != null) {
+                hub = previous.hub;
+                previous.hub = null;
+            }
+            if (hub == null) {
+                hub = new HubProxyImpl();
+            }
+            try {
+                hubField.set(context.getDelegate(), hub);
+                hub.attach(context);
+            } catch (Exception ex) {
+                context.getLog().log(LogLevel.ERROR, ex);
+            }
+        }
+
+        @Override
+        public void onInit() {
+            hub.onDescriptorInit();
+        }
+
+        @Override
+        public void onReset() {
+            hub.onDescriptorReset();
+        }
+
+        @Override
+        public void dispose() {
+            if (hub != null) {
+                hub.onDescriptorDispose();
+            }
+            hub = null;
+        }
+
+        static Descriptor create(CodeConnector<?> connector, Field field) {
+            if (HubProxy.class.equals(field.getType())) {
+                field.setAccessible(true);
+                return new Descriptor(connector, field.getName(), field);
+            } else {
+                return null;
+            }
+        }
+
+    }
+
+}

--- a/praxiscore-hub-net/src/main/java/org/praxislive/hub/net/NetworkCoreFactory.java
+++ b/praxiscore-hub-net/src/main/java/org/praxislive/hub/net/NetworkCoreFactory.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  * 
- * Copyright 2023 Neil C Smith.
+ * Copyright 2026 Neil C Smith.
  * 
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3 only, as
@@ -25,6 +25,7 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.net.UnknownHostException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -90,8 +91,15 @@ public final class NetworkCoreFactory implements Hub.CoreRootFactory {
 
     @Override
     public synchronized Lookup extendLookup(Lookup lookup) {
-        if (root instanceof ServerCoreRoot) {
-            return Lookup.of(lookup, ((ServerCoreRoot) root).getResourceResolver());
+        List<Object> ext = new ArrayList<>();
+        if (childLauncher != null) {
+            ext.add(childLauncher);
+        }
+        if (root instanceof ServerCoreRoot scr) {
+            ext.add(scr.getResourceResolver());
+        }
+        if (!ext.isEmpty()) {
+            return Lookup.of(lookup, ext.toArray());
         } else {
             return lookup;
         }

--- a/praxiscore-hub/src/main/java/org/praxislive/hub/BasicCoreRoot.java
+++ b/praxiscore-hub/src/main/java/org/praxislive/hub/BasicCoreRoot.java
@@ -50,6 +50,9 @@ import org.praxislive.core.types.PReference;
 import org.praxislive.core.types.PString;
 
 import static java.lang.System.Logger.Level;
+import org.praxislive.core.ComponentInfo;
+import org.praxislive.core.Info;
+import org.praxislive.core.protocols.ComponentProtocol;
 
 /**
  * A base implementation of a core root for use with {@link Hub}. This is the
@@ -59,7 +62,13 @@ import static java.lang.System.Logger.Level;
  */
 public class BasicCoreRoot extends AbstractRoot {
 
-    private final static Logger LOG = System.getLogger(BasicCoreRoot.class.getName());
+    private static final Logger LOG = System.getLogger(BasicCoreRoot.class.getName());
+
+    private static final ComponentInfo INFO = Info.component()
+            .merge(RootManagerService.API_INFO)
+            .control(SystemManagerService.SYSTEM_EXIT,
+                    SystemManagerService.SYSTEM_EXIT_INFO)
+            .build();
 
     private final Hub.Accessor hubAccess;
     private final List<Root> exts;
@@ -189,6 +198,11 @@ public class BasicCoreRoot extends AbstractRoot {
      * @param ctrls map of control id to control
      */
     protected void buildControlMap(Map<String, Control> ctrls) {
+        ctrls.computeIfAbsent(ComponentProtocol.INFO, k -> (call, router) -> {
+            if (call.isReplyRequired()) {
+                router.route(call.reply(INFO));
+            }
+        });
         ctrls.computeIfAbsent(RootManagerService.ADD_ROOT, k -> new AddRootControl());
         ctrls.computeIfAbsent(RootManagerService.REMOVE_ROOT, k -> new RemoveRootControl());
         ctrls.computeIfAbsent(RootManagerService.ROOTS, k -> new RootsControl());

--- a/praxiscore-hub/src/main/java/org/praxislive/hub/ExternalAccess.java
+++ b/praxiscore-hub/src/main/java/org/praxislive/hub/ExternalAccess.java
@@ -22,30 +22,61 @@
 package org.praxislive.hub;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
 import org.praxislive.base.AbstractRoot;
+import org.praxislive.base.Binding;
+import org.praxislive.base.BindingContext;
+import org.praxislive.base.BindingContextControl;
 import org.praxislive.core.Call;
+import org.praxislive.core.ComponentAddress;
+import org.praxislive.core.ComponentInfo;
 import org.praxislive.core.Control;
 import org.praxislive.core.ControlAddress;
+import org.praxislive.core.ControlInfo;
 import org.praxislive.core.PacketRouter;
+import org.praxislive.core.RootHub;
 import org.praxislive.core.Value;
 import org.praxislive.core.services.ScriptService;
 import org.praxislive.core.types.PError;
 import org.praxislive.core.types.PString;
+import org.praxislive.core.HubProxy;
+import org.praxislive.core.protocols.ComponentProtocol;
 
 final class ExternalAccess extends AbstractRoot {
 
     private static final String SCRIPT_CONTROL_ID = "_ext-eval";
 
-    private final Map<String, Control> controls;
+    private final Hub hub;
     private final Map<Integer, CompletableFuture<List<Value>>> evalPending;
 
-    ExternalAccess() {
+    private Map<String, Control> controls;
+    private BindingContextControl bindings;
+
+    ExternalAccess(Hub hub) {
+        this.hub = hub;
         this.evalPending = new HashMap<>();
-        controls = Map.of(SCRIPT_CONTROL_ID, this::processEvalResponse);
+    }
+
+    @Override
+    public Controller initialize(String id, RootHub hub) {
+        AbstractRoot.Controller ctrl = super.initialize(id, hub);
+        bindings = new BindingContextControl(ControlAddress.of(getAddress(), "_bindings"),
+                getExecutionContext(),
+                getRouter());
+        controls = Map.of(
+                SCRIPT_CONTROL_ID, this::processEvalResponse,
+                "_bindings", bindings);
+        return ctrl;
     }
 
     @Override
@@ -72,6 +103,10 @@ final class ExternalAccess extends AbstractRoot {
         CompletableFuture<List<Value>> future = new CompletableFuture<>();
         invokeLater(() -> processEvalRequest(script, future));
         return future;
+    }
+
+    HubProxy createHubProxy() {
+        return new HubProxyImpl(this);
     }
 
     private void processEvalRequest(String script, CompletableFuture<List<Value>> future) {
@@ -103,6 +138,288 @@ final class ExternalAccess extends AbstractRoot {
                 future.completeExceptionally(ex);
             }
         }
+    }
+
+    private static class HubProxyImpl implements HubProxy {
+
+        private final ExternalAccess root;
+        private final ConcurrentMap<ComponentAddress, ComponentProxy> components;
+
+        private HubProxyImpl(ExternalAccess root) {
+            this.root = root;
+            components = new ConcurrentHashMap<>();
+        }
+
+        @Override
+        public Component component(ComponentAddress address) {
+            ComponentProxy cmp = components.computeIfAbsent(address,
+                    ad -> {
+                        if (ad.depth() == 1) {
+                            return new RootProxy(this, ad);
+                        } else {
+                            return new ComponentProxy(this, ad);
+                        }
+                    });
+            invokeLater(cmp::validateImpl);
+            return cmp;
+        }
+
+        @Override
+        public Root root(String id) {
+            return (Root) component(ComponentAddress.of("/" + id));
+        }
+
+        @Override
+        public Set<Component> proxies() {
+            return Set.copyOf(components.values());
+        }
+
+        @Override
+        public List<String> roots() {
+            return root.hub.roots();
+        }
+
+        @Override
+        public HubProxy unsyncAll() {
+            components.forEach((ad, cmp) -> cmp.unsync());
+            return this;
+        }
+
+        @Override
+        public HubProxy clear() {
+            Map<ComponentAddress, ComponentProxy> cmps = Map.copyOf(components);
+            components.clear();
+            invokeLater(() -> {
+                cmps.forEach((ad, cmp) -> cmp.disposeImpl());
+            });
+            return this;
+        }
+
+        @Override
+        public void dispose() {
+            clear();
+        }
+
+        @Override
+        public Future<List<Value>> eval(String script) {
+            return root.eval(script);
+        }
+
+        private void invokeLater(Runnable task) {
+            root.invokeLater(task);
+        }
+
+        private void removeComponent(ComponentProxy cmp) {
+            components.remove(cmp.address(), cmp);
+        }
+
+        private BindingContext bindings() {
+            return root.bindings;
+        }
+
+    }
+
+    private static class ComponentProxy implements HubProxy.Component {
+
+        private final HubProxyImpl hub;
+        private final ComponentAddress address;
+        private final Binding.PropertyAdaptor infoBinding;
+        private final AtomicReference<ComponentInfo> info;
+        private final AtomicReference<Set<String>> sync;
+        private final Map<String, Binding.PropertyAdaptor> bindings;
+        private final ConcurrentMap<String, Value> values;
+        private final AtomicReference<CompletableFuture<Optional<ComponentInfo>>> pendingInfo;
+
+        private ComponentProxy(HubProxyImpl hubProxy, ComponentAddress address) {
+            this.hub = hubProxy;
+            this.address = address;
+            infoBinding = new Binding.PropertyAdaptor();
+            info = new AtomicReference<>();
+            pendingInfo = new AtomicReference<>();
+            sync = new AtomicReference<>();
+            bindings = new ConcurrentHashMap<>();
+            values = new ConcurrentHashMap<>();
+            infoBinding.setSyncRate(Binding.SyncRate.Low);
+            infoBinding.onChange(v -> {
+                updateInfo(ComponentInfo.from(v).orElse(null));
+            }).onSync(a -> {
+                if (sync.get() == null) {
+                    a.setActive(false);
+                }
+                CompletableFuture<Optional<ComponentInfo>> futureInfo
+                        = pendingInfo.getAndSet(null);
+                if (futureInfo != null) {
+                    futureInfo.complete(info());
+                }
+            }).onSyncError(a -> {
+                updateInfo(null);
+            });
+            hubProxy.invokeLater(() -> {
+                hubProxy.bindings().bind(
+                        ControlAddress.of(address, ComponentProtocol.INFO),
+                        infoBinding);
+                infoBinding.setActive(true);
+            });
+        }
+
+        @Override
+        public HubProxy hub() {
+            return hub;
+        }
+
+        @Override
+        public HubProxy.Component set(String id, Value value) {
+            values.put(id, value);
+            hub.invokeLater(() -> {
+                Binding.PropertyAdaptor binding = bindings.get(id);
+                if (binding != null) {
+                    binding.send(value);
+                } else {
+                    values.remove(id, value);
+                }
+            });
+            return this;
+        }
+
+        @Override
+        public Optional<Value> get(String id) {
+            return Optional.ofNullable(values.get(id));
+        }
+
+        @Override
+        public ComponentAddress address() {
+            return address;
+        }
+
+        @Override
+        public Optional<ComponentInfo> info() {
+            return Optional.ofNullable(info.get());
+        }
+
+        @Override
+        public void dispose() {
+            hub.removeComponent(this);
+            hub.invokeLater(this::disposeImpl);
+        }
+
+        @Override
+        public HubProxy.Component sync() {
+            sync.set(Set.of());
+            hub.invokeLater(this::checkSyncing);
+            return this;
+        }
+
+        @Override
+        public HubProxy.Component sync(Set<String> properties) {
+            sync.set(Set.copyOf(properties));
+            hub.invokeLater(this::checkSyncing);
+            return this;
+        }
+
+        @Override
+        public HubProxy.Component unsync() {
+            sync.set(null);
+            hub.invokeLater(this::checkSyncing);
+            return this;
+        }
+
+        @Override
+        public Future<Optional<ComponentInfo>> validate() {
+            CompletableFuture<Optional<ComponentInfo>> future
+                    = pendingInfo.updateAndGet(f -> {
+                        return f == null ? new CompletableFuture<>() : f;
+                    });
+            hub.invokeLater(this::validateImpl);
+            return future;
+        }
+
+        @Override
+        public String toString() {
+            return "ComponentProxy : " + address();
+        }
+
+        private void checkSyncing() {
+            Set<String> syncSet = sync.get();
+            infoBinding.setActive(syncSet != null);
+            bindings.forEach((id, binding) -> {
+                if (syncSet != null && (syncSet.isEmpty() || syncSet.contains(id))) {
+                    binding.setActive(true);
+                } else {
+                    binding.setActive(false);
+                }
+            });
+        }
+
+        private void disposeImpl() {
+            infoBinding.setActive(false);
+            hub.bindings().unbind(
+                    ControlAddress.of(address(), ComponentProtocol.INFO),
+                    infoBinding);
+            updateInfo(null);
+        }
+
+        private boolean isProperty(ComponentInfo info, String control) {
+            ControlInfo controlInfo = info.controlInfo(control);
+            return controlInfo != null
+                    && (controlInfo.controlType() == ControlInfo.Type.Property
+                    || controlInfo.controlType() == ControlInfo.Type.ReadOnlyProperty);
+        }
+
+        private void updateInfo(ComponentInfo info) {
+            Set<String> props;
+            if (info == null) {
+                props = Set.of();
+            } else {
+                props = info.controls().stream()
+                        .filter(id -> isProperty(info, id))
+                        .collect(Collectors.toSet());
+            }
+            Set<String> working = new HashSet<>(bindings.keySet());
+            working.removeAll(props);
+            working.forEach(id -> {
+                values.remove(id);
+                Binding.PropertyAdaptor removed = bindings.remove(id);
+                if (removed != null) {
+                    hub.bindings().unbind(ControlAddress.of(address, id), removed);
+                }
+            });
+            working.clear();
+            working.addAll(bindings.keySet());
+            props.forEach(id -> {
+                if (!working.contains(id)) {
+                    Binding.PropertyAdaptor binding = new Binding.PropertyAdaptor();
+                    binding.setSyncRate(Binding.SyncRate.Medium);
+                    binding.onChange(value -> values.put(id, value));
+                    hub.bindings().bind(ControlAddress.of(address, id), binding);
+                    bindings.put(id, binding);
+                }
+            });
+            checkSyncing();
+            this.info.set(info);
+            CompletableFuture<Optional<ComponentInfo>> futureInfo
+                    = pendingInfo.getAndSet(null);
+            if (futureInfo != null) {
+                futureInfo.complete(Optional.ofNullable(info));
+            }
+        }
+
+        private void validateImpl() {
+            infoBinding.setActive(true);
+        }
+
+    }
+
+    private static class RootProxy extends ComponentProxy implements HubProxy.Root {
+
+        private RootProxy(HubProxyImpl hub, ComponentAddress address) {
+            super(hub, address);
+        }
+
+        @Override
+        public String toString() {
+            return "RootProxy : " + address();
+        }
+
     }
 
 }

--- a/praxiscore-hub/src/main/java/org/praxislive/hub/Hub.java
+++ b/praxiscore-hub/src/main/java/org/praxislive/hub/Hub.java
@@ -38,6 +38,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.praxislive.core.Clock;
 import org.praxislive.core.ComponentAddress;
+import org.praxislive.core.HubProxy;
 import org.praxislive.core.Lookup;
 import org.praxislive.core.Packet;
 import org.praxislive.core.Root;
@@ -76,7 +77,7 @@ public final class Hub {
 
     private Hub(Builder builder) {
         CoreRootFactory coreFactory = builder.coreRootFactory;
-        externalAccess = new ExternalAccess();
+        externalAccess = new ExternalAccess(this);
         List<Root> exts = Stream.concat(
                 Stream.of(
                         new DefaultComponentFactoryService(),
@@ -177,6 +178,10 @@ public final class Hub {
         return externalAccess.eval(script);
     }
 
+    public HubProxy createHubProxy() {
+        return externalAccess.createHubProxy();
+    }
+
     /**
      * Return an exit value for the hub. This may be used as the exit value for
      * the hub process. The default value is 0.
@@ -189,6 +194,10 @@ public final class Hub {
         } else {
             return 0;
         }
+    }
+
+    List<String> roots() {
+        return List.copyOf(rootIDs);
     }
 
     private boolean registerRootController(String id, Root.Controller controller) {
@@ -362,8 +371,19 @@ public final class Hub {
          *
          * @return registered root IDs
          */
+        @Deprecated(forRemoval = true)
         public String[] getRootIDs() {
             return Hub.this.getRootIDs();
+        }
+
+        /**
+         * Get a list of the registered root IDs. The returned list is an
+         * immutable snapshot.
+         *
+         * @return registered root IDs
+         */
+        public List<String> rootIDs() {
+            return Hub.this.roots();
         }
 
         /**

--- a/praxiscore-hub/src/test/java/org/praxislive/hub/AbstractTestBase.java
+++ b/praxiscore-hub/src/test/java/org/praxislive/hub/AbstractTestBase.java
@@ -1,0 +1,73 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright 2026 Neil C Smith.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License version 3 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * version 3 for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License version 3
+ * along with this work; if not, see http://www.gnu.org/licenses/
+ *
+ *
+ * Please visit https://www.praxislive.org if you need additional information or
+ * have any questions.
+ */
+package org.praxislive.hub;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Supplier;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInfo;
+
+abstract class AbstractTestBase {
+
+    public static final boolean VERBOSE = Boolean.getBoolean("praxis.test.verbose");
+    public static final int TIMEOUT = Integer.getInteger("praxis.test.timeout", 10000);
+
+    @BeforeEach
+    public void beforeEach(TestInfo info) {
+        if (VERBOSE) {
+            System.out.println("START TEST : " + info.getDisplayName());
+        }
+    }
+
+    @AfterEach
+    public void afterEach(TestInfo info) {
+        if (VERBOSE) {
+            System.out.println("END TEST : " + info.getDisplayName());
+            System.out.println("=====================================");
+        }
+    }
+
+    protected void log(Object output) {
+        if (VERBOSE) {
+            System.out.println(output);
+            System.out.println("");
+        }
+    }
+
+    protected void repeatUntil(Supplier<Boolean> poll) throws TimeoutException {
+        long start = System.nanoTime();
+        long timeout = TimeUnit.MILLISECONDS.toNanos(TIMEOUT);
+        do {
+            if (poll.get()) {
+                return;
+            }
+            try {
+                Thread.sleep(1);
+            } catch (InterruptedException ex) {
+            }
+        } while (System.nanoTime() - start < timeout);
+        throw new TimeoutException();
+    }
+
+}

--- a/praxiscore-hub/src/test/java/org/praxislive/hub/HubTest.java
+++ b/praxiscore-hub/src/test/java/org/praxislive/hub/HubTest.java
@@ -1,0 +1,208 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright 2026 Neil C Smith.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License version 3 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * version 3 for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License version 3
+ * along with this work; if not, see http://www.gnu.org/licenses/
+ *
+ *
+ * Please visit https://www.praxislive.org if you need additional information or
+ * have any questions.
+ */
+package org.praxislive.hub;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+import org.praxislive.base.AbstractComponent;
+import org.praxislive.base.AbstractRoot;
+import org.praxislive.base.AbstractRootContainer;
+import org.praxislive.core.Call;
+import org.praxislive.core.ComponentAddress;
+import org.praxislive.core.ComponentInfo;
+import org.praxislive.core.HubProxy;
+import org.praxislive.core.Info;
+import org.praxislive.core.PacketRouter;
+import org.praxislive.core.RootHub;
+import org.praxislive.core.Value;
+import org.praxislive.core.protocols.ComponentProtocol;
+import org.praxislive.core.protocols.ContainerProtocol;
+import org.praxislive.core.protocols.StartableProtocol;
+import org.praxislive.core.services.ComponentFactoryService;
+import org.praxislive.core.services.RootFactoryService;
+import org.praxislive.core.services.Service;
+import org.praxislive.core.types.PArray;
+import org.praxislive.core.types.PBoolean;
+import org.praxislive.core.types.PReference;
+import org.praxislive.core.types.PString;
+
+/**
+ *
+ */
+public class HubTest extends AbstractTestBase {
+
+    @Test
+    public void testHubEval() throws Exception {
+        Hub hub = Hub.builder()
+                .addExtension(new ComponentFactoryImpl())
+                .build();
+        hub.start();
+        List<Value> result = hub.eval("""
+                @ /root root:test {
+                    @ ./cmp test:component {
+                        .value "FOO"
+                    }
+                }
+                /root.start
+                array [/root.is-running] [/root/cmp.value]
+                """).get(TIMEOUT, TimeUnit.MILLISECONDS);
+        assertEquals(1, result.size());
+        PArray array = PArray.from(result.getFirst()).orElseThrow();
+        log(array);
+        assertTrue(PBoolean.from(array.get(0)).orElseThrow().value());
+        assertEquals("FOO", array.get(1).toString());
+        hub.shutdown();
+        hub.await(TIMEOUT, TimeUnit.MILLISECONDS);
+    }
+
+    @Test
+    public void testHubProxy() throws Exception {
+        Hub hub = Hub.builder()
+                .addExtension(new ComponentFactoryImpl())
+                .build();
+        hub.start();
+        hub.eval("""
+                @ /root root:test {
+                    @ ./cmp test:component {
+                        .value "FOO"
+                    }
+                }
+                /root.start
+                """).get(TIMEOUT, TimeUnit.MILLISECONDS);
+        HubProxy proxy = hub.createHubProxy();
+        HubProxy.Root root = proxy.root("root");
+        ComponentInfo info = root.validate()
+                .get(TIMEOUT, TimeUnit.MILLISECONDS)
+                .orElseThrow();
+        log(info.print());
+        assertTrue(root.isContainer());
+        assertNull(root.parent());
+        assertEquals(List.of(), root.children());
+        root.sync();
+        repeatUntil(() -> !root.children().isEmpty());
+        assertEquals(List.of("cmp"), root.children());
+        HubProxy.Component cmp = root.resolve("cmp");
+        assertEquals(root, cmp.parent());
+        assertEquals("cmp", cmp.id());
+        repeatUntil(() -> cmp.isValid());
+        cmp.sync(Set.of("value"));
+        repeatUntil(() -> cmp.get("value").isPresent());
+        assertEquals("FOO", cmp.get("value").orElseThrow().toString());
+        cmp.set("value", PString.of("BAR"));
+        repeatUntil(() -> Objects.equals("BAR",
+                cmp.get("value").map(Value::toString).orElse("")));
+        HubProxy.Component invalid = root.resolve("none");
+        assertTrue(invalid.validate().get(TIMEOUT, TimeUnit.MILLISECONDS).isEmpty());
+        HubProxy.Component cmp2 = proxy.component(ComponentAddress.of("/root/cmp"));
+        assertEquals(cmp, cmp2);
+        assertEquals(Set.of(root, cmp, invalid), proxy.proxies());
+        proxy.proxies().stream().filter(c -> !c.isValid()).forEach(c -> c.dispose());
+        assertEquals(Set.of(root, cmp), proxy.proxies());
+        proxy.clear();
+        assertEquals(Set.of(), proxy.proxies());
+        HubProxy.Root root2 = proxy.root("root");
+        assertNotEquals(root, root2);
+        root2.sync();
+        root2.stop();
+        repeatUntil(() -> Objects.equals(PBoolean.FALSE,
+                root2.get("is-running").orElse(PBoolean.TRUE)));
+        proxy.dispose();
+        hub.shutdown();
+        hub.await(TIMEOUT, TimeUnit.MILLISECONDS);
+    }
+
+    private static class ComponentFactoryImpl extends AbstractRoot implements RootHub.ServiceProvider {
+
+        @Override
+        public List<Class<? extends Service>> services() {
+            return List.of(ComponentFactoryService.class, RootFactoryService.class);
+        }
+
+        @Override
+        protected void processCall(Call call, PacketRouter router) {
+            if (call.isRequest()) {
+                switch (call.to().controlID()) {
+                    case RootFactoryService.NEW_ROOT_INSTANCE -> {
+                        router.route(call.reply(PReference.of(new RootImpl())));
+                    }
+                    case ComponentFactoryService.NEW_INSTANCE -> {
+                        router.route(call.reply(PReference.of(new CmpImpl())));
+                    }
+                }
+            }
+        }
+
+    }
+
+    private static class RootImpl extends AbstractRootContainer {
+
+        private final ComponentInfo info;
+
+        private RootImpl() {
+            this.info = Info.component()
+                    .merge(ComponentProtocol.API_INFO)
+                    .merge(ContainerProtocol.API_INFO)
+                    .merge(StartableProtocol.API_INFO)
+                    .build();
+        }
+
+        @Override
+        public ComponentInfo getInfo() {
+            return info;
+        }
+
+    }
+
+    private static class CmpImpl extends AbstractComponent {
+
+        private final ComponentInfo info;
+
+        private String value = "";
+
+        private CmpImpl() {
+            this.info = Info.component(cmp -> cmp
+                    .merge(ComponentProtocol.API_INFO)
+                    .control("value", p -> p.property().input(PString.class))
+            );
+            registerControl("value", (call, router) -> {
+                if (call.isRequest()) {
+                    if (!call.args().isEmpty()) {
+                        value = call.args().getFirst().toString();
+                    }
+                    router.route(call.reply(PString.of(value)));
+                }
+            });
+        }
+
+        @Override
+        public ComponentInfo getInfo() {
+            return info;
+        }
+
+    }
+
+}


### PR DESCRIPTION
Add HubProxy API interface to praxiscore-api.
Add HubProxy implementation in praxiscore-code for injection in user code.
Add HubProxy implementation in praxiscore-hub for use externally to Hub.
Update bindings to support sync errors.
Speed up initial binding sync by immediate info update.

Resolves #99 