### PR TITLE
Add Vec.BufF buffers and other Vec API improvements.

### DIFF
--- a/praxiscore-code/src/main/java/org/praxislive/code/userapi/Vec.java
+++ b/praxiscore-code/src/main/java/org/praxislive/code/userapi/Vec.java
@@ -22,7 +22,9 @@
  */
 package org.praxislive.code.userapi;
 
+import java.nio.BufferOverflowException;
 import java.nio.DoubleBuffer;
+import java.nio.FloatBuffer;
 import java.nio.IntBuffer;
 import java.util.ArrayList;
 import java.util.List;
@@ -484,6 +486,20 @@ public sealed interface Vec {
         public abstract void transformIndexed(ObjIntConsumer<Data> transformer);
 
         /**
+         * Write the data into the provided {@link DoubleBuffer}. The data will
+         * be written at the destination's position, and the destination must
+         * have enough remaining space to write {code count() * elementSize()}
+         * values.
+         *
+         * @param buffer destination
+         * @throws BufferOverflowException if there is insufficient space in the
+         * destination
+         */
+        public void writeTo(DoubleBuffer buffer) {
+            buffer.put(data, 0, count * elementSize);
+        }
+
+        /**
          * Data holder used for modifying element data in buffers.
          */
         public static final class Data {
@@ -520,7 +536,7 @@ public sealed interface Vec {
                 throw new IndexOutOfBoundsException("Not enough capacity");
             }
             clear();
-            write(buffer);
+            add(buffer);
         }
 
         @Override
@@ -584,7 +600,7 @@ public sealed interface Vec {
          * @param buffer source buffer
          * @return number of appended elements
          */
-        public final int write(BufD2 buffer) {
+        public final int add(BufD2 buffer) {
             int remaining = capacity - count;
             int copyCount = Math.min(buffer.count(), remaining);
             System.arraycopy(buffer.data(), 0, data, count * 2, copyCount * 2);
@@ -595,9 +611,9 @@ public sealed interface Vec {
         /**
          * Append the provided {@link Vec.D2} into this buffer.
          *
-         * @param vec element to write
+         * @param vec element to add
          */
-        public final void write(D2 vec) {
+        public final void add(D2 vec) {
             int pos = count * 2;
             data[pos] = vec.x();
             data[pos + 1] = vec.y();
@@ -611,12 +627,12 @@ public sealed interface Vec {
          * @param vecs list of elements
          * @return number of appended elements
          */
-        public final int write(List<D2> vecs) {
+        public final int add(List<D2> vecs) {
             for (int i = 0; i < vecs.size(); i++) {
                 if (count >= capacity) {
                     return i;
                 }
-                write(vecs.get(i));
+                add(vecs.get(i));
             }
             return vecs.size();
         }
@@ -639,7 +655,7 @@ public sealed interface Vec {
          */
         public static BufD2 fromVecList(List<D2> vecs) {
             BufD2 buffer = new BufD2(vecs.size());
-            buffer.write(vecs);
+            buffer.add(vecs);
             return buffer;
         }
 
@@ -668,7 +684,7 @@ public sealed interface Vec {
                 throw new IndexOutOfBoundsException("Not enough capacity");
             }
             clear();
-            write(buffer);
+            add(buffer);
         }
 
         @Override
@@ -737,7 +753,7 @@ public sealed interface Vec {
          * @param buffer source buffer
          * @return number of appended elements
          */
-        public final int write(BufD3 buffer) {
+        public final int add(BufD3 buffer) {
             int remaining = capacity - count;
             int copyCount = Math.min(buffer.count(), remaining);
             System.arraycopy(buffer.data(), 0, data, count * 3, copyCount * 3);
@@ -748,9 +764,9 @@ public sealed interface Vec {
         /**
          * Append the provided {@link Vec.D3} into this buffer.
          *
-         * @param vec element to write
+         * @param vec element to add
          */
-        public final void write(D3 vec) {
+        public final void add(D3 vec) {
             int pos = count * 3;
             data[pos] = vec.x();
             data[pos + 1] = vec.y();
@@ -765,12 +781,12 @@ public sealed interface Vec {
          * @param vecs list of elements
          * @return number of appended elements
          */
-        public final int write(List<D3> vecs) {
+        public final int add(List<D3> vecs) {
             for (int i = 0; i < vecs.size(); i++) {
                 if (count >= capacity) {
                     return i;
                 }
-                write(vecs.get(i));
+                add(vecs.get(i));
             }
             return vecs.size();
         }
@@ -793,7 +809,7 @@ public sealed interface Vec {
          */
         public static BufD3 fromVecList(List<D3> vecs) {
             BufD3 buffer = new BufD3(vecs.size());
-            buffer.write(vecs);
+            buffer.add(vecs);
             return buffer;
         }
 
@@ -821,7 +837,7 @@ public sealed interface Vec {
                 throw new IndexOutOfBoundsException("Not enough capacity");
             }
             clear();
-            write(buffer);
+            add(buffer);
         }
 
         @Override
@@ -895,7 +911,7 @@ public sealed interface Vec {
          * @param buffer source buffer
          * @return number of appended elements
          */
-        public final int write(BufD4 buffer) {
+        public final int add(BufD4 buffer) {
             int remaining = capacity - count;
             int copyCount = Math.min(buffer.count(), remaining);
             System.arraycopy(buffer.data(), 0, data, count * 4, copyCount * 4);
@@ -906,9 +922,9 @@ public sealed interface Vec {
         /**
          * Append the provided {@link Vec.D4} into this buffer.
          *
-         * @param vec element to write
+         * @param vec element to add
          */
-        public final void write(D4 vec) {
+        public final void add(D4 vec) {
             int pos = count * 4;
             data[pos] = vec.x();
             data[pos + 1] = vec.y();
@@ -924,12 +940,12 @@ public sealed interface Vec {
          * @param vecs list of elements
          * @return number of appended elements
          */
-        public final int write(List<D4> vecs) {
+        public final int add(List<D4> vecs) {
             for (int i = 0; i < vecs.size(); i++) {
                 if (count >= capacity) {
                     return i;
                 }
-                write(vecs.get(i));
+                add(vecs.get(i));
             }
             return vecs.size();
         }
@@ -952,7 +968,716 @@ public sealed interface Vec {
          */
         public static BufD4 fromVecList(List<D4> vecs) {
             BufD4 buffer = new BufD4(vecs.size());
-            buffer.write(vecs);
+            buffer.add(vecs);
+            return buffer;
+        }
+
+    }
+
+    /**
+     * Mutable buffer for vector types wrapping a float array. Buffers can be
+     * converted to and from lists of the equivalent VecD record types. The
+     * element size of a buffer corresponds to the number of components in the
+     * corresponding VecD type. Maximum capacity and count are given in terms of
+     * number of elements. Various generator, iterator and transform functions
+     * allow for in-place calculations via an element data holder.
+     * <p>
+     * The buffer data is stored as 32-bit single precision floating point
+     * values for situations where data in that format is required. The
+     * corresponding record types and data holder use double precision values.
+     * Some precision will be lost when storing these values in a BufF buffer.
+     */
+    public static sealed abstract class BufF {
+
+        final float[] data;
+        final int elementSize;
+        final int capacity;
+
+        int count;
+
+        BufF(int elementSize, int capacity) {
+            this.data = new float[elementSize * capacity];
+            this.elementSize = elementSize;
+            this.capacity = capacity;
+            count = 0;
+        }
+
+        /**
+         * Maximum capacity of the buffer in elements.
+         *
+         * @return maximum capacity
+         */
+        public final int capacity() {
+            return capacity;
+        }
+
+        /**
+         * Count of elements written to the buffer.
+         *
+         * @return element count
+         */
+        public final int count() {
+            return count;
+        }
+
+        /**
+         * Explicitly set the element count. The count must not be negative or
+         * greater than the capacity.
+         *
+         * @param count element count
+         */
+        public final void count(int count) {
+            if (count < 0 || count > capacity) {
+                throw new IllegalArgumentException("Invalid count");
+            }
+            this.count = count;
+        }
+
+        /**
+         * The element size of the corresponding Vec type.
+         *
+         * @return element size
+         */
+        public final int elementSize() {
+            return elementSize;
+        }
+
+        /**
+         * Access the underlying data array. Modifications to the buffer will be
+         * reflected in the array, and vice-versa. The array is of length
+         * {@code capacity() * elementSize()}.
+         *
+         * @return data array
+         */
+        public final float[] data() {
+            return data;
+        }
+
+        /**
+         * Reset the count to zero. The underlying array data is not modified.
+         */
+        public final void clear() {
+            count = 0;
+        }
+
+        /**
+         * Call the provided action for each element in the buffer. A single
+         * {@link Data} holder is used across every call. The action will be
+         * called {@link #count()} times.
+         *
+         * @param action action to perform for each element
+         */
+        public final void forEach(Consumer<Data> action) {
+            forEachIndexed((d, idx) -> action.accept(d));
+        }
+
+        /**
+         * Call the provided action for each element in the buffer. A single
+         * {@link Data} holder is used across every call. The action will be
+         * called {@link #count()} times. The index will be incremented for each
+         * call, starting at zero.
+         *
+         * @param action action to perform for each element
+         */
+        public abstract void forEachIndexed(ObjIntConsumer<Data> action);
+
+        /**
+         * Generate elements to add to the buffer by calling the provided
+         * generator function. A single {@link Data} holder is used across every
+         * call to the generator. Elements are appended to those currently in
+         * the buffer. There must be enough space between count and capacity to
+         * fit in the provided amount of elements.
+         *
+         * @param amount number of elements to append
+         * @param generator function to generate each element
+         * @throws IndexOutOfBoundsException if there is not enough space in the
+         * buffer
+         */
+        public final void generate(int amount, Consumer<Data> generator) {
+            generateIndexed(amount, (d, idx) -> generator.accept(d));
+        }
+
+        /**
+         * Generate elements to add to the buffer by calling the provided
+         * generator function. A single {@link Data} holder is used across every
+         * call to the generator. Elements are appended to those currently in
+         * the buffer. There must be enough space between count and capacity to
+         * fit in the provided amount of elements. The index will be incremented
+         * for each call, starting at zero.
+         *
+         * @param amount number of elements to append
+         * @param generator function to generate each element
+         * @throws IndexOutOfBoundsException if there is not enough space in the
+         * buffer
+         */
+        public abstract void generateIndexed(int amount, ObjIntConsumer<Data> generator);
+
+        /**
+         * Merge elements from another buffer into this one using the provided
+         * mapper function. The mapper function is provided with the destination
+         * data from this buffer and the corresponding element of the source
+         * buffer, in that order. The destination data will be written back to
+         * this buffer. The buffers may be of different element sizes. The count
+         * of merged elements will be the lower of this buffer count and the
+         * source buffer count.
+         *
+         * @param srcBuffer source buffer
+         * @param mapper function accepting element data from this buffer and
+         * the corresponding element of the source buffer
+         * @return count of merged elements
+         */
+        public int merge(BufF srcBuffer, BiConsumer<Data, Data> mapper) {
+            int mergeCount = Math.min(srcBuffer.count, count);
+            if (mergeCount < 1) {
+                return 0;
+            }
+            Data src = new Data();
+            Data dst = new Data();
+            float[] srcArray = srcBuffer.data();
+            int srcSize = srcBuffer.elementSize();
+            int dstSize = elementSize();
+            for (int i = 0, srcPos = 0, dstPos = 0; i < mergeCount; i++) {
+                src.x = srcArray[srcPos];
+                src.y = srcArray[srcPos + 1];
+                src.z = srcSize > 2 ? srcArray[srcPos + 2] : 0;
+                src.w = srcSize > 3 ? srcArray[srcPos + 3] : 0;
+                dst.x = data[dstPos];
+                dst.y = data[dstPos + 1];
+                dst.z = dstSize > 2 ? data[dstPos + 2] : 0;
+                dst.w = dstSize > 3 ? data[dstPos + 3] : 0;
+                mapper.accept(dst, src);
+                switch (dstSize) {
+                    case 2 -> {
+                        data[dstPos] = (float) dst.x;
+                        data[dstPos + 1] = (float) dst.y;
+                    }
+                    case 3 -> {
+                        data[dstPos] = (float) dst.x;
+                        data[dstPos + 1] = (float) dst.y;
+                        data[dstPos + 2] = (float) dst.z;
+                    }
+                    case 4 -> {
+                        data[dstPos] = (float) dst.x;
+                        data[dstPos + 1] = (float) dst.y;
+                        data[dstPos + 2] = (float) dst.z;
+                        data[dstPos + 3] = (float) dst.w;
+                    }
+                }
+                srcPos += srcSize;
+                dstPos += dstSize;
+            }
+            return mergeCount;
+        }
+
+        /**
+         * Modify the buffer by calling the provided function for each element.
+         * A single {@link Data} holder is used across every call. Modifications
+         * to the data overwrite the element in the buffer. The transformer will
+         * be called {@link #count()} times.
+         *
+         * @param transformer function to transform each element
+         */
+        public final void transform(Consumer<Data> transformer) {
+            transformIndexed((d, idx) -> transformer.accept(d));
+        }
+
+        /**
+         * Modify the buffer by calling the provided function for each element.
+         * A single {@link Data} holder is used across every call. Modifications
+         * to the data overwrite the element in the buffer. The transformer will
+         * be called {@link #count()} times. The index will be incremented for
+         * each call, starting at zero.
+         *
+         * @param transformer function to transform each element
+         */
+        public abstract void transformIndexed(ObjIntConsumer<Data> transformer);
+
+        /**
+         * Write the data into the provided {@link FloatBuffer}. The data will
+         * be written at the destination's position, and the destination must
+         * have enough remaining space to write {code count() * elementSize()}
+         * values.
+         *
+         * @param buffer destination
+         * @throws BufferOverflowException if there is insufficient space in the
+         * destination
+         */
+        public void writeTo(FloatBuffer buffer) {
+            buffer.put(data, 0, count * elementSize);
+        }
+
+        /**
+         * Data holder used for modifying element data in buffers.
+         */
+        public static final class Data {
+
+            public double x, y, z, w;
+
+            private Data() {
+
+            }
+
+        }
+
+    }
+
+    /**
+     * Buffer holding elements of two floats, a single precision equivalent to
+     * {@link Vec.D2}.
+     */
+    public static final class BufF2 extends BufF {
+
+        private BufF2(int capacity) {
+            super(2, capacity);
+        }
+
+        /**
+         * Copy the provided buffer into this buffer. This buffer is first
+         * cleared. This buffer must have the capacity to store the count of
+         * elements in the provided buffer.
+         *
+         * @param buffer buffer to copy from
+         * @throws IndexOutOfBoundsException if not enough capacity
+         */
+        public void copy(BufF2 buffer) {
+            if (buffer.count() > capacity) {
+                throw new IndexOutOfBoundsException("Not enough capacity");
+            }
+            clear();
+            add(buffer);
+        }
+
+        @Override
+        public void forEachIndexed(ObjIntConsumer<Data> transformer) {
+            Data holder = new Data();
+            for (int i = 0, pos = 0; i < count; i++) {
+                holder.x = data[pos];
+                holder.y = data[pos + 1];
+                transformer.accept(holder, i);
+                pos += 2;
+            }
+        }
+
+        @Override
+        public void generateIndexed(int amount, ObjIntConsumer<Data> transformer) {
+            Data holder = new Data();
+            int space = capacity - count;
+            if (amount > space) {
+                throw new IndexOutOfBoundsException("Not enough remaining space");
+            }
+            for (int i = 0, pos = count * 2; i < amount; i++) {
+                holder.x = 0;
+                holder.y = 0;
+                transformer.accept(holder, i);
+                data[pos++] = (float) holder.x;
+                data[pos++] = (float) holder.y;
+                count++;
+            }
+        }
+
+        @Override
+        public void transformIndexed(ObjIntConsumer<Data> transformer) {
+            Data holder = new Data();
+            for (int i = 0, pos = 0; i < count; i++) {
+                holder.x = data[pos];
+                holder.y = data[pos + 1];
+                transformer.accept(holder, i);
+                data[pos] = (float) holder.x;
+                data[pos + 1] = (float) holder.y;
+                pos += 2;
+            }
+        }
+
+        /**
+         * Create a list of {@link Vec.D2} from the elements in this buffer.
+         *
+         * @return list of Vec.D2
+         */
+        public final List<D2> toVecList() {
+            List<D2> list = new ArrayList<>(capacity);
+            forEach(d -> {
+                list.add(new D2(d.x, d.y));
+            });
+            return List.copyOf(list);
+        }
+
+        /**
+         * Append as many of the provided buffer's elements as will fit into the
+         * remaining capacity of this buffer.
+         *
+         * @param buffer source buffer
+         * @return number of appended elements
+         */
+        public final int add(BufF2 buffer) {
+            int remaining = capacity - count;
+            int copyCount = Math.min(buffer.count(), remaining);
+            System.arraycopy(buffer.data(), 0, data, count * 2, copyCount * 2);
+            count += copyCount;
+            return copyCount;
+        }
+
+        /**
+         * Append the provided {@link Vec.D2} into this buffer.
+         *
+         * @param vec element to add
+         */
+        public final void add(D2 vec) {
+            int pos = count * 2;
+            data[pos] = (float) vec.x();
+            data[pos + 1] = (float) vec.y();
+            count++;
+        }
+
+        /**
+         * Append as many of the provided list of {@link Vec.D2} as will fit
+         * into the remaining capacity of this buffer.
+         *
+         * @param vecs list of elements
+         * @return number of appended elements
+         */
+        public final int add(List<D2> vecs) {
+            for (int i = 0; i < vecs.size(); i++) {
+                if (count >= capacity) {
+                    return i;
+                }
+                add(vecs.get(i));
+            }
+            return vecs.size();
+        }
+
+        /**
+         * Allocate a buffer capable of holding the provided number of elements.
+         *
+         * @param capacity maximum element capacity
+         * @return created buffer
+         */
+        public static BufF2 allocate(int capacity) {
+            return new BufF2(capacity);
+        }
+
+        /**
+         * Create a buffer from the provided list of {@link Vec.D2}.
+         *
+         * @param vecs list of elements
+         * @return created buffer
+         */
+        public static BufF2 fromVecList(List<D2> vecs) {
+            BufF2 buffer = new BufF2(vecs.size());
+            buffer.add(vecs);
+            return buffer;
+        }
+
+    }
+
+    /**
+     * Buffer holding elements of three floats, a single precision equivalent to
+     * {@link Vec.D3}.
+     */
+    public static final class BufF3 extends BufF {
+
+        private BufF3(int capacity) {
+            super(3, capacity);
+        }
+
+        /**
+         * Copy the provided buffer into this buffer. This buffer is first
+         * cleared. This buffer must have the capacity to store the count of
+         * elements in the provided buffer.
+         *
+         * @param buffer buffer to copy from
+         * @throws IndexOutOfBoundsException if not enough capacity
+         */
+        public void copy(BufF3 buffer) {
+            if (buffer.count() > capacity) {
+                throw new IndexOutOfBoundsException("Not enough capacity");
+            }
+            clear();
+            add(buffer);
+        }
+
+        @Override
+        public void forEachIndexed(ObjIntConsumer<Data> transformer) {
+            Data holder = new Data();
+            for (int i = 0, pos = 0; i < count; i++) {
+                holder.x = data[pos];
+                holder.y = data[pos + 1];
+                holder.z = data[pos + 2];
+                transformer.accept(holder, i);
+                pos += 3;
+            }
+        }
+
+        @Override
+        public void generateIndexed(int amount, ObjIntConsumer<Data> transformer) {
+            Data holder = new Data();
+            int space = capacity - count;
+            if (amount > space) {
+                throw new IndexOutOfBoundsException("Not enough remaining space");
+            }
+            for (int i = 0, pos = count * 3; i < amount; i++) {
+                holder.x = 0;
+                holder.y = 0;
+                holder.z = 0;
+                transformer.accept(holder, i);
+                data[pos++] = (float) holder.x;
+                data[pos++] = (float) holder.y;
+                data[pos++] = (float) holder.z;
+                count++;
+            }
+        }
+
+        @Override
+        public void transformIndexed(ObjIntConsumer<Data> transformer) {
+            Data holder = new Data();
+            for (int i = 0, pos = 0; i < count; i++) {
+                holder.x = data[pos];
+                holder.y = data[pos + 1];
+                holder.z = data[pos + 2];
+                transformer.accept(holder, i);
+                data[pos] = (float) holder.x;
+                data[pos + 1] = (float) holder.y;
+                data[pos + 2] = (float) holder.z;
+                pos += 3;
+            }
+        }
+
+        /**
+         * Create a list of {@link Vec.D3} from the elements in this buffer.
+         *
+         * @return list of Vec.D3
+         */
+        public final List<D3> toVecList() {
+            List<D3> list = new ArrayList<>(capacity);
+            forEach(d -> {
+                list.add(new D3(d.x, d.y, d.z));
+            });
+            return List.copyOf(list);
+        }
+
+        /**
+         * Append as many of the provided buffer's elements as will fit into the
+         * remaining capacity of this buffer.
+         *
+         * @param buffer source buffer
+         * @return number of appended elements
+         */
+        public final int add(BufF3 buffer) {
+            int remaining = capacity - count;
+            int copyCount = Math.min(buffer.count(), remaining);
+            System.arraycopy(buffer.data(), 0, data, count * 3, copyCount * 3);
+            count += copyCount;
+            return copyCount;
+        }
+
+        /**
+         * Append the provided {@link Vec.D3} into this buffer.
+         *
+         * @param vec element to add
+         */
+        public final void add(D3 vec) {
+            int pos = count * 3;
+            data[pos] = (float) vec.x();
+            data[pos + 1] = (float) vec.y();
+            data[pos + 2] = (float) vec.z();
+            count++;
+        }
+
+        /**
+         * Append as many of the provided list of {@link Vec.D3} as will fit
+         * into the remaining capacity of this buffer.
+         *
+         * @param vecs list of elements
+         * @return number of appended elements
+         */
+        public final int add(List<D3> vecs) {
+            for (int i = 0; i < vecs.size(); i++) {
+                if (count >= capacity) {
+                    return i;
+                }
+                add(vecs.get(i));
+            }
+            return vecs.size();
+        }
+
+        /**
+         * Allocate a buffer capable of holding the provided number of elements.
+         *
+         * @param capacity maximum element capacity
+         * @return created buffer
+         */
+        public static BufF3 allocate(int capacity) {
+            return new BufF3(capacity);
+        }
+
+        /**
+         * Create a buffer from the provided list of {@link Vec.D3}.
+         *
+         * @param vecs list of elements
+         * @return created buffer
+         */
+        public static BufF3 fromVecList(List<D3> vecs) {
+            BufF3 buffer = new BufF3(vecs.size());
+            buffer.add(vecs);
+            return buffer;
+        }
+
+    }
+
+    /**
+     * Buffer holding elements of four floats, a single precision equivalent to
+     * {@link Vec.D4}.
+     */
+    public static final class BufF4 extends BufF {
+
+        private BufF4(int capacity) {
+            super(4, capacity);
+        }
+
+        /**
+         * Copy the provided buffer into this buffer. This buffer is first
+         * cleared. This buffer must have the capacity to store the count of
+         * elements in the provided buffer.
+         *
+         * @param buffer buffer to copy from
+         * @throws IndexOutOfBoundsException if not enough capacity
+         */
+        public void copy(BufF4 buffer) {
+            if (buffer.count() > capacity) {
+                throw new IndexOutOfBoundsException("Not enough capacity");
+            }
+            clear();
+            add(buffer);
+        }
+
+        @Override
+        public void forEachIndexed(ObjIntConsumer<Data> transformer) {
+            Data holder = new Data();
+            for (int i = 0, pos = 0; i < count; i++) {
+                holder.x = data[pos];
+                holder.y = data[pos + 1];
+                holder.z = data[pos + 2];
+                holder.w = data[pos + 3];
+                transformer.accept(holder, i);
+                pos += 4;
+            }
+        }
+
+        @Override
+        public void generateIndexed(int amount, ObjIntConsumer<Data> transformer) {
+            Data holder = new Data();
+            int space = capacity - count;
+            if (amount > space) {
+                throw new IndexOutOfBoundsException("Not enough remaining space");
+            }
+            for (int i = 0, pos = count * 4; i < amount; i++) {
+                holder.x = 0;
+                holder.y = 0;
+                holder.z = 0;
+                holder.w = 0;
+                transformer.accept(holder, i);
+                data[pos++] = (float) holder.x;
+                data[pos++] = (float) holder.y;
+                data[pos++] = (float) holder.z;
+                data[pos++] = (float) holder.w;
+                count++;
+            }
+        }
+
+        @Override
+        public void transformIndexed(ObjIntConsumer<Data> transformer) {
+            Data holder = new Data();
+            for (int i = 0, pos = 0; i < count; i++) {
+                holder.x = data[pos];
+                holder.y = data[pos + 1];
+                holder.z = data[pos + 2];
+                holder.w = data[pos + 3];
+                transformer.accept(holder, i);
+                data[pos] = (float) holder.x;
+                data[pos + 1] = (float) holder.y;
+                data[pos + 2] = (float) holder.z;
+                data[pos + 3] = (float) holder.w;
+                pos += 4;
+            }
+        }
+
+        /**
+         * Create a list of {@link Vec.D4} from the elements in this buffer.
+         *
+         * @return list of Vec.D4
+         */
+        public final List<D4> toVecList() {
+            List<D4> list = new ArrayList<>(capacity);
+            forEach(d -> {
+                list.add(new D4(d.x, d.y, d.z, d.w));
+            });
+            return List.copyOf(list);
+        }
+
+        /**
+         * Append as many of the provided buffer's elements as will fit into the
+         * remaining capacity of this buffer.
+         *
+         * @param buffer source buffer
+         * @return number of appended elements
+         */
+        public final int add(BufF4 buffer) {
+            int remaining = capacity - count;
+            int copyCount = Math.min(buffer.count(), remaining);
+            System.arraycopy(buffer.data(), 0, data, count * 4, copyCount * 4);
+            count += copyCount;
+            return copyCount;
+        }
+
+        /**
+         * Append the provided {@link Vec.D4} into this buffer.
+         *
+         * @param vec element to add
+         */
+        public final void add(D4 vec) {
+            int pos = count * 4;
+            data[pos] = (float) vec.x();
+            data[pos + 1] = (float) vec.y();
+            data[pos + 2] = (float) vec.z();
+            data[pos + 3] = (float) vec.w();
+            count++;
+        }
+
+        /**
+         * Append as many of the provided list of {@link Vec.D4} as will fit
+         * into the remaining capacity of this buffer.
+         *
+         * @param vecs list of elements
+         * @return number of appended elements
+         */
+        public final int add(List<D4> vecs) {
+            for (int i = 0; i < vecs.size(); i++) {
+                if (count >= capacity) {
+                    return i;
+                }
+                add(vecs.get(i));
+            }
+            return vecs.size();
+        }
+
+        /**
+         * Allocate a buffer capable of holding the provided number of elements.
+         *
+         * @param capacity maximum element capacity
+         * @return created buffer
+         */
+        public static BufF4 allocate(int capacity) {
+            return new BufF4(capacity);
+        }
+
+        /**
+         * Create a buffer from the provided list of {@link Vec.D4}.
+         *
+         * @param vecs list of elements
+         * @return created buffer
+         */
+        public static BufF4 fromVecList(List<D4> vecs) {
+            BufF4 buffer = new BufF4(vecs.size());
+            buffer.add(vecs);
             return buffer;
         }
 
@@ -1172,6 +1897,20 @@ public sealed interface Vec {
         public abstract void transformIndexed(ObjIntConsumer<Data> transformer);
 
         /**
+         * Write the data into the provided {@link IntBuffer}. The data will be
+         * written at the destination's position, and the destination must have
+         * enough remaining space to write {code count() * elementSize()}
+         * values.
+         *
+         * @param buffer destination
+         * @throws BufferOverflowException if there is insufficient space in the
+         * destination
+         */
+        public void writeTo(IntBuffer buffer) {
+            buffer.put(data, 0, count * elementSize);
+        }
+
+        /**
          * Data holder used for modifying element data in buffers.
          */
         public static final class Data {
@@ -1208,7 +1947,7 @@ public sealed interface Vec {
                 throw new IndexOutOfBoundsException("Not enough capacity");
             }
             clear();
-            write(buffer);
+            add(buffer);
         }
 
         @Override
@@ -1272,7 +2011,7 @@ public sealed interface Vec {
          * @param buffer source buffer
          * @return number of appended elements
          */
-        public final int write(BufI2 buffer) {
+        public final int add(BufI2 buffer) {
             int remaining = capacity - count;
             int copyCount = Math.min(buffer.count(), remaining);
             System.arraycopy(buffer.data(), 0, data, count * 2, copyCount * 2);
@@ -1283,9 +2022,9 @@ public sealed interface Vec {
         /**
          * Append the provided {@link Vec.I2} into this buffer.
          *
-         * @param vec element to write
+         * @param vec element to add
          */
-        public final void write(I2 vec) {
+        public final void add(I2 vec) {
             int pos = count * 2;
             data[pos] = vec.x();
             data[pos + 1] = vec.y();
@@ -1299,12 +2038,12 @@ public sealed interface Vec {
          * @param vecs list of elements
          * @return number of appended elements
          */
-        public final int write(List<I2> vecs) {
+        public final int add(List<I2> vecs) {
             for (int i = 0; i < vecs.size(); i++) {
                 if (count >= capacity) {
                     return i;
                 }
-                write(vecs.get(i));
+                add(vecs.get(i));
             }
             return vecs.size();
         }
@@ -1327,7 +2066,7 @@ public sealed interface Vec {
          */
         public static BufI2 fromVecList(List<I2> vecs) {
             BufI2 buffer = new BufI2(vecs.size());
-            buffer.write(vecs);
+            buffer.add(vecs);
             return buffer;
         }
 
@@ -1356,7 +2095,7 @@ public sealed interface Vec {
                 throw new IndexOutOfBoundsException("Not enough capacity");
             }
             clear();
-            write(buffer);
+            add(buffer);
         }
 
         @Override
@@ -1425,7 +2164,7 @@ public sealed interface Vec {
          * @param buffer source buffer
          * @return number of appended elements
          */
-        public final int write(BufI3 buffer) {
+        public final int add(BufI3 buffer) {
             int remaining = capacity - count;
             int copyCount = Math.min(buffer.count(), remaining);
             System.arraycopy(buffer.data(), 0, data, count * 3, copyCount * 3);
@@ -1436,9 +2175,9 @@ public sealed interface Vec {
         /**
          * Append the provided {@link Vec.I3} into this buffer.
          *
-         * @param vec element to write
+         * @param vec element to add
          */
-        public final void write(I3 vec) {
+        public final void add(I3 vec) {
             int pos = count * 3;
             data[pos] = vec.x();
             data[pos + 1] = vec.y();
@@ -1453,12 +2192,12 @@ public sealed interface Vec {
          * @param vecs list of elements
          * @return number of appended elements
          */
-        public final int write(List<I3> vecs) {
+        public final int add(List<I3> vecs) {
             for (int i = 0; i < vecs.size(); i++) {
                 if (count >= capacity) {
                     return i;
                 }
-                write(vecs.get(i));
+                add(vecs.get(i));
             }
             return vecs.size();
         }
@@ -1481,7 +2220,7 @@ public sealed interface Vec {
          */
         public static BufI3 fromVecList(List<I3> vecs) {
             BufI3 buffer = new BufI3(vecs.size());
-            buffer.write(vecs);
+            buffer.add(vecs);
             return buffer;
         }
 
@@ -1509,7 +2248,7 @@ public sealed interface Vec {
                 throw new IndexOutOfBoundsException("Not enough capacity");
             }
             clear();
-            write(buffer);
+            add(buffer);
         }
 
         @Override
@@ -1583,7 +2322,7 @@ public sealed interface Vec {
          * @param buffer source buffer
          * @return number of appended elements
          */
-        public final int write(BufI4 buffer) {
+        public final int add(BufI4 buffer) {
             int remaining = capacity - count;
             int copyCount = Math.min(buffer.count(), remaining);
             System.arraycopy(buffer.data(), 0, data, count * 4, copyCount * 4);
@@ -1594,9 +2333,9 @@ public sealed interface Vec {
         /**
          * Append the provided {@link Vec.I4} into this buffer.
          *
-         * @param vec element to write
+         * @param vec element to add
          */
-        public final void write(I4 vec) {
+        public final void add(I4 vec) {
             int pos = count * 4;
             data[pos] = vec.x();
             data[pos + 1] = vec.y();
@@ -1612,12 +2351,12 @@ public sealed interface Vec {
          * @param vecs list of elements
          * @return number of appended elements
          */
-        public final int write(List<I4> vecs) {
+        public final int add(List<I4> vecs) {
             for (int i = 0; i < vecs.size(); i++) {
                 if (count >= capacity) {
                     return i;
                 }
-                write(vecs.get(i));
+                add(vecs.get(i));
             }
             return vecs.size();
         }
@@ -1640,7 +2379,7 @@ public sealed interface Vec {
          */
         public static BufI4 fromVecList(List<I4> vecs) {
             BufI4 buffer = new BufI4(vecs.size());
-            buffer.write(vecs);
+            buffer.add(vecs);
             return buffer;
         }
 

--- a/praxiscore-code/src/test/java/org/praxislive/code/userapi/VecTest.java
+++ b/praxiscore-code/src/test/java/org/praxislive/code/userapi/VecTest.java
@@ -270,6 +270,183 @@ public class VecTest {
     }
 
     @Test
+    void testGenerateIndexed_BufF2() {
+        Vec.BufF2 buffer = Vec.BufF2.allocate(4);
+        assertEquals(4, buffer.capacity());
+        assertEquals(0, buffer.count());
+        buffer.generateIndexed(3, (d, i) -> {
+            d.x = i * 2;
+            d.y = d.x + 1;
+        });
+        assertArrayEquals(new float[]{
+            0, 1,
+            2, 3,
+            4, 5,
+            0, 0
+        }, buffer.data(), 0.001f);
+        assertEquals(3, buffer.count());
+    }
+
+    @Test
+    void testGenerateIndexed_BufF3() {
+        Vec.BufF3 buffer = Vec.BufF3.allocate(4);
+        assertEquals(4, buffer.capacity());
+        assertEquals(0, buffer.count());
+        buffer.generateIndexed(3, (d, i) -> {
+            d.x = i * 3;
+            d.y = d.x + 1;
+            d.z = d.y + 1;
+        });
+        assertArrayEquals(new float[]{
+            0, 1, 2,
+            3, 4, 5,
+            6, 7, 8,
+            0, 0, 0
+        }, buffer.data(), 0.001f);
+        assertEquals(3, buffer.count());
+    }
+
+    @Test
+    void testGenerateIndexed_BufF4() {
+        Vec.BufF4 buffer = Vec.BufF4.allocate(4);
+        assertEquals(4, buffer.capacity());
+        assertEquals(0, buffer.count());
+        buffer.generateIndexed(3, (d, i) -> {
+            d.x = i * 4;
+            d.y = d.x + 1;
+            d.z = d.y + 1;
+            d.w = d.z + 1;
+        });
+        assertArrayEquals(new float[]{
+            0, 1, 2, 3,
+            4, 5, 6, 7,
+            8, 9, 10, 11,
+            0, 0, 0, 0
+        }, buffer.data(), 0.001f);
+        assertEquals(3, buffer.count());
+    }
+
+    @Test
+    void testMerge_BufF() {
+        Vec.BufF2 buf2 = Vec.BufF2.fromVecList(List.of(
+                new Vec.D2(1, 2),
+                new Vec.D2(3, 4),
+                new Vec.D2(5, 6),
+                new Vec.D2(7, 8),
+                new Vec.D2(9, 10)
+        ));
+        Vec.BufF3 buf3 = Vec.BufF3.allocate(4);
+        Vec.BufF4 buf4 = Vec.BufF4.allocate(5);
+        int copied = buf3.merge(buf2, (dst, src) -> {
+            dst.y = src.x;
+            dst.z = src.y;
+        });
+        assertEquals(0, copied);
+        assertEquals(0, buf3.count());
+        buf3.count(4);
+        copied = buf3.merge(buf2, (dst, src) -> {
+            dst.y = src.x;
+            dst.z = src.y;
+        });
+        assertEquals(4, copied);
+        assertArrayEquals(new float[]{
+            0, 1, 2,
+            0, 3, 4,
+            0, 5, 6,
+            0, 7, 8
+        }, buf3.data(), 0.001f);
+        buf4.count(3);
+        copied = buf4.merge(buf3, (dst, src) -> {
+            dst.x = src.z;
+            dst.y = -src.y;
+            dst.w = src.z * 2;
+        });
+        assertEquals(3, copied);
+        assertEquals(3, buf4.count());
+        assertArrayEquals(new float[]{
+            2, -1, 0, 4,
+            4, -3, 0, 8,
+            6, -5, 0, 12,
+            0, 0, 0, 0,
+            0, 0, 0, 0
+        }, buf4.data(), 0.001f);
+        buf4.count(5);
+        copied = buf2.merge(buf4, (dst, src) -> {
+            dst.x = src.y;
+            dst.y = src.w;
+        });
+        assertEquals(5, copied);
+        assertEquals(5, buf2.count());
+        assertArrayEquals(new float[]{
+            -1, 4,
+            -3, 8,
+            -5, 12,
+            0, 0,
+            0, 0
+        }, buf2.data(), 0.001f);
+    }
+
+    @Test
+    void testTransformIndexed_BufF2() {
+        Vec.BufF2 buffer = Vec.BufF2.fromVecList(List.of(
+                new Vec.D2(1, 2),
+                new Vec.D2(3, 4),
+                new Vec.D2(5, 6)
+        ));
+        buffer.transformIndexed((d, i) -> {
+            d.y = d.x;
+            d.x *= -1 - i;
+        });
+        assertArrayEquals(new float[]{
+            -1, 1,
+            -6, 3,
+            -15, 5
+        }, buffer.data(), 0.001f);
+        assertEquals(3, buffer.count());
+    }
+
+    @Test
+    void testTransformIndexed_BufF3() {
+        Vec.BufF3 buffer = Vec.BufF3.fromVecList(List.of(
+                new Vec.D3(1, 2, 3),
+                new Vec.D3(4, 5, 6),
+                new Vec.D3(7, 8, 9)
+        ));
+        buffer.transformIndexed((d, i) -> {
+            d.y = d.x;
+            d.x *= -1 - i;
+            d.z = 0;
+        });
+        assertArrayEquals(new float[]{
+            -1, 1, 0,
+            -8, 4, 0,
+            -21, 7, 0
+        }, buffer.data(), 0.001f);
+        assertEquals(3, buffer.count());
+    }
+
+    @Test
+    void testTransformIndexed_BufF4() {
+        Vec.BufF4 buffer = Vec.BufF4.fromVecList(List.of(
+                new Vec.D4(1, 2, 3, 4),
+                new Vec.D4(5, 6, 7, 8),
+                new Vec.D4(9, 10, 11, 12)
+        ));
+        buffer.transformIndexed((d, i) -> {
+            d.y = d.x;
+            d.x *= -1 - i;
+            d.z += 100;
+            d.w = 0;
+        });
+        assertArrayEquals(new float[]{
+            -1, 1, 103, 0,
+            -10, 5, 107, 0,
+            -27, 9, 111, 0
+        }, buffer.data(), 0.001f);
+        assertEquals(3, buffer.count());
+    }
+
+    @Test
     void testGenerateIndexed_BufI2() {
         Vec.BufI2 buffer = Vec.BufI2.allocate(4);
         assertEquals(4, buffer.capacity());


### PR DESCRIPTION
Add Vec.BufF single precision float buffer wrapping a float[], but working with double precision Vec records and data holder.

Change Vec.Buf API to use add(..) rather than write(..).

Add writeTo(..) methods to write Vec.Buf data to NIO buffers.