### PR TITLE
Update MIMA support to allow BOM imports.

### DIFF
--- a/praxiscore-code-mima/pom.xml
+++ b/praxiscore-code-mima/pom.xml
@@ -29,7 +29,7 @@
     <dependency>
       <groupId>eu.maveniverse.maven.mima</groupId>
       <artifactId>context</artifactId>
-      <version>2.4.42</version>
+      <version>2.4.45</version>
       <exclusions>
         <exclusion>
           <groupId>org.apache.maven.resolver</groupId>
@@ -44,7 +44,7 @@
     <dependency>
       <groupId>eu.maveniverse.maven.mima.runtime</groupId>
       <artifactId>standalone-static-uber</artifactId>
-      <version>2.4.42</version>
+      <version>2.4.45</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/praxiscore-code-mima/src/main/java/org/praxislive/code/services/mima/MimaResolver.java
+++ b/praxiscore-code-mima/src/main/java/org/praxislive/code/services/mima/MimaResolver.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright 2024 Neil C Smith.
+ * Copyright 2026 Neil C Smith.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3 only, as
@@ -37,9 +37,8 @@ import org.praxislive.purl.PackageURL;
  *
  */
 public class MimaResolver implements LibraryResolver {
-    
+
     MimaWrapper mima;
-    
 
     @Override
     public Optional<Entry> resolve(PResource resource, Context context) throws Exception {
@@ -65,30 +64,31 @@ public class MimaResolver implements LibraryResolver {
         PResource root = resource;
         List<PResource> provides = new ArrayList<>();
         List<Path> files = new ArrayList<>();
-        
+
         for (Artifact dep : resolved) {
             Artifact ex = findExisting(installed, dep);
             if (ex == null) {
-                Path file = dep.getFile().toPath();
                 PResource purl = toPURL(dep);
                 if (matchingArtifacts(dep, artifact)) {
                     root = purl;
                 }
                 provides.add(purl);
-                files.add(file);
+                if (!Objects.equals("pom", dep.getExtension())) {
+                    files.add(dep.getFile().toPath());
+                }
                 context.log().log(LogLevel.INFO, "Installing dependency " + purl);
             } else {
                 if (!Objects.equals(dep.getVersion(), ex.getVersion())) {
-                        context.log().log(LogLevel.WARNING,
-                                "Found already installed dependency " + toPURL(ex)
-                                + " instead of version " + dep.getVersion());
-                    } else {
-                        context.log().log(LogLevel.INFO,
-                                "Found already installed dependency " + toPURL(ex));
-                    }
+                    context.log().log(LogLevel.WARNING,
+                            "Found already installed dependency " + toPURL(ex)
+                            + " instead of version " + dep.getVersion());
+                } else {
+                    context.log().log(LogLevel.INFO,
+                            "Found already installed dependency " + toPURL(ex));
+                }
             }
         }
-        
+
         return Optional.of(new Entry(root, files, provides));
     }
 
@@ -109,7 +109,7 @@ public class MimaResolver implements LibraryResolver {
                 purl.qualifiers().flatMap(q -> Optional.ofNullable(q.get("type"))).orElse("jar"),
                 purl.version().orElse(""));
     }
-    
+
     private static PResource toPURL(Artifact artifact) {
         PackageURL.Builder builder = PackageURL.builder()
                 .withType("maven")
@@ -145,7 +145,7 @@ public class MimaResolver implements LibraryResolver {
         }
         return List.copyOf(list);
     }
-    
+
     private static Artifact findExisting(List<Artifact> installed, Artifact artifact) {
         return installed.stream()
                 .filter(lib -> matchingArtifacts(lib, artifact))

--- a/praxiscore-code-mima/src/main/java/org/praxislive/code/services/mima/MimaWrapper.java
+++ b/praxiscore-code-mima/src/main/java/org/praxislive/code/services/mima/MimaWrapper.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright 2025 Neil C Smith.
+ * Copyright 2026 Neil C Smith.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3 only, as
@@ -26,9 +26,14 @@ import eu.maveniverse.maven.mima.context.ContextOverrides;
 import eu.maveniverse.maven.mima.context.Runtime;
 import eu.maveniverse.maven.mima.context.Runtimes;
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Stream;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.collection.CollectRequest;
 import org.eclipse.aether.graph.Dependency;
+import org.eclipse.aether.resolution.ArtifactDescriptorException;
+import org.eclipse.aether.resolution.ArtifactDescriptorRequest;
+import org.eclipse.aether.resolution.ArtifactDescriptorResult;
 import org.eclipse.aether.resolution.ArtifactResult;
 import org.eclipse.aether.resolution.DependencyRequest;
 import org.eclipse.aether.resolution.DependencyResolutionException;
@@ -39,29 +44,34 @@ import org.eclipse.aether.util.artifact.JavaScopes;
  *
  */
 class MimaWrapper {
-    
+
     private final Context context;
-    
+
     MimaWrapper() {
         Runtime runtime = Runtimes.INSTANCE.getRuntime();
         context = runtime.create(ContextOverrides.create().withUserSettings(true).build());
     }
-    
+
     List<Artifact> resolve(Artifact artifact, List<Artifact> existing) throws DependencyResolutionException {
-        Dependency dependency = new Dependency(artifact, JavaScopes.COMPILE);
-        
         CollectRequest collectRequest = new CollectRequest();
-        collectRequest.setRoot(dependency);
         collectRequest.setRepositories(context.remoteRepositories());
+
         if (existing != null && !existing.isEmpty()) {
-            collectRequest.setManagedDependencies(existing.stream()
-                    .map(a -> new Dependency(a, JavaScopes.COMPILE))
-                    .toList()
-            );
+            List<Dependency> managedDeps = existing.stream()
+                    .flatMap(this::artifactToDeps)
+                    .toList();
+            collectRequest.setManagedDependencies(managedDeps);
+            collectRequest.addDependency(toDependency(artifact, managedDeps));
+        } else {
+            collectRequest.addDependency(toDependency(artifact, List.of()));
         }
-        
+
         DependencyRequest dependencyRequest = new DependencyRequest(collectRequest,
-                (node, parents) -> !node.getDependency().getOptional()
+                (node, parents) -> {
+                    return node == null
+                    || node.getDependency() == null
+                    || !node.getDependency().isOptional();
+                }
         );
         DependencyResult dependencyResult = context.repositorySystem()
                 .resolveDependencies(context.repositorySystemSession(), dependencyRequest);
@@ -70,11 +80,46 @@ class MimaWrapper {
                 .filter(ArtifactResult::isResolved)
                 .map(ArtifactResult::getArtifact)
                 .toList();
-        
+
     }
-    
+
     void dispose() {
         context.close();
+    }
+
+    private Stream<Dependency> artifactToDeps(Artifact artifact) {
+        if ("pom".equals(artifact.getExtension())) {
+            ArtifactDescriptorRequest req = new ArtifactDescriptorRequest()
+                    .setArtifact(artifact);
+            try {
+                ArtifactDescriptorResult res = context.repositorySystem()
+                        .readArtifactDescriptor(context.repositorySystemSession(), req);
+                return res.getManagedDependencies().stream();
+            } catch (ArtifactDescriptorException ex) {
+                return Stream.empty();
+            }
+        } else {
+            return Stream.of(new Dependency(artifact, JavaScopes.COMPILE));
+        }
+    }
+
+    private Dependency toDependency(Artifact artifact, List<Dependency> managedDeps) {
+        if (artifact.getVersion().isEmpty()) {
+            return managedDeps.stream()
+                    .filter(d -> isMatchingDependency(d, artifact))
+                    .findFirst()
+                    .orElseGet(() -> new Dependency(artifact, JavaScopes.COMPILE));
+        } else {
+            return new Dependency(artifact, JavaScopes.COMPILE);
+        }
+    }
+
+    private boolean isMatchingDependency(Dependency dependency, Artifact artifact) {
+        Artifact dep = dependency.getArtifact();
+        return Objects.equals(dep.getGroupId(), artifact.getGroupId())
+                && Objects.equals(dep.getArtifactId(), artifact.getArtifactId())
+                && Objects.equals(dep.getClassifier(), artifact.getClassifier())
+                && Objects.equals(dep.getExtension(), artifact.getExtension());
     }
 
 }


### PR DESCRIPTION
Update MIMA support to allow using Package-URL's with `?type=pom` to import managed dependencies.

Resolves #141 