### PR TITLE
Add support for loading PBytes from files

### DIFF
--- a/praxiscore-api/src/main/java/org/praxislive/core/types/PResource.java
+++ b/praxiscore-api/src/main/java/org/praxislive/core/types/PResource.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  * 
- * Copyright 2023 Neil C Smith.
+ * Copyright 2026 Neil C Smith.
  * 
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3 only, as
@@ -42,6 +42,13 @@ public final class PResource extends Value implements Comparable<PResource> {
     public static final String TYPE_NAME = "Resource";
 
     public final static String KEY_ALLOW_EMPTY = ArgumentInfo.KEY_ALLOW_EMPTY;
+
+    /**
+     * Optional key for hints to supported mime types for a resource. The
+     * attribute should be an array of values. The hint might be used to filter
+     * resource selection in a UI, etc.
+     */
+    public static final String KEY_MIME_TYPES = "mime-types";
 
     private final URI uri;
 

--- a/praxiscore-code/src/main/java/org/praxislive/code/AnnotationUtils.java
+++ b/praxiscore-code/src/main/java/org/praxislive/code/AnnotationUtils.java
@@ -255,8 +255,21 @@ class AnnotationUtils {
             Type.Resource annotation) throws TypeMismatchException {
         Class<?> targetType = TypeUtils.extractRawType(mapper.type());
         if (targetType == PResource.class) {
+            String[] mimes = annotation.mime();
+            PArray mimeTypes = mimes.length == 0 ? PArray.EMPTY
+                    : Stream.of(mimes)
+                            .map(PString::of)
+                            .collect(PArray.collector());
+            ArgumentInfo info = Info.argument(a -> {
+                Info.ValueInfoBuilder bld = a.type(PResource.class)
+                        .property(PResource.KEY_ALLOW_EMPTY, true);
+                if (!mimeTypes.isEmpty()) {
+                    bld.property(PResource.KEY_MIME_TYPES, mimeTypes);
+                }
+                return bld;
+            });
             return new ArgumentData<>(mapper, PString.EMPTY,
-                    mapper.createInfo(), v -> true);
+                    info, v -> true);
         } else {
             throw new TypeMismatchException();
         }

--- a/praxiscore-code/src/main/java/org/praxislive/code/CodeConnector.java
+++ b/praxiscore-code/src/main/java/org/praxislive/code/CodeConnector.java
@@ -71,6 +71,7 @@ import org.praxislive.core.types.PString;
 import org.praxislive.core.services.LogBuilder;
 import org.praxislive.core.services.LogLevel;
 import org.praxislive.core.types.PArray;
+import org.praxislive.core.types.PBytes;
 
 /**
  * Base class for analysing a {@link CodeDelegate} and creating the resources
@@ -695,10 +696,17 @@ public abstract class CodeConnector<D extends CodeDelegate> {
     }
 
     private boolean analyseResourcePropertyField(P ann, Field field) {
-        if (field.getAnnotation(Type.Resource.class) != null
-                && String.class.equals(field.getType())) {
-            ResourceProperty.Descriptor rpd
-                    = ResourceProperty.Descriptor.create(this, ann, field, ResourceProperty.getStringLoader());
+        if (field.getAnnotation(Type.Resource.class) != null) {
+            ResourceProperty.Descriptor rpd;
+            if (String.class.equals(field.getType())) {
+                rpd = ResourceProperty.Descriptor.create(this, ann, field,
+                        ResourceProperty.getStringLoader());
+            } else if (PBytes.class.equals(field.getType())) {
+                rpd = ResourceProperty.Descriptor.create(this, ann, field,
+                        ResourceProperty.getBytesLoader());
+            } else {
+                rpd = null;
+            }
             if (rpd != null) {
                 addControl(rpd);
                 if (shouldAddPort(field)) {

--- a/praxiscore-code/src/main/java/org/praxislive/code/ResourceProperty.java
+++ b/praxiscore-code/src/main/java/org/praxislive/code/ResourceProperty.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright 2023 Neil C Smith.
+ * Copyright 2026 Neil C Smith.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3 only, as
@@ -22,6 +22,7 @@
  */
 package org.praxislive.code;
 
+import java.io.BufferedInputStream;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
@@ -52,6 +53,7 @@ import org.praxislive.core.types.PReference;
 import org.praxislive.core.types.PResource;
 import org.praxislive.core.types.PString;
 import org.praxislive.core.services.LogLevel;
+import org.praxislive.core.types.PBytes;
 
 /**
  *
@@ -188,9 +190,14 @@ public final class ResourceProperty<V> extends AbstractAsyncProperty<V> {
         return StringLoader.INSTANCE;
     }
 
+    public static Loader<PBytes> getBytesLoader() {
+        return PBytesLoader.INSTANCE;
+    }
+
+    // @TODO in v7 use readAllAsString - keep existing line delimiters
     private static class StringLoader extends Loader<String> {
 
-        private final static StringLoader INSTANCE = new StringLoader();
+        private static final StringLoader INSTANCE = new StringLoader();
 
         private StringLoader() {
             super(String.class);
@@ -212,6 +219,35 @@ public final class ResourceProperty<V> extends AbstractAsyncProperty<V> {
         @Override
         public String getEmptyValue() {
             return "";
+        }
+
+    }
+
+    private static class PBytesLoader extends Loader<PBytes> {
+
+        private static final PBytesLoader INSTANCE = new PBytesLoader();
+
+        private PBytesLoader() {
+            super(PBytes.class);
+        }
+
+        @Override
+        public PBytes load(URI uri) throws IOException {
+            try (BufferedInputStream bis = new BufferedInputStream(
+                    uri.toURL().openStream())) {
+                PBytes.OutputStream bos = new PBytes.OutputStream();
+                bis.transferTo(bos);
+                return bos.toBytes();
+            } catch (IOException ex) {
+                throw ex;
+            } catch (Exception ex) {
+                throw new IOException(ex);
+            }
+        }
+
+        @Override
+        public PBytes getEmptyValue() {
+            return PBytes.EMPTY;
         }
 
     }

--- a/praxiscore-code/src/main/java/org/praxislive/code/ResourceProperty.java
+++ b/praxiscore-code/src/main/java/org/praxislive/code/ResourceProperty.java
@@ -33,42 +33,36 @@ import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.praxislive.code.userapi.Config;
 import org.praxislive.code.userapi.OnChange;
 import org.praxislive.code.userapi.OnError;
 import org.praxislive.code.userapi.P;
+import org.praxislive.code.userapi.Type;
 import org.praxislive.core.Value;
 import org.praxislive.core.Control;
 import org.praxislive.core.Lookup;
 import org.praxislive.core.Port;
 import org.praxislive.core.ControlInfo;
+import org.praxislive.core.Info;
 import org.praxislive.core.PortInfo;
 import org.praxislive.core.TreeWriter;
 import org.praxislive.core.services.TaskService;
 import org.praxislive.core.types.PError;
-import org.praxislive.core.types.PMap;
 import org.praxislive.core.types.PNumber;
 import org.praxislive.core.types.PReference;
 import org.praxislive.core.types.PResource;
 import org.praxislive.core.types.PString;
 import org.praxislive.core.services.LogLevel;
+import org.praxislive.core.types.PArray;
 import org.praxislive.core.types.PBytes;
 
 /**
  *
  */
 public final class ResourceProperty<V> extends AbstractAsyncProperty<V> {
-
-    private final static ControlInfo INFO = ControlInfo.createPropertyInfo(
-            PResource.info(true),
-            PString.EMPTY,
-            PMap.EMPTY);
-
-    private final static ControlInfo PREF_INFO = ControlInfo.createPropertyInfo(
-            PResource.info(true),
-            PString.EMPTY,
-            PMap.of("preferred", true));
 
     private final Loader<V> loader;
     private Field field;
@@ -274,8 +268,33 @@ public final class ResourceProperty<V> extends AbstractAsyncProperty<V> {
             this.field = field;
             this.onChange = onChange;
             this.onError = onError;
-            this.info = field.isAnnotationPresent(Config.Preferred.class)
-                    ? PREF_INFO : INFO;
+            PArray mimeTypes = Optional.ofNullable(field.getAnnotation(Type.Resource.class))
+                    .map(ann -> {
+                        String[] mimes = ann.mime();
+                        if (mimes.length == 0) {
+                            return PArray.EMPTY;
+                        } else {
+                            return Stream.of(mimes)
+                                    .map(PString::of)
+                                    .collect(PArray.collector());
+                        }
+                    }).orElse(PArray.EMPTY);
+            Info.PropertyInfoBuilder infoBld = Info.control().property()
+                    .input(a -> {
+                        Info.ValueInfoBuilder bld = a.type(PResource.class)
+                                .property(PResource.KEY_ALLOW_EMPTY, true);
+                        if (!mimeTypes.isEmpty()) {
+                            bld.property(PResource.KEY_MIME_TYPES, mimeTypes);
+                        }
+                        return bld;
+                    })
+                    .defaultValue(PString.EMPTY);
+
+            boolean preferred = field.isAnnotationPresent(Config.Preferred.class);
+            if (preferred) {
+                infoBld.property("preferred", true);
+            }
+            this.info = infoBld.build();
         }
 
         @Override

--- a/praxiscore-code/src/main/java/org/praxislive/code/userapi/Constants.java
+++ b/praxiscore-code/src/main/java/org/praxislive/code/userapi/Constants.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright 2025 Neil C Smith.
+ * Copyright 2026 Neil C Smith.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3 only, as
@@ -108,5 +108,10 @@ public final class Constants {
      * with inlining in HTML.
      */
     public static final String MIME_SVG = "image/x.svg-html";
+
+    /**
+     * Media type representing a folder or directory - {@code inode/directory}.
+     */
+    public static final String MIME_FOLDER = "inode/directory";
 
 }

--- a/praxiscore-code/src/main/java/org/praxislive/code/userapi/Type.java
+++ b/praxiscore-code/src/main/java/org/praxislive/code/userapi/Type.java
@@ -221,6 +221,15 @@ public @interface Type {
     @Retention(RetentionPolicy.RUNTIME)
     public static @interface Resource {
 
+        /**
+         * Optional list of mime types to filter supported resources. Any
+         * non-empty value will be added as an info hint where it may be used to
+         * filter resource selection in a UI, etc. The default value is empty.
+         *
+         * @return optional mime filters
+         */
+        public java.lang.String[] mime() default {};
+
     }
 
 }


### PR DESCRIPTION
Add PBytes loader to ResourceProperty.
Update CodeConnector to check use of `@Type.Resource` with PBytes properties.

Add a mime filter hint info key to `PResource`.
Add optional mime element to `@Type.Resource` to configure hint.
Use annotation to set hint in `ResourceProperty`.

Resolves #146 