### PR TITLE
Add vector types and buffers.

### DIFF
--- a/praxiscore-code/src/main/java/org/praxislive/code/userapi/Vec.java
+++ b/praxiscore-code/src/main/java/org/praxislive/code/userapi/Vec.java
@@ -1,0 +1,1649 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright 2026 Neil C Smith.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License version 3 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * version 3 for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License version 3
+ * along with this work; if not, see http://www.gnu.org/licenses/
+ *
+ *
+ * Please visit https://www.praxislive.org if you need additional information or
+ * have any questions.
+ *
+ */
+package org.praxislive.code.userapi;
+
+import java.nio.DoubleBuffer;
+import java.nio.IntBuffer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.ObjIntConsumer;
+
+/**
+ * A range of integer and floating point vector record types for holding two,
+ * three and four dimensional data.
+ * <p>
+ * This class also contains mutable buffer types for working with arrays holding
+ * element data corresponding to the various vector types.
+ */
+public sealed interface Vec {
+
+    /**
+     * Read the data from a {@link DoubleBuffer} into a list of {@code T} by
+     * reading into a {@code double[]} of size stride and using the mapper
+     * function to create an instance of T. The buffer is read using relative
+     * methods taking account of position and limit. The same array is used in
+     * every call to the mapper. The returned list is immutable.
+     * <p>
+     * This method can be used to read a list of Vec into a list - eg.
+     * {@code read(buffer, 2, Vec.D2::new);}. The stride can be higher than the
+     * component count of the Vec to read interleaved data.
+     *
+     * @param <T> mapped type
+     * @param buffer data to read from
+     * @param stride size of array / distance between data values
+     * @param mapper function to create T from double array
+     * @return list of T
+     */
+    public static <T> List<T> read(DoubleBuffer buffer, int stride,
+            Function<double[], T> mapper) {
+        if (stride < 1) {
+            throw new IllegalArgumentException("Stride must be greater than zero");
+        }
+        if (buffer.remaining() < stride) {
+            return List.of();
+        }
+        double[] holder = new double[stride];
+        List<T> list = new ArrayList<>(buffer.remaining() / stride);
+        while (buffer.remaining() >= stride) {
+            buffer.get(holder);
+            list.add(mapper.apply(holder));
+        }
+        return List.copyOf(list);
+    }
+
+    /**
+     * Read the data from an {@link IntBuffer} into a list of {@code T} by
+     * reading into a {@code int[]} of size stride and using the mapper function
+     * to create an instance of T. The buffer is read using relative methods
+     * taking account of position and limit. The same array is used in every
+     * call to the mapper. The returned list is immutable.
+     * <p>
+     * This method can be used to read a list of Vec into a list - eg.
+     * {@code read(buffer, 2, Vec.I2::new);}. The stride can be higher than the
+     * component count of the Vec to read interleaved data.
+     *
+     * @param <T> mapped type
+     * @param buffer data to read from
+     * @param stride size of array / distance between data values
+     * @param mapper function to create T from double array
+     * @return list of T
+     */
+    public static <T> List<T> read(IntBuffer buffer, int stride,
+            Function<int[], T> mapper) {
+        if (stride < 1) {
+            throw new IllegalArgumentException("Stride must be greater than zero");
+        }
+        if (buffer.remaining() < stride) {
+            return List.of();
+        }
+        int[] holder = new int[stride];
+        List<T> list = new ArrayList<>(buffer.remaining() / stride);
+        while (buffer.remaining() >= stride) {
+            buffer.get(holder);
+            list.add(mapper.apply(holder));
+        }
+        return List.copyOf(list);
+    }
+
+    /**
+     * Transform a {@link DoubleBuffer} in sections by repeatably reading into
+     * an array of size stride, passing to the transformer function, and writing
+     * back the result.
+     *
+     * @param buffer buffer
+     * @param stride array size
+     * @param transformer transform function accepting array of size stride
+     */
+    public static void transform(DoubleBuffer buffer, int stride,
+            Consumer<double[]> transformer) {
+        if (stride < 1) {
+            throw new IllegalArgumentException("Stride must be greater than zero");
+        }
+        double[] holder = new double[stride];
+        int position = buffer.position();
+        int limit = buffer.limit();
+        for (; position + stride < limit; position += stride) {
+            buffer.get(position, holder);
+            transformer.accept(holder);
+            buffer.put(position, holder);
+        }
+        buffer.position(position);
+    }
+
+    /**
+     * Transform an {@link IntBuffer} in sections by repeatably reading into an
+     * array of size stride, passing to the transformer function, and writing
+     * back the result.
+     *
+     * @param buffer buffer
+     * @param stride array size
+     * @param transformer transform function accepting array of size stride
+     */
+    public static void transform(IntBuffer buffer, int stride,
+            Consumer<int[]> transformer) {
+        if (stride < 1) {
+            throw new IllegalArgumentException("Stride must be greater than zero");
+        }
+        int[] holder = new int[stride];
+        int position = buffer.position();
+        int limit = buffer.limit();
+        for (; position + stride < limit; position += stride) {
+            buffer.get(position, holder);
+            transformer.accept(holder);
+            buffer.put(position, holder);
+        }
+        buffer.position(position);
+    }
+
+    /**
+     * A Vec of two doubles.
+     */
+    public static record D2(double x, double y) implements Vec {
+
+        /**
+         * Create a D2 from an array of values, where {code x = data[0]; y =
+         * data[1]}. The data array must contain at least two values. Additional
+         * values are ignored.
+         *
+         * @param data array
+         * @throws IndexOutOfBoundsException if array is too small
+         */
+        public D2(double[] data) {
+            this(data[0], data[1]);
+        }
+
+    }
+
+    /**
+     * A Vec of three doubles.
+     */
+    public static record D3(double x, double y, double z) implements Vec {
+
+        /**
+         * Create a D3 from an array of values, where {code x = data[0]; y =
+         * data[1]; z = data[2]}. The data array must contain at least three
+         * values. Additional values are ignored.
+         *
+         * @param data array
+         * @throws IndexOutOfBoundsException if array is too small
+         */
+        public D3(double[] data) {
+            this(data[0], data[1], data[2]);
+        }
+
+    }
+
+    /**
+     * A Vec of four doubles.
+     */
+    public static record D4(double x, double y, double z, double w) implements Vec {
+
+        /**
+         * Create a D4 from an array of values, where {code x = data[0]; y =
+         * data[1]; z = data[2]; w = data[3]}. The data array must contain at
+         * least four values. Additional values are ignored.
+         *
+         * @param data array
+         * @throws IndexOutOfBoundsException if array is too small
+         */
+        public D4(double[] data) {
+            this(data[0], data[1], data[2], data[3]);
+        }
+    }
+
+    /**
+     * A Vec of two integers.
+     */
+    public static record I2(int x, int y) implements Vec {
+
+        /**
+         * Create a I2 from an array of values, where {code x = data[0]; y =
+         * data[1]}. The data array must contain at least two values. Additional
+         * values are ignored.
+         *
+         * @param data array
+         * @throws IndexOutOfBoundsException if array is too small
+         */
+        public I2(int[] data) {
+            this(data[0], data[1]);
+        }
+
+    }
+
+    /**
+     * A Vec of three integers.
+     */
+    public static record I3(int x, int y, int z) implements Vec {
+
+        /**
+         * Create a I3 from an array of values, where {code x = data[0]; y =
+         * data[1]; z = data[2]}. The data array must contain at least three
+         * values. Additional values are ignored.
+         *
+         * @param data array
+         * @throws IndexOutOfBoundsException if array is too small
+         */
+        public I3(int[] data) {
+            this(data[0], data[1], data[2]);
+        }
+
+    }
+
+    /**
+     * A Vec of four integers.
+     */
+    public static record I4(int x, int y, int z, int w) implements Vec {
+
+        /**
+         * Create a I4 from an array of values, where {code x = data[0]; y =
+         * data[1]; z = data[2]; w = data[3]}. The data array must contain at
+         * least four values. Additional values are ignored.
+         *
+         * @param data array
+         * @throws IndexOutOfBoundsException if array is too small
+         */
+        public I4(int[] data) {
+            this(data[0], data[1], data[2], data[3]);
+        }
+    }
+
+    /**
+     * Mutable buffer for vector types wrapping a double array. Buffers can be
+     * converted to and from lists of the equivalent Vec record types. The
+     * element size of a buffer corresponds to the number of components in the
+     * corresponding Vec type. Maximum capacity and count are given in terms of
+     * number of elements. Various generator, iterator and transform functions
+     * allow for in-place calculations via an element data holder.
+     */
+    public static sealed abstract class BufD {
+
+        final double[] data;
+        final int elementSize;
+        final int capacity;
+
+        int count;
+
+        BufD(int elementSize, int capacity) {
+            this.data = new double[elementSize * capacity];
+            this.elementSize = elementSize;
+            this.capacity = capacity;
+            count = 0;
+        }
+
+        /**
+         * Maximum capacity of the buffer in elements.
+         *
+         * @return maximum capacity
+         */
+        public final int capacity() {
+            return capacity;
+        }
+
+        /**
+         * Count of elements written to the buffer.
+         *
+         * @return element count
+         */
+        public final int count() {
+            return count;
+        }
+
+        /**
+         * Explicitly set the element count. The count must not be negative or
+         * greater than the capacity.
+         *
+         * @param count element count
+         */
+        public final void count(int count) {
+            if (count < 0 || count > capacity) {
+                throw new IllegalArgumentException("Invalid count");
+            }
+            this.count = count;
+        }
+
+        /**
+         * The element size of the corresponding Vec type.
+         *
+         * @return element size
+         */
+        public final int elementSize() {
+            return elementSize;
+        }
+
+        /**
+         * Access the underlying data array. Modifications to the buffer will be
+         * reflected in the array, and vice-versa. The array is of length
+         * {@code capacity() * elementSize()}.
+         *
+         * @return data array
+         */
+        public final double[] data() {
+            return data;
+        }
+
+        /**
+         * Reset the count to zero. The underlying array data is not modified.
+         */
+        public final void clear() {
+            count = 0;
+        }
+
+        /**
+         * Call the provided action for each element in the buffer. A single
+         * {@link Data} holder is used across every call. The action will be
+         * called {@link #count()} times.
+         *
+         * @param action action to perform for each element
+         */
+        public final void forEach(Consumer<Data> action) {
+            forEachIndexed((d, idx) -> action.accept(d));
+        }
+
+        /**
+         * Call the provided action for each element in the buffer. A single
+         * {@link Data} holder is used across every call. The action will be
+         * called {@link #count()} times. The index will be incremented for each
+         * call, starting at zero.
+         *
+         * @param action action to perform for each element
+         */
+        public abstract void forEachIndexed(ObjIntConsumer<Data> action);
+
+        /**
+         * Generate elements to add to the buffer by calling the provided
+         * generator function. A single {@link Data} holder is used across every
+         * call to the generator. Elements are appended to those currently in
+         * the buffer. There must be enough space between count and capacity to
+         * fit in the provided amount of elements.
+         *
+         * @param amount number of elements to append
+         * @param generator function to generate each element
+         * @throws IndexOutOfBoundsException if there is not enough space in the
+         * buffer
+         */
+        public final void generate(int amount, Consumer<Data> generator) {
+            generateIndexed(amount, (d, idx) -> generator.accept(d));
+        }
+
+        /**
+         * Generate elements to add to the buffer by calling the provided
+         * generator function. A single {@link Data} holder is used across every
+         * call to the generator. Elements are appended to those currently in
+         * the buffer. There must be enough space between count and capacity to
+         * fit in the provided amount of elements. The index will be incremented
+         * for each call, starting at zero.
+         *
+         * @param amount number of elements to append
+         * @param generator function to generate each element
+         * @throws IndexOutOfBoundsException if there is not enough space in the
+         * buffer
+         */
+        public abstract void generateIndexed(int amount, ObjIntConsumer<Data> generator);
+
+        /**
+         * Merge elements from another buffer into this one using the provided
+         * mapper function. The mapper function is provided with the destination
+         * data from this buffer and the corresponding element of the source
+         * buffer, in that order. The destination data will be written back to
+         * this buffer. The buffers may be of different element sizes. The count
+         * of merged elements will be the lower of this buffer count and the
+         * source buffer count.
+         *
+         * @param srcBuffer source buffer
+         * @param mapper function accepting element data from this buffer and
+         * the corresponding element of the source buffer
+         * @return count of merged elements
+         */
+        public int merge(BufD srcBuffer, BiConsumer<Data, Data> mapper) {
+            int mergeCount = Math.min(srcBuffer.count, count);
+            if (mergeCount < 1) {
+                return 0;
+            }
+            Data src = new Data();
+            Data dst = new Data();
+            double[] srcArray = srcBuffer.data();
+            int srcSize = srcBuffer.elementSize();
+            int dstSize = elementSize();
+            for (int i = 0, srcPos = 0, dstPos = 0; i < mergeCount; i++) {
+                src.x = srcArray[srcPos];
+                src.y = srcArray[srcPos + 1];
+                src.z = srcSize > 2 ? srcArray[srcPos + 2] : 0;
+                src.w = srcSize > 3 ? srcArray[srcPos + 3] : 0;
+                dst.x = data[dstPos];
+                dst.y = data[dstPos + 1];
+                dst.z = dstSize > 2 ? data[dstPos + 2] : 0;
+                dst.w = dstSize > 3 ? data[dstPos + 3] : 0;
+                mapper.accept(dst, src);
+                switch (dstSize) {
+                    case 2 -> {
+                        data[dstPos] = dst.x;
+                        data[dstPos + 1] = dst.y;
+                    }
+                    case 3 -> {
+                        data[dstPos] = dst.x;
+                        data[dstPos + 1] = dst.y;
+                        data[dstPos + 2] = dst.z;
+                    }
+                    case 4 -> {
+                        data[dstPos] = dst.x;
+                        data[dstPos + 1] = dst.y;
+                        data[dstPos + 2] = dst.z;
+                        data[dstPos + 3] = dst.w;
+                    }
+                }
+                srcPos += srcSize;
+                dstPos += dstSize;
+            }
+            return mergeCount;
+        }
+
+        /**
+         * Modify the buffer by calling the provided function for each element.
+         * A single {@link Data} holder is used across every call. Modifications
+         * to the data overwrite the element in the buffer. The transformer will
+         * be called {@link #count()} times.
+         *
+         * @param transformer function to transform each element
+         */
+        public final void transform(Consumer<Data> transformer) {
+            transformIndexed((d, idx) -> transformer.accept(d));
+        }
+
+        /**
+         * Modify the buffer by calling the provided function for each element.
+         * A single {@link Data} holder is used across every call. Modifications
+         * to the data overwrite the element in the buffer. The transformer will
+         * be called {@link #count()} times. The index will be incremented for
+         * each call, starting at zero.
+         *
+         * @param transformer function to transform each element
+         */
+        public abstract void transformIndexed(ObjIntConsumer<Data> transformer);
+
+        /**
+         * Data holder used for modifying element data in buffers.
+         */
+        public static final class Data {
+
+            public double x, y, z, w;
+
+            private Data() {
+
+            }
+
+        }
+
+    }
+
+    /**
+     * Buffer holding elements of two doubles, corresponding to {@link Vec.D2}.
+     */
+    public static final class BufD2 extends BufD {
+
+        private BufD2(int capacity) {
+            super(2, capacity);
+        }
+
+        /**
+         * Copy the provided buffer into this buffer. This buffer is first
+         * cleared. This buffer must have the capacity to store the count of
+         * elements in the provided buffer.
+         *
+         * @param buffer buffer to copy from
+         * @throws IndexOutOfBoundsException if not enough capacity
+         */
+        public void copy(BufD2 buffer) {
+            if (buffer.count() > capacity) {
+                throw new IndexOutOfBoundsException("Not enough capacity");
+            }
+            clear();
+            write(buffer);
+        }
+
+        @Override
+        public void forEachIndexed(ObjIntConsumer<Data> transformer) {
+            Data holder = new Data();
+            for (int i = 0, pos = 0; i < count; i++) {
+                holder.x = data[pos];
+                holder.y = data[pos + 1];
+                transformer.accept(holder, i);
+                pos += 2;
+            }
+        }
+
+        @Override
+        public void generateIndexed(int amount, ObjIntConsumer<Data> transformer) {
+            Data holder = new Data();
+            int space = capacity - count;
+            if (amount > space) {
+                throw new IndexOutOfBoundsException("Not enough remaining space");
+            }
+            for (int i = 0, pos = count * 2; i < amount; i++) {
+                holder.x = 0;
+                holder.y = 0;
+                transformer.accept(holder, i);
+                data[pos++] = holder.x;
+                data[pos++] = holder.y;
+                count++;
+            }
+        }
+
+        @Override
+        public void transformIndexed(ObjIntConsumer<Data> transformer) {
+            Data holder = new Data();
+            for (int i = 0, pos = 0; i < count; i++) {
+                holder.x = data[pos];
+                holder.y = data[pos + 1];
+                transformer.accept(holder, i);
+                data[pos] = holder.x;
+                data[pos + 1] = holder.y;
+                pos += 2;
+            }
+        }
+
+        /**
+         * Create a list of {@link Vec.D2} from the elements in this buffer.
+         *
+         * @return list of Vec.D2
+         */
+        public final List<D2> toVecList() {
+            List<D2> list = new ArrayList<>(capacity);
+            forEach(d -> {
+                list.add(new D2(d.x, d.y));
+            });
+            return List.copyOf(list);
+        }
+
+        /**
+         * Append as many of the provided buffer's elements as will fit into the
+         * remaining capacity of this buffer.
+         *
+         * @param buffer source buffer
+         * @return number of appended elements
+         */
+        public final int write(BufD2 buffer) {
+            int remaining = capacity - count;
+            int copyCount = Math.min(buffer.count(), remaining);
+            System.arraycopy(buffer.data(), 0, data, count * 2, copyCount * 2);
+            count += copyCount;
+            return copyCount;
+        }
+
+        /**
+         * Append the provided {@link Vec.D2} into this buffer.
+         *
+         * @param vec element to write
+         */
+        public final void write(D2 vec) {
+            int pos = count * 2;
+            data[pos] = vec.x();
+            data[pos + 1] = vec.y();
+            count++;
+        }
+
+        /**
+         * Append as many of the provided list of {@link Vec.D2} as will fit
+         * into the remaining capacity of this buffer.
+         *
+         * @param vecs list of elements
+         * @return number of appended elements
+         */
+        public final int write(List<D2> vecs) {
+            for (int i = 0; i < vecs.size(); i++) {
+                if (count >= capacity) {
+                    return i;
+                }
+                write(vecs.get(i));
+            }
+            return vecs.size();
+        }
+
+        /**
+         * Allocate a buffer capable of holding the provided number of elements.
+         *
+         * @param capacity maximum element capacity
+         * @return created buffer
+         */
+        public static BufD2 allocate(int capacity) {
+            return new BufD2(capacity);
+        }
+
+        /**
+         * Create a buffer from the provided list of {@link Vec.D2}.
+         *
+         * @param vecs list of elements
+         * @return created buffer
+         */
+        public static BufD2 fromVecList(List<D2> vecs) {
+            BufD2 buffer = new BufD2(vecs.size());
+            buffer.write(vecs);
+            return buffer;
+        }
+
+    }
+
+    /**
+     * Buffer holding elements of three doubles, corresponding to
+     * {@link Vec.D3}.
+     */
+    public static final class BufD3 extends BufD {
+
+        private BufD3(int capacity) {
+            super(3, capacity);
+        }
+
+        /**
+         * Copy the provided buffer into this buffer. This buffer is first
+         * cleared. This buffer must have the capacity to store the count of
+         * elements in the provided buffer.
+         *
+         * @param buffer buffer to copy from
+         * @throws IndexOutOfBoundsException if not enough capacity
+         */
+        public void copy(BufD3 buffer) {
+            if (buffer.count() > capacity) {
+                throw new IndexOutOfBoundsException("Not enough capacity");
+            }
+            clear();
+            write(buffer);
+        }
+
+        @Override
+        public void forEachIndexed(ObjIntConsumer<Data> transformer) {
+            Data holder = new Data();
+            for (int i = 0, pos = 0; i < count; i++) {
+                holder.x = data[pos];
+                holder.y = data[pos + 1];
+                holder.z = data[pos + 2];
+                transformer.accept(holder, i);
+                pos += 3;
+            }
+        }
+
+        @Override
+        public void generateIndexed(int amount, ObjIntConsumer<Data> transformer) {
+            Data holder = new Data();
+            int space = capacity - count;
+            if (amount > space) {
+                throw new IndexOutOfBoundsException("Not enough remaining space");
+            }
+            for (int i = 0, pos = count * 3; i < amount; i++) {
+                holder.x = 0;
+                holder.y = 0;
+                holder.z = 0;
+                transformer.accept(holder, i);
+                data[pos++] = holder.x;
+                data[pos++] = holder.y;
+                data[pos++] = holder.z;
+                count++;
+            }
+        }
+
+        @Override
+        public void transformIndexed(ObjIntConsumer<Data> transformer) {
+            Data holder = new Data();
+            for (int i = 0, pos = 0; i < count; i++) {
+                holder.x = data[pos];
+                holder.y = data[pos + 1];
+                holder.z = data[pos + 2];
+                transformer.accept(holder, i);
+                data[pos] = holder.x;
+                data[pos + 1] = holder.y;
+                data[pos + 2] = holder.z;
+                pos += 3;
+            }
+        }
+
+        /**
+         * Create a list of {@link Vec.D3} from the elements in this buffer.
+         *
+         * @return list of Vec.D3
+         */
+        public final List<D3> toVecList() {
+            List<D3> list = new ArrayList<>(capacity);
+            forEach(d -> {
+                list.add(new D3(d.x, d.y, d.z));
+            });
+            return List.copyOf(list);
+        }
+
+        /**
+         * Append as many of the provided buffer's elements as will fit into the
+         * remaining capacity of this buffer.
+         *
+         * @param buffer source buffer
+         * @return number of appended elements
+         */
+        public final int write(BufD3 buffer) {
+            int remaining = capacity - count;
+            int copyCount = Math.min(buffer.count(), remaining);
+            System.arraycopy(buffer.data(), 0, data, count * 3, copyCount * 3);
+            count += copyCount;
+            return copyCount;
+        }
+
+        /**
+         * Append the provided {@link Vec.D3} into this buffer.
+         *
+         * @param vec element to write
+         */
+        public final void write(D3 vec) {
+            int pos = count * 3;
+            data[pos] = vec.x();
+            data[pos + 1] = vec.y();
+            data[pos + 2] = vec.z();
+            count++;
+        }
+
+        /**
+         * Append as many of the provided list of {@link Vec.D3} as will fit
+         * into the remaining capacity of this buffer.
+         *
+         * @param vecs list of elements
+         * @return number of appended elements
+         */
+        public final int write(List<D3> vecs) {
+            for (int i = 0; i < vecs.size(); i++) {
+                if (count >= capacity) {
+                    return i;
+                }
+                write(vecs.get(i));
+            }
+            return vecs.size();
+        }
+
+        /**
+         * Allocate a buffer capable of holding the provided number of elements.
+         *
+         * @param capacity maximum element capacity
+         * @return created buffer
+         */
+        public static BufD3 allocate(int capacity) {
+            return new BufD3(capacity);
+        }
+
+        /**
+         * Create a buffer from the provided list of {@link Vec.D3}.
+         *
+         * @param vecs list of elements
+         * @return created buffer
+         */
+        public static BufD3 fromVecList(List<D3> vecs) {
+            BufD3 buffer = new BufD3(vecs.size());
+            buffer.write(vecs);
+            return buffer;
+        }
+
+    }
+
+    /**
+     * Buffer holding elements of four doubles, corresponding to {@link Vec.D4}.
+     */
+    public static final class BufD4 extends BufD {
+
+        private BufD4(int capacity) {
+            super(4, capacity);
+        }
+
+        /**
+         * Copy the provided buffer into this buffer. This buffer is first
+         * cleared. This buffer must have the capacity to store the count of
+         * elements in the provided buffer.
+         *
+         * @param buffer buffer to copy from
+         * @throws IndexOutOfBoundsException if not enough capacity
+         */
+        public void copy(BufD4 buffer) {
+            if (buffer.count() > capacity) {
+                throw new IndexOutOfBoundsException("Not enough capacity");
+            }
+            clear();
+            write(buffer);
+        }
+
+        @Override
+        public void forEachIndexed(ObjIntConsumer<Data> transformer) {
+            Data holder = new Data();
+            for (int i = 0, pos = 0; i < count; i++) {
+                holder.x = data[pos];
+                holder.y = data[pos + 1];
+                holder.z = data[pos + 2];
+                holder.w = data[pos + 3];
+                transformer.accept(holder, i);
+                pos += 4;
+            }
+        }
+
+        @Override
+        public void generateIndexed(int amount, ObjIntConsumer<Data> transformer) {
+            Data holder = new Data();
+            int space = capacity - count;
+            if (amount > space) {
+                throw new IndexOutOfBoundsException("Not enough remaining space");
+            }
+            for (int i = 0, pos = count * 4; i < amount; i++) {
+                holder.x = 0;
+                holder.y = 0;
+                holder.z = 0;
+                holder.w = 0;
+                transformer.accept(holder, i);
+                data[pos++] = holder.x;
+                data[pos++] = holder.y;
+                data[pos++] = holder.z;
+                data[pos++] = holder.w;
+                count++;
+            }
+        }
+
+        @Override
+        public void transformIndexed(ObjIntConsumer<Data> transformer) {
+            Data holder = new Data();
+            for (int i = 0, pos = 0; i < count; i++) {
+                holder.x = data[pos];
+                holder.y = data[pos + 1];
+                holder.z = data[pos + 2];
+                holder.w = data[pos + 3];
+                transformer.accept(holder, i);
+                data[pos] = holder.x;
+                data[pos + 1] = holder.y;
+                data[pos + 2] = holder.z;
+                data[pos + 3] = holder.w;
+                pos += 4;
+            }
+        }
+
+        /**
+         * Create a list of {@link Vec.D4} from the elements in this buffer.
+         *
+         * @return list of Vec.D4
+         */
+        public final List<D4> toVecList() {
+            List<D4> list = new ArrayList<>(capacity);
+            forEach(d -> {
+                list.add(new D4(d.x, d.y, d.z, d.w));
+            });
+            return List.copyOf(list);
+        }
+
+        /**
+         * Append as many of the provided buffer's elements as will fit into the
+         * remaining capacity of this buffer.
+         *
+         * @param buffer source buffer
+         * @return number of appended elements
+         */
+        public final int write(BufD4 buffer) {
+            int remaining = capacity - count;
+            int copyCount = Math.min(buffer.count(), remaining);
+            System.arraycopy(buffer.data(), 0, data, count * 4, copyCount * 4);
+            count += copyCount;
+            return copyCount;
+        }
+
+        /**
+         * Append the provided {@link Vec.D4} into this buffer.
+         *
+         * @param vec element to write
+         */
+        public final void write(D4 vec) {
+            int pos = count * 4;
+            data[pos] = vec.x();
+            data[pos + 1] = vec.y();
+            data[pos + 2] = vec.z();
+            data[pos + 3] = vec.w();
+            count++;
+        }
+
+        /**
+         * Append as many of the provided list of {@link Vec.D4} as will fit
+         * into the remaining capacity of this buffer.
+         *
+         * @param vecs list of elements
+         * @return number of appended elements
+         */
+        public final int write(List<D4> vecs) {
+            for (int i = 0; i < vecs.size(); i++) {
+                if (count >= capacity) {
+                    return i;
+                }
+                write(vecs.get(i));
+            }
+            return vecs.size();
+        }
+
+        /**
+         * Allocate a buffer capable of holding the provided number of elements.
+         *
+         * @param capacity maximum element capacity
+         * @return created buffer
+         */
+        public static BufD4 allocate(int capacity) {
+            return new BufD4(capacity);
+        }
+
+        /**
+         * Create a buffer from the provided list of {@link Vec.D4}.
+         *
+         * @param vecs list of elements
+         * @return created buffer
+         */
+        public static BufD4 fromVecList(List<D4> vecs) {
+            BufD4 buffer = new BufD4(vecs.size());
+            buffer.write(vecs);
+            return buffer;
+        }
+
+    }
+
+    /**
+     * Mutable buffer for vector types wrapping an integer array. Buffers can be
+     * converted to and from lists of the equivalent Vec record types. The
+     * element size of a buffer corresponds to the number of components in the
+     * corresponding Vec type. Maximum capacity and count are given in terms of
+     * number of elements. Various generator, iterator and transform functions
+     * allow for in-place calculations via an element data holder.
+     */
+    public static sealed abstract class BufI {
+
+        final int[] data;
+        final int elementSize;
+        final int capacity;
+
+        int count;
+
+        BufI(int elementSize, int capacity) {
+            this.data = new int[elementSize * capacity];
+            this.elementSize = elementSize;
+            this.capacity = capacity;
+            count = 0;
+        }
+
+        /**
+         * Maximum capacity of the buffer in elements.
+         *
+         * @return maximum capacity
+         */
+        public final int capacity() {
+            return capacity;
+        }
+
+        /**
+         * Count of elements written to the buffer.
+         *
+         * @return element count
+         */
+        public final int count() {
+            return count;
+        }
+
+        /**
+         * Explicitly set the element count. The count must not be negative or
+         * greater than the capacity.
+         *
+         * @param count element count
+         */
+        public final void count(int count) {
+            if (count < 0 || count > capacity) {
+                throw new IllegalArgumentException("Invalid count");
+            }
+            this.count = count;
+        }
+
+        /**
+         * The element size of the corresponding Vec type.
+         *
+         * @return element size
+         */
+        public final int elementSize() {
+            return elementSize;
+        }
+
+        /**
+         * Access the underlying data array. Modifications to the buffer will be
+         * reflected in the array, and vice-versa. The array is of length
+         * {@code capacity() * elementSize()}.
+         *
+         * @return data array
+         */
+        public final int[] data() {
+            return data;
+        }
+
+        /**
+         * Reset the count to zero. The underlying array data is not modified.
+         */
+        public final void clear() {
+            count = 0;
+        }
+
+        /**
+         * Call the provided action for each element in the buffer. A single
+         * {@link Data} holder is used across every call. The action will be
+         * called {@link #count()} times.
+         *
+         * @param action action to perform for each element
+         */
+        public final void forEach(Consumer<Data> action) {
+            forEachIndexed((d, idx) -> action.accept(d));
+        }
+
+        /**
+         * Call the provided action for each element in the buffer. A single
+         * {@link Data} holder is used across every call. The action will be
+         * called {@link #count()} times. The index will be incremented for each
+         * call, starting at zero.
+         *
+         * @param action action to perform for each element
+         */
+        public abstract void forEachIndexed(ObjIntConsumer<Data> action);
+
+        /**
+         * Generate elements to add to the buffer by calling the provided
+         * generator function. A single {@link Data} holder is used across every
+         * call to the generator. Elements are appended to those currently in
+         * the buffer. There must be enough space between count and capacity to
+         * fit in the provided amount of elements.
+         *
+         * @param amount number of elements to append
+         * @param generator function to generate each element
+         * @throws IndexOutOfBoundsException if there is not enough space in the
+         * buffer
+         */
+        public final void generate(int amount, Consumer<Data> generator) {
+            generateIndexed(amount, (d, idx) -> generator.accept(d));
+        }
+
+        /**
+         * Generate elements to add to the buffer by calling the provided
+         * generator function. A single {@link Data} holder is used across every
+         * call to the generator. Elements are appended to those currently in
+         * the buffer. There must be enough space between count and capacity to
+         * fit in the provided amount of elements. The index will be incremented
+         * for each call, starting at zero.
+         *
+         * @param amount number of elements to append
+         * @param generator function to generate each element
+         * @throws IndexOutOfBoundsException if there is not enough space in the
+         * buffer
+         */
+        public abstract void generateIndexed(int amount, ObjIntConsumer<Data> generator);
+
+        /**
+         * Merge elements from another buffer into this one using the provided
+         * mapper function. The mapper function is provided with the destination
+         * data from this buffer and the corresponding element of the source
+         * buffer, in that order. The destination data will be written back to
+         * this buffer. The buffers may be of different element sizes. The count
+         * of merged elements will be the lower of this buffer count and the
+         * source buffer count.
+         *
+         * @param srcBuffer source buffer
+         * @param mapper function accepting element data from this buffer and
+         * the corresponding element of the source buffer
+         * @return count of merged elements
+         */
+        public int merge(BufI srcBuffer, BiConsumer<Data, Data> mapper) {
+            int mergeCount = Math.min(srcBuffer.count, count);
+            if (mergeCount < 1) {
+                return 0;
+            }
+            Data src = new Data();
+            Data dst = new Data();
+            int[] srcArray = srcBuffer.data();
+            int srcSize = srcBuffer.elementSize();
+            int dstSize = elementSize();
+            for (int i = 0, srcPos = 0, dstPos = 0; i < mergeCount; i++) {
+                src.x = srcArray[srcPos];
+                src.y = srcArray[srcPos + 1];
+                src.z = srcSize > 2 ? srcArray[srcPos + 2] : 0;
+                src.w = srcSize > 3 ? srcArray[srcPos + 3] : 0;
+                dst.x = data[dstPos];
+                dst.y = data[dstPos + 1];
+                dst.z = dstSize > 2 ? data[dstPos + 2] : 0;
+                dst.w = dstSize > 3 ? data[dstPos + 3] : 0;
+                mapper.accept(dst, src);
+                switch (dstSize) {
+                    case 2 -> {
+                        data[dstPos] = dst.x;
+                        data[dstPos + 1] = dst.y;
+                    }
+                    case 3 -> {
+                        data[dstPos] = dst.x;
+                        data[dstPos + 1] = dst.y;
+                        data[dstPos + 2] = dst.z;
+                    }
+                    case 4 -> {
+                        data[dstPos] = dst.x;
+                        data[dstPos + 1] = dst.y;
+                        data[dstPos + 2] = dst.z;
+                        data[dstPos + 3] = dst.w;
+                    }
+                }
+                srcPos += srcSize;
+                dstPos += dstSize;
+            }
+            return mergeCount;
+        }
+
+        /**
+         * Modify the buffer by calling the provided function for each element.
+         * A single {@link Data} holder is used across every call. Modifications
+         * to the data overwrite the element in the buffer. The transformer will
+         * be called {@link #count()} times.
+         *
+         * @param transformer function to transform each element
+         */
+        public final void transform(Consumer<Data> transformer) {
+            transformIndexed((d, idx) -> transformer.accept(d));
+        }
+
+        /**
+         * Modify the buffer by calling the provided function for each element.
+         * A single {@link Data} holder is used across every call. Modifications
+         * to the data overwrite the element in the buffer. The transformer will
+         * be called {@link #count()} times. The index will be incremented for
+         * each call, starting at zero.
+         *
+         * @param transformer function to transform each element
+         */
+        public abstract void transformIndexed(ObjIntConsumer<Data> transformer);
+
+        /**
+         * Data holder used for modifying element data in buffers.
+         */
+        public static final class Data {
+
+            public int x, y, z, w;
+
+            private Data() {
+
+            }
+
+        }
+
+    }
+
+    /**
+     * Buffer holding elements of two doubles, corresponding to {@link Vec.D2}.
+     */
+    public static final class BufI2 extends BufI {
+
+        private BufI2(int capacity) {
+            super(2, capacity);
+        }
+
+        /**
+         * Copy the provided buffer into this buffer. This buffer is first
+         * cleared. This buffer must have the capacity to store the count of
+         * elements in the provided buffer.
+         *
+         * @param buffer buffer to copy from
+         * @throws IndexOutOfBoundsException if not enough capacity
+         */
+        public void copy(BufI2 buffer) {
+            if (buffer.count() > capacity) {
+                throw new IndexOutOfBoundsException("Not enough capacity");
+            }
+            clear();
+            write(buffer);
+        }
+
+        @Override
+        public void forEachIndexed(ObjIntConsumer<Data> transformer) {
+            Data holder = new Data();
+            for (int i = 0, pos = 0; i < count; i++) {
+                holder.x = data[pos];
+                holder.y = data[pos + 1];
+                transformer.accept(holder, i);
+                pos += 2;
+            }
+        }
+
+        @Override
+        public void generateIndexed(int amount, ObjIntConsumer<Data> transformer) {
+            Data holder = new Data();
+            int space = capacity - count;
+            if (amount > space) {
+                throw new IndexOutOfBoundsException("Not enough remaining space");
+            }
+            for (int i = 0, pos = count * 2; i < amount; i++) {
+                holder.x = 0;
+                holder.y = 0;
+                transformer.accept(holder, i);
+                data[pos++] = holder.x;
+                data[pos++] = holder.y;
+                count++;
+            }
+        }
+
+        @Override
+        public void transformIndexed(ObjIntConsumer<Data> transformer) {
+            Data holder = new Data();
+            for (int i = 0, pos = 0; i < count; i++) {
+                holder.x = data[pos];
+                holder.y = data[pos + 1];
+                transformer.accept(holder, i);
+                data[pos] = holder.x;
+                data[pos + 1] = holder.y;
+                pos += 2;
+            }
+        }
+
+        /**
+         * Create a list of {@link Vec.I2} from the elements in this buffer.
+         *
+         * @return list of Vec.I2
+         */
+        public final List<I2> toVecList() {
+            List<I2> list = new ArrayList<>(capacity);
+            forEach(d -> {
+                list.add(new I2(d.x, d.y));
+            });
+            return List.copyOf(list);
+        }
+
+        /**
+         * Append as many of the provided buffer's elements as will fit into the
+         * remaining capacity of this buffer.
+         *
+         * @param buffer source buffer
+         * @return number of appended elements
+         */
+        public final int write(BufI2 buffer) {
+            int remaining = capacity - count;
+            int copyCount = Math.min(buffer.count(), remaining);
+            System.arraycopy(buffer.data(), 0, data, count * 2, copyCount * 2);
+            count += copyCount;
+            return copyCount;
+        }
+
+        /**
+         * Append the provided {@link Vec.I2} into this buffer.
+         *
+         * @param vec element to write
+         */
+        public final void write(I2 vec) {
+            int pos = count * 2;
+            data[pos] = vec.x();
+            data[pos + 1] = vec.y();
+            count++;
+        }
+
+        /**
+         * Append as many of the provided list of {@link Vec.I2} as will fit
+         * into the remaining capacity of this buffer.
+         *
+         * @param vecs list of elements
+         * @return number of appended elements
+         */
+        public final int write(List<I2> vecs) {
+            for (int i = 0; i < vecs.size(); i++) {
+                if (count >= capacity) {
+                    return i;
+                }
+                write(vecs.get(i));
+            }
+            return vecs.size();
+        }
+
+        /**
+         * Allocate a buffer capable of holding the provided number of elements.
+         *
+         * @param capacity maximum element capacity
+         * @return created buffer
+         */
+        public static BufI2 allocate(int capacity) {
+            return new BufI2(capacity);
+        }
+
+        /**
+         * Create a buffer from the provided list of {@link Vec.I2}.
+         *
+         * @param vecs list of elements
+         * @return created buffer
+         */
+        public static BufI2 fromVecList(List<I2> vecs) {
+            BufI2 buffer = new BufI2(vecs.size());
+            buffer.write(vecs);
+            return buffer;
+        }
+
+    }
+
+    /**
+     * Buffer holding elements of three doubles, corresponding to
+     * {@link Vec.I3}.
+     */
+    public static final class BufI3 extends BufI {
+
+        private BufI3(int capacity) {
+            super(3, capacity);
+        }
+
+        /**
+         * Copy the provided buffer into this buffer. This buffer is first
+         * cleared. This buffer must have the capacity to store the count of
+         * elements in the provided buffer.
+         *
+         * @param buffer buffer to copy from
+         * @throws IndexOutOfBoundsException if not enough capacity
+         */
+        public void copy(BufI3 buffer) {
+            if (buffer.count() > capacity) {
+                throw new IndexOutOfBoundsException("Not enough capacity");
+            }
+            clear();
+            write(buffer);
+        }
+
+        @Override
+        public void forEachIndexed(ObjIntConsumer<Data> transformer) {
+            Data holder = new Data();
+            for (int i = 0, pos = 0; i < count; i++) {
+                holder.x = data[pos];
+                holder.y = data[pos + 1];
+                holder.z = data[pos + 2];
+                transformer.accept(holder, i);
+                pos += 3;
+            }
+        }
+
+        @Override
+        public void generateIndexed(int amount, ObjIntConsumer<Data> transformer) {
+            Data holder = new Data();
+            int space = capacity - count;
+            if (amount > space) {
+                throw new IndexOutOfBoundsException("Not enough remaining space");
+            }
+            for (int i = 0, pos = count * 3; i < amount; i++) {
+                holder.x = 0;
+                holder.y = 0;
+                holder.z = 0;
+                transformer.accept(holder, i);
+                data[pos++] = holder.x;
+                data[pos++] = holder.y;
+                data[pos++] = holder.z;
+                count++;
+            }
+        }
+
+        @Override
+        public void transformIndexed(ObjIntConsumer<Data> transformer) {
+            Data holder = new Data();
+            for (int i = 0, pos = 0; i < count; i++) {
+                holder.x = data[pos];
+                holder.y = data[pos + 1];
+                holder.z = data[pos + 2];
+                transformer.accept(holder, i);
+                data[pos] = holder.x;
+                data[pos + 1] = holder.y;
+                data[pos + 2] = holder.z;
+                pos += 3;
+            }
+        }
+
+        /**
+         * Create a list of {@link Vec.I3} from the elements in this buffer.
+         *
+         * @return list of Vec.I3
+         */
+        public final List<I3> toVecList() {
+            List<I3> list = new ArrayList<>(capacity);
+            forEach(d -> {
+                list.add(new I3(d.x, d.y, d.z));
+            });
+            return List.copyOf(list);
+        }
+
+        /**
+         * Append as many of the provided buffer's elements as will fit into the
+         * remaining capacity of this buffer.
+         *
+         * @param buffer source buffer
+         * @return number of appended elements
+         */
+        public final int write(BufI3 buffer) {
+            int remaining = capacity - count;
+            int copyCount = Math.min(buffer.count(), remaining);
+            System.arraycopy(buffer.data(), 0, data, count * 3, copyCount * 3);
+            count += copyCount;
+            return copyCount;
+        }
+
+        /**
+         * Append the provided {@link Vec.I3} into this buffer.
+         *
+         * @param vec element to write
+         */
+        public final void write(I3 vec) {
+            int pos = count * 3;
+            data[pos] = vec.x();
+            data[pos + 1] = vec.y();
+            data[pos + 2] = vec.z();
+            count++;
+        }
+
+        /**
+         * Append as many of the provided list of {@link Vec.I3} as will fit
+         * into the remaining capacity of this buffer.
+         *
+         * @param vecs list of elements
+         * @return number of appended elements
+         */
+        public final int write(List<I3> vecs) {
+            for (int i = 0; i < vecs.size(); i++) {
+                if (count >= capacity) {
+                    return i;
+                }
+                write(vecs.get(i));
+            }
+            return vecs.size();
+        }
+
+        /**
+         * Allocate a buffer capable of holding the provided number of elements.
+         *
+         * @param capacity maximum element capacity
+         * @return created buffer
+         */
+        public static BufI3 allocate(int capacity) {
+            return new BufI3(capacity);
+        }
+
+        /**
+         * Create a buffer from the provided list of {@link Vec.I3}.
+         *
+         * @param vecs list of elements
+         * @return created buffer
+         */
+        public static BufI3 fromVecList(List<I3> vecs) {
+            BufI3 buffer = new BufI3(vecs.size());
+            buffer.write(vecs);
+            return buffer;
+        }
+
+    }
+
+    /**
+     * Buffer holding elements of four doubles, corresponding to {@link Vec.I4}.
+     */
+    public static final class BufI4 extends BufI {
+
+        private BufI4(int capacity) {
+            super(4, capacity);
+        }
+
+        /**
+         * Copy the provided buffer into this buffer. This buffer is first
+         * cleared. This buffer must have the capacity to store the count of
+         * elements in the provided buffer.
+         *
+         * @param buffer buffer to copy from
+         * @throws IndexOutOfBoundsException if not enough capacity
+         */
+        public void copy(BufI4 buffer) {
+            if (buffer.count() > capacity) {
+                throw new IndexOutOfBoundsException("Not enough capacity");
+            }
+            clear();
+            write(buffer);
+        }
+
+        @Override
+        public void forEachIndexed(ObjIntConsumer<Data> transformer) {
+            Data holder = new Data();
+            for (int i = 0, pos = 0; i < count; i++) {
+                holder.x = data[pos];
+                holder.y = data[pos + 1];
+                holder.z = data[pos + 2];
+                holder.w = data[pos + 3];
+                transformer.accept(holder, i);
+                pos += 4;
+            }
+        }
+
+        @Override
+        public void generateIndexed(int amount, ObjIntConsumer<Data> transformer) {
+            Data holder = new Data();
+            int space = capacity - count;
+            if (amount > space) {
+                throw new IndexOutOfBoundsException("Not enough remaining space");
+            }
+            for (int i = 0, pos = count * 4; i < amount; i++) {
+                holder.x = 0;
+                holder.y = 0;
+                holder.z = 0;
+                holder.w = 0;
+                transformer.accept(holder, i);
+                data[pos++] = holder.x;
+                data[pos++] = holder.y;
+                data[pos++] = holder.z;
+                data[pos++] = holder.w;
+                count++;
+            }
+        }
+
+        @Override
+        public void transformIndexed(ObjIntConsumer<Data> transformer) {
+            Data holder = new Data();
+            for (int i = 0, pos = 0; i < count; i++) {
+                holder.x = data[pos];
+                holder.y = data[pos + 1];
+                holder.z = data[pos + 2];
+                holder.w = data[pos + 3];
+                transformer.accept(holder, i);
+                data[pos] = holder.x;
+                data[pos + 1] = holder.y;
+                data[pos + 2] = holder.z;
+                data[pos + 3] = holder.w;
+                pos += 4;
+            }
+        }
+
+        /**
+         * Create a list of {@link Vec.I4} from the elements in this buffer.
+         *
+         * @return list of Vec.I4
+         */
+        public final List<I4> toVecList() {
+            List<I4> list = new ArrayList<>(capacity);
+            forEach(d -> {
+                list.add(new I4(d.x, d.y, d.z, d.w));
+            });
+            return List.copyOf(list);
+        }
+
+        /**
+         * Append as many of the provided buffer's elements as will fit into the
+         * remaining capacity of this buffer.
+         *
+         * @param buffer source buffer
+         * @return number of appended elements
+         */
+        public final int write(BufI4 buffer) {
+            int remaining = capacity - count;
+            int copyCount = Math.min(buffer.count(), remaining);
+            System.arraycopy(buffer.data(), 0, data, count * 4, copyCount * 4);
+            count += copyCount;
+            return copyCount;
+        }
+
+        /**
+         * Append the provided {@link Vec.I4} into this buffer.
+         *
+         * @param vec element to write
+         */
+        public final void write(I4 vec) {
+            int pos = count * 4;
+            data[pos] = vec.x();
+            data[pos + 1] = vec.y();
+            data[pos + 2] = vec.z();
+            data[pos + 3] = vec.w();
+            count++;
+        }
+
+        /**
+         * Append as many of the provided list of {@link Vec.I4} as will fit
+         * into the remaining capacity of this buffer.
+         *
+         * @param vecs list of elements
+         * @return number of appended elements
+         */
+        public final int write(List<I4> vecs) {
+            for (int i = 0; i < vecs.size(); i++) {
+                if (count >= capacity) {
+                    return i;
+                }
+                write(vecs.get(i));
+            }
+            return vecs.size();
+        }
+
+        /**
+         * Allocate a buffer capable of holding the provided number of elements.
+         *
+         * @param capacity maximum element capacity
+         * @return created buffer
+         */
+        public static BufI4 allocate(int capacity) {
+            return new BufI4(capacity);
+        }
+
+        /**
+         * Create a buffer from the provided list of {@link Vec.I4}.
+         *
+         * @param vecs list of elements
+         * @return created buffer
+         */
+        public static BufI4 fromVecList(List<I4> vecs) {
+            BufI4 buffer = new BufI4(vecs.size());
+            buffer.write(vecs);
+            return buffer;
+        }
+
+    }
+
+}

--- a/praxiscore-code/src/test/java/org/praxislive/code/userapi/VecTest.java
+++ b/praxiscore-code/src/test/java/org/praxislive/code/userapi/VecTest.java
@@ -1,0 +1,449 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright 2026 Neil C Smith.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License version 3 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * version 3 for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License version 3
+ * along with this work; if not, see http://www.gnu.org/licenses/
+ *
+ *
+ * Please visit https://www.praxislive.org if you need additional information or
+ * have any questions.
+ *
+ */
+package org.praxislive.code.userapi;
+
+import java.nio.DoubleBuffer;
+import java.nio.IntBuffer;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class VecTest {
+
+    @Test
+    public void testTransformDoubleBuffer() {
+        double[] data = new double[]{1, 2, 3, 4, 5, 6, 7, 8, 9};
+        DoubleBuffer buffer = DoubleBuffer.wrap(data);
+        Vec.transform(buffer, 2, d -> {
+            d[0] = -1;
+            d[1] *= 1.5;
+        });
+        assertArrayEquals(new double[]{-1, 3, -1, 6, -1, 9, -1, 12, 9}, data, 0.001);
+        assertEquals(1, buffer.remaining());
+    }
+
+    @Test
+    public void testTransformIntBuffer() {
+        int[] data = new int[]{1, 2, 3, 4, 5, 6, 7, 8, 9};
+        IntBuffer buffer = IntBuffer.wrap(data);
+        Vec.transform(buffer, 2, d -> {
+            d[0] = -1;
+            d[1] *= 2;
+        });
+        assertArrayEquals(new int[]{-1, 4, -1, 8, -1, 12, -1, 16, 9}, data);
+        assertEquals(1, buffer.remaining());
+    }
+
+    @Test
+    void testReadDoubleBuffer() {
+        double[] data = new double[]{1, 2, 3, 4, 5, 6, 7, 8, 9};
+        DoubleBuffer buffer = DoubleBuffer.wrap(data);
+        buffer.limit(7);
+        List<Vec.D2> vecs = Vec.read(buffer, 2, Vec.D2::new);
+        assertEquals(List.of(
+                new Vec.D2(1, 2),
+                new Vec.D2(3, 4),
+                new Vec.D2(5, 6)),
+                vecs);
+        buffer.clear().position(1);
+        vecs = Vec.read(buffer, 4, Vec.D2::new);
+        assertEquals(List.of(
+                new Vec.D2(2, 3),
+                new Vec.D2(6, 7)),
+                vecs);
+    }
+
+    @Test
+    void testReadIntBuffer() {
+        int[] data = new int[]{1, 2, 3, 4, 5, 6, 7, 8, 9};
+        IntBuffer buffer = IntBuffer.wrap(data);
+        buffer.limit(7);
+        var vec3D = Vec.read(buffer, 3, Vec.I3::new);
+        assertEquals(List.of(
+                new Vec.I3(1, 2, 3),
+                new Vec.I3(4, 5, 6)),
+                vec3D);
+        buffer.clear().position(1);
+        var vec2D = Vec.read(buffer, 4, Vec.I2::new);
+        assertEquals(List.of(
+                new Vec.I2(2, 3),
+                new Vec.I2(6, 7)),
+                vec2D);
+    }
+
+    @Test
+    void testGenerateIndexed_BufD2() {
+        Vec.BufD2 buffer = Vec.BufD2.allocate(4);
+        assertEquals(4, buffer.capacity());
+        assertEquals(0, buffer.count());
+        buffer.generateIndexed(3, (d, i) -> {
+            d.x = i * 2;
+            d.y = d.x + 1;
+        });
+        assertArrayEquals(new double[]{
+            0, 1,
+            2, 3,
+            4, 5,
+            0, 0
+        }, buffer.data(), 0.001);
+        assertEquals(3, buffer.count());
+    }
+
+    @Test
+    void testGenerateIndexed_BufD3() {
+        Vec.BufD3 buffer = Vec.BufD3.allocate(4);
+        assertEquals(4, buffer.capacity());
+        assertEquals(0, buffer.count());
+        buffer.generateIndexed(3, (d, i) -> {
+            d.x = i * 3;
+            d.y = d.x + 1;
+            d.z = d.y + 1;
+        });
+        assertArrayEquals(new double[]{
+            0, 1, 2,
+            3, 4, 5,
+            6, 7, 8,
+            0, 0, 0
+        }, buffer.data(), 0.001);
+        assertEquals(3, buffer.count());
+    }
+
+    @Test
+    void testGenerateIndexed_BufD4() {
+        Vec.BufD4 buffer = Vec.BufD4.allocate(4);
+        assertEquals(4, buffer.capacity());
+        assertEquals(0, buffer.count());
+        buffer.generateIndexed(3, (d, i) -> {
+            d.x = i * 4;
+            d.y = d.x + 1;
+            d.z = d.y + 1;
+            d.w = d.z + 1;
+        });
+        assertArrayEquals(new double[]{
+            0, 1, 2, 3,
+            4, 5, 6, 7,
+            8, 9, 10, 11,
+            0, 0, 0, 0
+        }, buffer.data(), 0.001);
+        assertEquals(3, buffer.count());
+    }
+
+    @Test
+    void testMerge_BufD() {
+        Vec.BufD2 buf2 = Vec.BufD2.fromVecList(List.of(
+                new Vec.D2(1, 2),
+                new Vec.D2(3, 4),
+                new Vec.D2(5, 6),
+                new Vec.D2(7, 8),
+                new Vec.D2(9, 10)
+        ));
+        Vec.BufD3 buf3 = Vec.BufD3.allocate(4);
+        Vec.BufD4 buf4 = Vec.BufD4.allocate(5);
+        int copied = buf3.merge(buf2, (dst, src) -> {
+            dst.y = src.x;
+            dst.z = src.y;
+        });
+        assertEquals(0, copied);
+        assertEquals(0, buf3.count());
+        buf3.count(4);
+        copied = buf3.merge(buf2, (dst, src) -> {
+            dst.y = src.x;
+            dst.z = src.y;
+        });
+        assertEquals(4, copied);
+        assertArrayEquals(new double[]{
+            0, 1, 2,
+            0, 3, 4,
+            0, 5, 6,
+            0, 7, 8
+        }, buf3.data(), 0.001);
+        buf4.count(3);
+        copied = buf4.merge(buf3, (dst, src) -> {
+            dst.x = src.z;
+            dst.y = -src.y;
+            dst.w = src.z * 2;
+        });
+        assertEquals(3, copied);
+        assertEquals(3, buf4.count());
+        assertArrayEquals(new double[]{
+            2, -1, 0, 4,
+            4, -3, 0, 8,
+            6, -5, 0, 12,
+            0, 0, 0, 0,
+            0, 0, 0, 0
+        }, buf4.data(), 0.001);
+        buf4.count(5);
+        copied = buf2.merge(buf4, (dst, src) -> {
+            dst.x = src.y;
+            dst.y = src.w;
+        });
+        assertEquals(5, copied);
+        assertEquals(5, buf2.count());
+        assertArrayEquals(new double[]{
+            -1, 4,
+            -3, 8,
+            -5, 12,
+            0, 0,
+            0, 0
+        }, buf2.data(), 0.001);
+    }
+
+    @Test
+    void testTransformIndexed_BufD2() {
+        Vec.BufD2 buffer = Vec.BufD2.fromVecList(List.of(
+                new Vec.D2(1, 2),
+                new Vec.D2(3, 4),
+                new Vec.D2(5, 6)
+        ));
+        buffer.transformIndexed((d, i) -> {
+            d.y = d.x;
+            d.x *= -1 - i;
+        });
+        assertArrayEquals(new double[]{
+            -1, 1,
+            -6, 3,
+            -15, 5
+        }, buffer.data(), 0.001);
+        assertEquals(3, buffer.count());
+    }
+
+    @Test
+    void testTransformIndexed_BufD3() {
+        Vec.BufD3 buffer = Vec.BufD3.fromVecList(List.of(
+                new Vec.D3(1, 2, 3),
+                new Vec.D3(4, 5, 6),
+                new Vec.D3(7, 8, 9)
+        ));
+        buffer.transformIndexed((d, i) -> {
+            d.y = d.x;
+            d.x *= -1 - i;
+            d.z = 0;
+        });
+        assertArrayEquals(new double[]{
+            -1, 1, 0,
+            -8, 4, 0,
+            -21, 7, 0
+        }, buffer.data(), 0.001);
+        assertEquals(3, buffer.count());
+    }
+
+    @Test
+    void testTransformIndexed_BufD4() {
+        Vec.BufD4 buffer = Vec.BufD4.fromVecList(List.of(
+                new Vec.D4(1, 2, 3, 4),
+                new Vec.D4(5, 6, 7, 8),
+                new Vec.D4(9, 10, 11, 12)
+        ));
+        buffer.transformIndexed((d, i) -> {
+            d.y = d.x;
+            d.x *= -1 - i;
+            d.z += 100;
+            d.w = 0;
+        });
+        assertArrayEquals(new double[]{
+            -1, 1, 103, 0,
+            -10, 5, 107, 0,
+            -27, 9, 111, 0
+        }, buffer.data(), 0.001);
+        assertEquals(3, buffer.count());
+    }
+
+    @Test
+    void testGenerateIndexed_BufI2() {
+        Vec.BufI2 buffer = Vec.BufI2.allocate(4);
+        assertEquals(4, buffer.capacity());
+        assertEquals(0, buffer.count());
+        buffer.generateIndexed(3, (d, i) -> {
+            d.x = i * 2;
+            d.y = d.x + 1;
+        });
+        assertArrayEquals(new int[]{
+            0, 1,
+            2, 3,
+            4, 5,
+            0, 0
+        }, buffer.data());
+        assertEquals(3, buffer.count());
+    }
+
+    @Test
+    void testGenerateIndexed_BufI3() {
+        Vec.BufI3 buffer = Vec.BufI3.allocate(4);
+        assertEquals(4, buffer.capacity());
+        assertEquals(0, buffer.count());
+        buffer.generateIndexed(3, (d, i) -> {
+            d.x = i * 3;
+            d.y = d.x + 1;
+            d.z = d.y + 1;
+        });
+        assertArrayEquals(new int[]{
+            0, 1, 2,
+            3, 4, 5,
+            6, 7, 8,
+            0, 0, 0
+        }, buffer.data());
+        assertEquals(3, buffer.count());
+    }
+
+    @Test
+    void testGenerateIndexed_BufI4() {
+        Vec.BufI4 buffer = Vec.BufI4.allocate(4);
+        assertEquals(4, buffer.capacity());
+        assertEquals(0, buffer.count());
+        buffer.generateIndexed(3, (d, i) -> {
+            d.x = i * 4;
+            d.y = d.x + 1;
+            d.z = d.y + 1;
+            d.w = d.z + 1;
+        });
+        assertArrayEquals(new int[]{
+            0, 1, 2, 3,
+            4, 5, 6, 7,
+            8, 9, 10, 11,
+            0, 0, 0, 0
+        }, buffer.data());
+        assertEquals(3, buffer.count());
+    }
+
+    @Test
+    void testMerge_BufI() {
+        Vec.BufI2 buf2 = Vec.BufI2.fromVecList(List.of(
+                new Vec.I2(1, 2),
+                new Vec.I2(3, 4),
+                new Vec.I2(5, 6),
+                new Vec.I2(7, 8),
+                new Vec.I2(9, 10)
+        ));
+        Vec.BufI3 buf3 = Vec.BufI3.allocate(4);
+        Vec.BufI4 buf4 = Vec.BufI4.allocate(5);
+        int copied = buf3.merge(buf2, (dst, src) -> {
+            dst.y = src.x;
+            dst.z = src.y;
+        });
+        assertEquals(0, copied);
+        assertEquals(0, buf3.count());
+        buf3.count(4);
+        copied = buf3.merge(buf2, (dst, src) -> {
+            dst.y = src.x;
+            dst.z = src.y;
+        });
+        assertEquals(4, copied);
+        assertArrayEquals(new int[]{
+            0, 1, 2,
+            0, 3, 4,
+            0, 5, 6,
+            0, 7, 8
+        }, buf3.data());
+        buf4.count(3);
+        copied = buf4.merge(buf3, (dst, src) -> {
+            dst.x = src.z;
+            dst.y = -src.y;
+            dst.w = src.z * 2;
+        });
+        assertEquals(3, copied);
+        assertEquals(3, buf4.count());
+        assertArrayEquals(new int[]{
+            2, -1, 0, 4,
+            4, -3, 0, 8,
+            6, -5, 0, 12,
+            0, 0, 0, 0,
+            0, 0, 0, 0
+        }, buf4.data());
+        buf4.count(5);
+        copied = buf2.merge(buf4, (dst, src) -> {
+            dst.x = src.y;
+            dst.y = src.w;
+        });
+        assertEquals(5, copied);
+        assertEquals(5, buf2.count());
+        assertArrayEquals(new int[]{
+            -1, 4,
+            -3, 8,
+            -5, 12,
+            0, 0,
+            0, 0
+        }, buf2.data());
+    }
+
+    @Test
+    void testTransformIndexed_BufI2() {
+        Vec.BufI2 buffer = Vec.BufI2.fromVecList(List.of(
+                new Vec.I2(1, 2),
+                new Vec.I2(3, 4),
+                new Vec.I2(5, 6)
+        ));
+        buffer.transformIndexed((d, i) -> {
+            d.y = d.x;
+            d.x *= -1 - i;
+        });
+        assertArrayEquals(new int[]{
+            -1, 1,
+            -6, 3,
+            -15, 5
+        }, buffer.data());
+        assertEquals(3, buffer.count());
+    }
+
+    @Test
+    void testTransformIndexed_BufI3() {
+        Vec.BufI3 buffer = Vec.BufI3.fromVecList(List.of(
+                new Vec.I3(1, 2, 3),
+                new Vec.I3(4, 5, 6),
+                new Vec.I3(7, 8, 9)
+        ));
+        buffer.transformIndexed((d, i) -> {
+            d.y = d.x;
+            d.x *= -1 - i;
+            d.z = 0;
+        });
+        assertArrayEquals(new int[]{
+            -1, 1, 0,
+            -8, 4, 0,
+            -21, 7, 0
+        }, buffer.data());
+        assertEquals(3, buffer.count());
+    }
+
+    @Test
+    void testTransformIndexed_BufI4() {
+        Vec.BufI4 buffer = Vec.BufI4.fromVecList(List.of(
+                new Vec.I4(1, 2, 3, 4),
+                new Vec.I4(5, 6, 7, 8),
+                new Vec.I4(9, 10, 11, 12)
+        ));
+        buffer.transformIndexed((d, i) -> {
+            d.y = d.x;
+            d.x *= -1 - i;
+            d.z += 100;
+            d.w = 0;
+        });
+        assertArrayEquals(new int[]{
+            -1, 1, 103, 0,
+            -10, 5, 107, 0,
+            -27, 9, 111, 0
+        }, buffer.data());
+        assertEquals(3, buffer.count());
+    }
+
+}


### PR DESCRIPTION
Add a range of integer and floating point vector record types for holding two, three and four dimensional data.

Also add a range of mutable typed buffers wrapping integer and double arrays holding elements corresponding to the various record types. The buffers can be converted to and from lists of the record type, as well as offering a range of in-place transformation functions.

Resolves #144 