### PR TITLE
Rename info properties as attributes to avoid confusion

### DIFF
--- a/praxiscore-api/src/main/java/org/praxislive/core/ArgumentInfo.java
+++ b/praxiscore-api/src/main/java/org/praxislive/core/ArgumentInfo.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  * 
- * Copyright 2023 Neil C Smith.
+ * Copyright 2026 Neil C Smith.
  * 
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3 only, as
@@ -28,7 +28,7 @@ import org.praxislive.core.types.PMap;
  * Info object used to define the valid input and output arguments of a Control.
  * <p>
  * As well as giving the type of the argument, an ArgumentInfo can have an
- * optional set of properties. This might be used for defining the "minimum" and
+ * optional set of attributes. This might be used for defining the "minimum" and
  * "maximum" values of a PNumber argument, for example.
  *
  */
@@ -115,9 +115,26 @@ public final class ArgumentInfo extends PMap.MapBasedValue {
      * This method is equivalent to calling
      * {@link PMap.MapBasedValue#dataMap()}.
      *
+     * @deprecated replaced by {@link #attributes()} to reduce confusion with
+     * property controls.
+     *
      * @return property map
      */
+    @Deprecated(forRemoval = true)
     public PMap properties() {
+        return dataMap();
+    }
+
+    /**
+     * Access the map of attributes. The map includes the value type, as well as
+     * any custom or optional attributes.
+     * <p>
+     * This method is equivalent to calling
+     * {@link PMap.MapBasedValue#dataMap()}.
+     *
+     * @return attribute map
+     */
+    public PMap attributes() {
         return dataMap();
     }
 
@@ -135,22 +152,22 @@ public final class ArgumentInfo extends PMap.MapBasedValue {
 
     /**
      * Create an ArgumentInfo from the Value class and optional PMap of
-     * additional properties.
+     * additional attributes.
      *
      * @param argClass
-     * @param properties
+     * @param attributes
      * @return ArgumentInfo
      */
     public static ArgumentInfo of(Class<? extends Value> argClass,
-            PMap properties) {
-        return create(Value.Type.of(argClass).name(), properties);
+            PMap attributes) {
+        return create(Value.Type.of(argClass).name(), attributes);
 
     }
 
-    static ArgumentInfo create(String argumentType, PMap properties) {
+    static ArgumentInfo create(String argumentType, PMap attributes) {
         PMap map = PMap.of(KEY_TYPE, argumentType);
-        if (properties != null) {
-            map = PMap.merge(map, properties, PMap.IF_ABSENT);
+        if (attributes != null) {
+            map = PMap.merge(map, attributes, PMap.IF_ABSENT);
         }
         return new ArgumentInfo(argumentType, map);
     }

--- a/praxiscore-api/src/main/java/org/praxislive/core/ComponentInfo.java
+++ b/praxiscore-api/src/main/java/org/praxislive/core/ComponentInfo.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  * 
- * Copyright 2024 Neil C Smith.
+ * Copyright 2026 Neil C Smith.
  * 
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3 only, as
@@ -31,10 +31,10 @@ import org.praxislive.core.types.PMap;
 import org.praxislive.core.types.PString;
 
 /**
- * Information about the controls, ports, protocols and properties of a
+ * Information about the controls, ports, protocols and attributes of a
  * Component.
  */
-public class ComponentInfo extends PMap.MapBasedValue {
+public final class ComponentInfo extends PMap.MapBasedValue {
 
     /**
      * Value type name.
@@ -58,7 +58,7 @@ public class ComponentInfo extends PMap.MapBasedValue {
 
     /**
      * Optional key for storing the {@link ComponentType} of the Component in
-     * the properties map. value must be a valid component type.
+     * the attributes map. Value must be a valid component type.
      */
     public static final String KEY_COMPONENT_TYPE = "component-type";
 
@@ -80,11 +80,11 @@ public class ComponentInfo extends PMap.MapBasedValue {
      * Optional key for adding a default list of control IDs to give extra
      * priority to exposing to the user. Value must be an array.
      * <p>
-     * It is up to any editor whether to use or ignore this property (eg. the
+     * It is up to any editor whether to use or ignore this attribute (eg. the
      * PraxisLIVE graph editor will show exposed controls on the graph itself).
      * If the editor supports overriding the default list of exposed controls,
      * it should add the altered list under the same key in the
-     * {@link ComponentProtocol#META} property.
+     * {@link ComponentProtocol#META} attribute.
      */
     public static final String KEY_EXPOSE = "expose";
 
@@ -171,9 +171,26 @@ public class ComponentInfo extends PMap.MapBasedValue {
      * This method is equivalent to calling
      * {@link PMap.MapBasedValue#dataMap()}.
      *
+     * @deprecated replaced by {@link #attributes()} to reduce confusion with
+     * property controls.
+     *
      * @return property map
      */
+    @Deprecated(forRemoval = true)
     public PMap properties() {
+        return dataMap();
+    }
+
+    /**
+     * Access the map of attributes. The map includes all the controls, ports
+     * and protocols, as well as any custom or optional attributes.
+     * <p>
+     * This method is equivalent to calling
+     * {@link PMap.MapBasedValue#dataMap()}.
+     *
+     * @return attribute map
+     */
+    public PMap attributes() {
         return dataMap();
     }
 
@@ -181,7 +198,7 @@ public class ComponentInfo extends PMap.MapBasedValue {
             Map<String, ControlInfo> controls,
             Map<String, PortInfo> ports,
             Set<String> protocols,
-            PMap properties) {
+            PMap attributes) {
 
         var ctrls = OrderedMap.copyOf(controls);
         var prts = OrderedMap.copyOf(ports);
@@ -192,8 +209,8 @@ public class ComponentInfo extends PMap.MapBasedValue {
                 KEY_PROTOCOLS, protos.stream().map(PString::of).collect(PArray.collector())
         );
 
-        if (properties != null && !properties.isEmpty()) {
-            data = PMap.merge(data, properties, PMap.IF_ABSENT);
+        if (attributes != null && !attributes.isEmpty()) {
+            data = PMap.merge(data, attributes, PMap.IF_ABSENT);
         }
 
         return new ComponentInfo(ctrls, prts, protos, data);

--- a/praxiscore-api/src/main/java/org/praxislive/core/Container.java
+++ b/praxiscore-api/src/main/java/org/praxislive/core/Container.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  * 
- * Copyright 2023 Neil C Smith.
+ * Copyright 2026 Neil C Smith.
  * 
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3 only, as
@@ -94,7 +94,7 @@ public interface Container extends Component, Lookup.Provider {
      */
     public default ComponentType getType(Component child) {
         return Optional.ofNullable(child.getInfo())
-                .map(info -> info.properties().get(ComponentInfo.KEY_COMPONENT_TYPE))
+                .map(info -> info.attributes().get(ComponentInfo.KEY_COMPONENT_TYPE))
                 .flatMap(ComponentType::from)
                 .orElse(null);
     }

--- a/praxiscore-api/src/main/java/org/praxislive/core/ControlInfo.java
+++ b/praxiscore-api/src/main/java/org/praxislive/core/ControlInfo.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  * 
- * Copyright 2024 Neil C Smith.
+ * Copyright 2026 Neil C Smith.
  * 
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3 only, as
@@ -27,7 +27,7 @@ import org.praxislive.core.types.PArray;
 import org.praxislive.core.types.PMap;
 
 /**
- * Information on the type, inputs, outputs and properties of a {@link Control}.
+ * Information on the type, inputs, outputs and attributes of a {@link Control}.
  */
 public final class ControlInfo extends PMap.MapBasedValue {
 
@@ -143,9 +143,26 @@ public final class ControlInfo extends PMap.MapBasedValue {
      * This method is equivalent to calling
      * {@link PMap.MapBasedValue#dataMap()}.
      *
+     * @deprecated replaced by {@link #attributes()} to reduce confusion with
+     * property controls.
+     *
      * @return property map
      */
+    @Deprecated(forRemoval = true)
     public PMap properties() {
+        return dataMap();
+    }
+
+    /**
+     * Access the map of attributes. The map includes the type, inputs, outputs
+     * and defaults, as well as any custom or optional attributes.
+     * <p>
+     * This method is equivalent to calling
+     * {@link PMap.MapBasedValue#dataMap()}.
+     *
+     * @return attribute map
+     */
+    public PMap attributes() {
         return dataMap();
     }
 
@@ -182,18 +199,18 @@ public final class ControlInfo extends PMap.MapBasedValue {
      *
      * @param inputs list of input info
      * @param outputs list of output info
-     * @param properties additional properties (may be null)
+     * @param attributes additional attributes (may be null)
      * @return control info
      */
     public static ControlInfo createFunctionInfo(List<ArgumentInfo> inputs,
-            List<ArgumentInfo> outputs, PMap properties) {
+            List<ArgumentInfo> outputs, PMap attributes) {
         List<ArgumentInfo> ins = inputs == null ? List.of() : List.copyOf(inputs);
         List<ArgumentInfo> outs = outputs == null ? List.of() : List.copyOf(outputs);
         PMap map = PMap.of(KEY_TYPE, Type.Function,
                 KEY_INPUTS, PArray.of(ins),
                 KEY_OUTPUTS, PArray.of(outs));
-        if (properties != null) {
-            map = PMap.merge(map, properties, PMap.IF_ABSENT);
+        if (attributes != null) {
+            map = PMap.merge(map, attributes, PMap.IF_ABSENT);
         }
         return new ControlInfo(Type.Function, ins, outs, List.of(), map);
     }
@@ -201,13 +218,13 @@ public final class ControlInfo extends PMap.MapBasedValue {
     /**
      * Create ControlInfo for an action control.
      *
-     * @param properties additional properties (may be null)
+     * @param attributes additional attributes (may be null)
      * @return control info
      */
-    public static ControlInfo createActionInfo(PMap properties) {
+    public static ControlInfo createActionInfo(PMap attributes) {
         PMap map = PMap.of(KEY_TYPE, Type.Action);
-        if (properties != null) {
-            map = PMap.merge(map, properties, PMap.IF_ABSENT);
+        if (attributes != null) {
+            map = PMap.merge(map, attributes, PMap.IF_ABSENT);
         }
         return new ControlInfo(Type.Action, List.of(), List.of(), List.of(), map);
     }
@@ -217,23 +234,23 @@ public final class ControlInfo extends PMap.MapBasedValue {
      *
      * @param argument property value info
      * @param def default value
-     * @param properties additional properties (may be null)
+     * @param attributes additional attributes (may be null)
      * @return control info
      */
     public static ControlInfo createPropertyInfo(ArgumentInfo argument,
-            Value def, PMap properties) {
-        return createPropertyInfo(List.of(argument), List.of(def), properties);
+            Value def, PMap attributes) {
+        return createPropertyInfo(List.of(argument), List.of(def), attributes);
     }
 
     public static ControlInfo createPropertyInfo(List<ArgumentInfo> arguments,
-            List<Value> defaults, PMap properties) {
+            List<Value> defaults, PMap attributes) {
         List<ArgumentInfo> ins = arguments == null ? List.of() : List.copyOf(arguments);
         List<Value> defs = defaults == null ? List.of() : List.copyOf(defaults);
         PMap map = PMap.of(KEY_TYPE, Type.Property,
                 KEY_INPUTS, PArray.of(ins),
                 KEY_DEFAULTS, PArray.of(defs));
-        if (properties != null) {
-            map = PMap.merge(map, properties, PMap.IF_ABSENT);
+        if (attributes != null) {
+            map = PMap.merge(map, attributes, PMap.IF_ABSENT);
         }
         return new ControlInfo(Type.Property, ins, ins, defs, map);
     }
@@ -242,21 +259,21 @@ public final class ControlInfo extends PMap.MapBasedValue {
      * Create ControlInfo for a read-only property control.
      *
      * @param argument property value info
-     * @param properties additional properties (may be null)
+     * @param attributes additional attributes (may be null)
      * @return control info
      */
     public static ControlInfo createReadOnlyPropertyInfo(ArgumentInfo argument,
-            PMap properties) {
-        return createReadOnlyPropertyInfo(List.of(argument), properties);
+            PMap attributes) {
+        return createReadOnlyPropertyInfo(List.of(argument), attributes);
     }
 
     public static ControlInfo createReadOnlyPropertyInfo(List<ArgumentInfo> arguments,
-            PMap properties) {
+            PMap attributes) {
         List<ArgumentInfo> outs = arguments == null ? List.of() : List.copyOf(arguments);
         PMap map = PMap.of(KEY_TYPE, Type.ReadOnlyProperty,
                 KEY_OUTPUTS, PArray.of(outs));
-        if (properties != null) {
-            map = PMap.merge(map, properties, PMap.IF_ABSENT);
+        if (attributes != null) {
+            map = PMap.merge(map, attributes, PMap.IF_ABSENT);
         }
         return new ControlInfo(Type.ReadOnlyProperty, List.of(), outs, List.of(), map);
     }

--- a/praxiscore-api/src/main/java/org/praxislive/core/Info.java
+++ b/praxiscore-api/src/main/java/org/praxislive/core/Info.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  * 
- * Copyright 2023 Neil C Smith.
+ * Copyright 2026 Neil C Smith.
  * 
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3 only, as
@@ -135,7 +135,7 @@ public class Info {
         private final Map<String, ControlInfo> controls;
         private final Map<String, PortInfo> ports;
         private final Set<String> protocols;
-        private PMap.Builder properties;
+        private PMap.Builder attributes;
 
         ComponentInfoBuilder() {
             controls = new LinkedHashMap<>();
@@ -202,14 +202,26 @@ public class Info {
          * @param value Object value
          * @return this
          */
+        @Deprecated(forRemoval = true)
         public ComponentInfoBuilder property(String key, Object value) {
+            return attribute(key, value);
+        }
+
+        /**
+         * Add custom attribute.
+         *
+         * @param key String key
+         * @param value Object value
+         * @return this
+         */
+        public ComponentInfoBuilder attribute(String key, Object value) {
             if (RESERVED_KEYS.contains(key)) {
                 throw new IllegalArgumentException("Reserved key");
             }
-            if (properties == null) {
-                properties = PMap.builder();
+            if (attributes == null) {
+                attributes = PMap.builder();
             }
-            properties.put(key, value);
+            attributes.put(key, value);
             return this;
         }
 
@@ -249,9 +261,9 @@ public class Info {
             for (String id : info.ports()) {
                 ports.put(id, info.portInfo(id));
             }
-            for (String key : info.properties().keys()) {
+            for (String key : info.attributes().keys()) {
                 if (!RESERVED_KEYS.contains(key)) {
-                    property(key, info.properties().get(key));
+                    attribute(key, info.attributes().get(key));
                 }
             }
             info.protocols().forEach(this::protocol);
@@ -260,7 +272,7 @@ public class Info {
 
         public ComponentInfo build() {
             return ComponentInfo.create(controls, ports, protocols,
-                    properties == null ? PMap.EMPTY : properties.build());
+                    attributes == null ? PMap.EMPTY : attributes.build());
         }
 
     }
@@ -324,7 +336,7 @@ public class Info {
         );
 
         private final ControlInfo.Type type;
-        private PMap.Builder properties;
+        private PMap.Builder attributes;
 
         List<ArgumentInfo> inputs;
         List<ArgumentInfo> outputs;
@@ -345,21 +357,34 @@ public class Info {
          * @return this
          */
         @SuppressWarnings("unchecked")
+        @Deprecated(forRemoval = true)
         public T property(String key, Object value) {
+            return attribute(key, value);
+        }
+
+        /**
+         * Add custom attribute.
+         *
+         * @param key String key
+         * @param value Object value
+         * @return this
+         */
+        @SuppressWarnings("unchecked")
+        public T attribute(String key, Object value) {
             if (RESERVED_KEYS.contains(key)) {
                 throw new IllegalArgumentException("Reserved key");
             }
-            if (properties == null) {
-                properties = PMap.builder();
+            if (attributes == null) {
+                attributes = PMap.builder();
             }
-            properties.put(key, value);
+            attributes.put(key, value);
             return (T) this;
         }
 
         public abstract ControlInfo build();
 
-        PMap buildProperties() {
-            return properties == null ? PMap.EMPTY : properties.build();
+        PMap buildAttributes() {
+            return attributes == null ? PMap.EMPTY : attributes.build();
         }
 
     }
@@ -419,7 +444,7 @@ public class Info {
 
         @Override
         public ControlInfo build() {
-            return ControlInfo.createPropertyInfo(inputs, defaults, buildProperties());
+            return ControlInfo.createPropertyInfo(inputs, defaults, buildAttributes());
         }
 
     }
@@ -467,7 +492,7 @@ public class Info {
 
         @Override
         public ControlInfo build() {
-            return ControlInfo.createReadOnlyPropertyInfo(outputs, buildProperties());
+            return ControlInfo.createReadOnlyPropertyInfo(outputs, buildAttributes());
         }
 
     }
@@ -528,7 +553,7 @@ public class Info {
 
         @Override
         public ControlInfo build() {
-            return ControlInfo.createFunctionInfo(inputs, outputs, buildProperties());
+            return ControlInfo.createFunctionInfo(inputs, outputs, buildAttributes());
         }
 
     }
@@ -544,7 +569,7 @@ public class Info {
 
         @Override
         public ControlInfo build() {
-            return ControlInfo.createActionInfo(buildProperties());
+            return ControlInfo.createActionInfo(buildAttributes());
         }
 
     }
@@ -605,7 +630,7 @@ public class Info {
     public static abstract class ArgumentInfoBuilder<T extends ArgumentInfoBuilder<T>> {
 
         private final String type;
-        private PMap.Builder properties;
+        private PMap.Builder attributes;
 
         ArgumentInfoBuilder(String type) {
             this.type = type;
@@ -619,20 +644,33 @@ public class Info {
          * @return this
          */
         @SuppressWarnings("unchecked")
+        @Deprecated(forRemoval = true)
         public T property(String key, Object value) {
+            return attribute(key, value);
+        }
+
+        /**
+         * Add custom attribute.
+         *
+         * @param key String key
+         * @param value Object value
+         * @return this
+         */
+        @SuppressWarnings("unchecked")
+        public T attribute(String key, Object value) {
             if (ArgumentInfo.KEY_TYPE.equals(key)) {
                 throw new IllegalArgumentException("Reserved key");
             }
-            if (properties == null) {
-                properties = PMap.builder();
+            if (attributes == null) {
+                attributes = PMap.builder();
             }
-            properties.put(key, value);
+            attributes.put(key, value);
             return (T) this;
         }
 
         public ArgumentInfo build() {
             return ArgumentInfo.create(type,
-                    properties == null ? PMap.EMPTY : properties.build());
+                    attributes == null ? PMap.EMPTY : attributes.build());
         }
 
     }
@@ -664,7 +702,7 @@ public class Info {
          * @return this
          */
         public NumberInfoBuilder min(double min) {
-            return property(PNumber.KEY_MINIMUM, PNumber.of(min));
+            return attribute(PNumber.KEY_MINIMUM, PNumber.of(min));
         }
 
         /**
@@ -674,7 +712,7 @@ public class Info {
          * @return this
          */
         public NumberInfoBuilder max(double max) {
-            return property(PNumber.KEY_MAXIMUM, PNumber.of(max));
+            return attribute(PNumber.KEY_MAXIMUM, PNumber.of(max));
         }
 
         /**
@@ -684,7 +722,7 @@ public class Info {
          * @return this
          */
         public NumberInfoBuilder skew(double skew) {
-            return property(PNumber.KEY_MINIMUM, PNumber.of(skew));
+            return attribute(PNumber.KEY_MINIMUM, PNumber.of(skew));
         }
 
     }
@@ -705,7 +743,7 @@ public class Info {
          * @return this
          */
         public StringInfoBuilder allowed(String... values) {
-            return property(ArgumentInfo.KEY_ALLOWED_VALUES,
+            return attribute(ArgumentInfo.KEY_ALLOWED_VALUES,
                     Stream.of(values).map(PString::of).collect(PArray.collector()));
         }
 
@@ -716,7 +754,7 @@ public class Info {
          * @return this
          */
         public StringInfoBuilder suggested(String... values) {
-            return property(ArgumentInfo.KEY_SUGGESTED_VALUES,
+            return attribute(ArgumentInfo.KEY_SUGGESTED_VALUES,
                     Stream.of(values).map(PString::of).collect(PArray.collector()));
         }
 
@@ -726,7 +764,7 @@ public class Info {
          * @return this
          */
         public StringInfoBuilder emptyIsDefault() {
-            return property(ArgumentInfo.KEY_EMPTY_IS_DEFAULT, PBoolean.TRUE);
+            return attribute(ArgumentInfo.KEY_EMPTY_IS_DEFAULT, PBoolean.TRUE);
         }
 
         /**
@@ -736,7 +774,7 @@ public class Info {
          * @return this
          */
         public StringInfoBuilder template(String template) {
-            return property(ArgumentInfo.KEY_TEMPLATE, PString.of(template));
+            return attribute(ArgumentInfo.KEY_TEMPLATE, PString.of(template));
         }
 
         /**
@@ -746,7 +784,7 @@ public class Info {
          * @return this
          */
         public StringInfoBuilder mime(String mime) {
-            return property(ArgumentInfo.KEY_MIME_TYPE, PString.of(mime));
+            return attribute(ArgumentInfo.KEY_MIME_TYPE, PString.of(mime));
         }
 
     }
@@ -808,7 +846,7 @@ public class Info {
 
         private final String type;
         private final PortInfo.Direction direction;
-        private PMap.Builder properties;
+        private PMap.Builder attributes;
 
         PortInfoBuilder(String type, PortInfo.Direction direction) {
             this.type = type;
@@ -822,17 +860,29 @@ public class Info {
          * @param value Object value
          * @return this
          */
+        @Deprecated(forRemoval = true)
         public PortInfoBuilder property(String key, Object value) {
-            if (properties == null) {
-                properties = PMap.builder();
+            return attribute(key, value);
+        }
+
+        /**
+         * Add custom attribute.
+         *
+         * @param key String key
+         * @param value Object value
+         * @return this
+         */
+        public PortInfoBuilder attribute(String key, Object value) {
+            if (attributes == null) {
+                attributes = PMap.builder();
             }
-            properties.put(key, value);
+            attributes.put(key, value);
             return this;
         }
 
         public PortInfo build() {
             return PortInfo.create(type, direction,
-                    properties == null ? PMap.EMPTY : properties.build());
+                    attributes == null ? PMap.EMPTY : attributes.build());
         }
 
     }

--- a/praxiscore-api/src/main/java/org/praxislive/core/PortInfo.java
+++ b/praxiscore-api/src/main/java/org/praxislive/core/PortInfo.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  * 
- * Copyright 2023 Neil C Smith.
+ * Copyright 2026 Neil C Smith.
  * 
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3 only, as
@@ -101,9 +101,26 @@ public final class PortInfo extends PMap.MapBasedValue {
      * This method is equivalent to calling
      * {@link PMap.MapBasedValue#dataMap()}.
      *
+     * @deprecated replaced by {@link #attributes()} to reduce confusion with
+     * property controls.
+     *
      * @return property map
      */
+    @Deprecated(forRemoval = true)
     public PMap properties() {
+        return dataMap();
+    }
+
+    /**
+     * Access the map of attributes. The map includes the type and direction, as
+     * well as any custom or optional attributes.
+     * <p>
+     * This method is equivalent to calling
+     * {@link PMap.MapBasedValue#dataMap()}.
+     *
+     * @return attribute map
+     */
+    public PMap attributes() {
         return dataMap();
     }
 

--- a/praxiscore-api/src/main/java/org/praxislive/core/ValueMapper.java
+++ b/praxiscore-api/src/main/java/org/praxislive/core/ValueMapper.java
@@ -297,7 +297,7 @@ public abstract class ValueMapper<T> {
                 return super.createInfo();
             } else {
                 return Info.argument().type(valueType().asClass())
-                        .property(ArgumentInfo.KEY_ALLOW_EMPTY, true)
+                        .attribute(ArgumentInfo.KEY_ALLOW_EMPTY, true)
                         .build();
             }
         }
@@ -371,7 +371,7 @@ public abstract class ValueMapper<T> {
         @Override
         public ArgumentInfo createInfo() {
             return Info.argument().type(PNumber.class)
-                    .property(PNumber.KEY_IS_INTEGER, true)
+                    .attribute(PNumber.KEY_IS_INTEGER, true)
                     .build();
         }
 
@@ -523,8 +523,8 @@ public abstract class ValueMapper<T> {
                 schemaEntries[i] = PMap.entry(names.get(i), mappers.get(i).createInfo());
             }
             return Info.argument().type(PMap.class)
-                    .property(ArgumentInfo.KEY_ALLOW_EMPTY, true)
-                    .property(PMap.KEY_SCHEMA, PMap.ofEntries(schemaEntries))
+                    .attribute(ArgumentInfo.KEY_ALLOW_EMPTY, true)
+                    .attribute(PMap.KEY_SCHEMA, PMap.ofEntries(schemaEntries))
                     .build();
         }
 

--- a/praxiscore-api/src/main/java/org/praxislive/core/Watch.java
+++ b/praxiscore-api/src/main/java/org/praxislive/core/Watch.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  * 
- * Copyright 2025 Neil C Smith.
+ * Copyright 2026 Neil C Smith.
  * 
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3 only, as
@@ -72,7 +72,7 @@ public final class Watch {
             Class<? extends Value> responseType) {
         return Info.control().function()
                 .outputs(Info.argument().type(responseType).build())
-                .property(WATCH_KEY, PMap.of(MIME_KEY, mimeType))
+                .attribute(WATCH_KEY, PMap.of(MIME_KEY, mimeType))
                 .build();
     }
 
@@ -83,7 +83,7 @@ public final class Watch {
      * @return true if a Watch control
      */
     public static boolean isWatch(ControlInfo info) {
-        return info.properties().get(WATCH_KEY) != null;
+        return info.attributes().get(WATCH_KEY) != null;
     }
 
 }

--- a/praxiscore-api/src/main/java/org/praxislive/core/protocols/SerializableProtocol.java
+++ b/praxiscore-api/src/main/java/org/praxislive/core/protocols/SerializableProtocol.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  * 
- * Copyright 2024 Neil C Smith.
+ * Copyright 2026 Neil C Smith.
  * 
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3 only, as
@@ -84,7 +84,7 @@ public final class SerializableProtocol implements Protocol {
      */
     public static final ControlInfo SERIALIZE_INFO
             = Info.control(c -> c.function()
-            .inputs(a -> a.type(PMap.class).property(ArgumentInfo.KEY_OPTIONAL, true))
+            .inputs(a -> a.type(PMap.class).attribute(ArgumentInfo.KEY_OPTIONAL, true))
             .outputs(a -> a.type(PMap.class)));
 
     /**

--- a/praxiscore-api/src/main/java/org/praxislive/core/services/LogService.java
+++ b/praxiscore-api/src/main/java/org/praxislive/core/services/LogService.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright 2020 Neil C Smith.
+ * Copyright 2026 Neil C Smith.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3 only, as
@@ -45,7 +45,7 @@ public class LogService implements Service {
                                 LogLevel.DEBUG.name()
                             ),
                             a -> a.type(Value.class)
-                                    .property(ArgumentInfo.KEY_VARARGS, PBoolean.TRUE))
+                                    .attribute(ArgumentInfo.KEY_VARARGS, PBoolean.TRUE))
             );
 
     @Override

--- a/praxiscore-api/src/main/java/org/praxislive/core/services/SystemManagerService.java
+++ b/praxiscore-api/src/main/java/org/praxislive/core/services/SystemManagerService.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright 2021 Neil C Smith.
+ * Copyright 2026 Neil C Smith.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3 only, as
@@ -38,8 +38,8 @@ public class SystemManagerService implements Service {
     public final static ControlInfo SYSTEM_EXIT_INFO
             = Info.control(c -> c.function()
                 .inputs(i -> i.type(PNumber.class)
-                    .property(PNumber.KEY_IS_INTEGER, PBoolean.TRUE)
-                    .property(ArgumentInfo.KEY_OPTIONAL, PBoolean.TRUE)
+                    .attribute(PNumber.KEY_IS_INTEGER, PBoolean.TRUE)
+                    .attribute(ArgumentInfo.KEY_OPTIONAL, PBoolean.TRUE)
                 )
             );
     

--- a/praxiscore-api/src/test/java/org/praxislive/core/InfoTest.java
+++ b/praxiscore-api/src/test/java/org/praxislive/core/InfoTest.java
@@ -74,16 +74,16 @@ public class InfoTest {
                 .protocol(StartableProtocol.class)
                 .control("p1", c -> c.property()
                         .input(a -> a.number().min(0).max(1)).defaultValue(PNumber.ONE)
-                        .property(ControlInfo.KEY_TRANSIENT, PBoolean.TRUE))
+                        .attribute(ControlInfo.KEY_TRANSIENT, PBoolean.TRUE))
                 .control("p2", c -> c.property()
                         .input(a -> a.string().template("public void draw(){"))
                         .defaultValue(PString.EMPTY))
                 .control("ro1", c -> c.readOnlyProperty()
                         .output(a -> a.number().min(0).max(1)))
-                .control("t1", c -> c.action().property("key", PString.of("value")))
+                .control("t1", c -> c.action().attribute("key", PString.of("value")))
                 .port("in", p -> p.input(ControlPort.class))
                 .port("out", p -> p.output(ControlPort.class))
-                .property(ComponentInfo.KEY_DYNAMIC, PBoolean.TRUE)
+                .attribute(ComponentInfo.KEY_DYNAMIC, PBoolean.TRUE)
                 
         );
         

--- a/praxiscore-api/src/test/java/org/praxislive/core/ValueMapperTest.java
+++ b/praxiscore-api/src/test/java/org/praxislive/core/ValueMapperTest.java
@@ -169,10 +169,10 @@ public class ValueMapperTest {
                 ArgumentInfo.of(PNumber.class, PMap.of(PNumber.KEY_IS_INTEGER, true)),
                 "flag", ArgumentInfo.of(PBoolean.class));
         ArgumentInfo info1 = r1mapper.createInfo();
-        assertEquals(schema, info1.properties().get(PMap.KEY_SCHEMA));
+        assertEquals(schema, info1.attributes().get(PMap.KEY_SCHEMA));
         ArgumentInfo info2 = r2mapper.createInfo();
         assertEquals(info1, PMap.from(
-                info2.properties().get(PMap.KEY_SCHEMA)).orElseThrow()
+                info2.attributes().get(PMap.KEY_SCHEMA)).orElseThrow()
                 .get("value")
         );
 

--- a/praxiscore-audio-components/src/main/java/org/praxislive/audio/impl/components/AudioInput.java
+++ b/praxiscore-audio-components/src/main/java/org/praxislive/audio/impl/components/AudioInput.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  * 
- * Copyright 2024 Neil C Smith.
+ * Copyright 2026 Neil C Smith.
  * 
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3 only, as
@@ -116,11 +116,11 @@ public class AudioInput extends AbstractComponent {
         if (info == null) {
             info = Info.component(cmp -> {
                 cmp.merge(ComponentProtocol.API_INFO);
-                cmp.property(ComponentInfo.KEY_COMPONENT_TYPE, ComponentType.of("audio:input"));
-                cmp.property(ComponentInfo.KEY_DYNAMIC, PBoolean.TRUE);
+                cmp.attribute(ComponentInfo.KEY_COMPONENT_TYPE, ComponentType.of("audio:input"));
+                cmp.attribute(ComponentInfo.KEY_DYNAMIC, PBoolean.TRUE);
                 cmp.control("channels", c -> c.property().input(a -> a
                         .number().min(1).max(MAX_CHANNELS)
-                        .property(PNumber.KEY_IS_INTEGER, PBoolean.TRUE)
+                        .attribute(PNumber.KEY_IS_INTEGER, PBoolean.TRUE)
                 ).defaultValue(PNumber.of(2)));
                 for (int i = 0; i < channelCount; i++) {
                     cmp.port(Port.OUT + "-" + (i + 1), p -> p.output(AudioPort.class));

--- a/praxiscore-audio-components/src/main/java/org/praxislive/audio/impl/components/AudioOutput.java
+++ b/praxiscore-audio-components/src/main/java/org/praxislive/audio/impl/components/AudioOutput.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  * 
- * Copyright 2024 Neil C Smith.
+ * Copyright 2026 Neil C Smith.
  * 
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3 only, as
@@ -116,11 +116,11 @@ public class AudioOutput extends AbstractComponent {
         if (info == null) {
             info = Info.component(cmp -> {
                 cmp.merge(ComponentProtocol.API_INFO);
-                cmp.property(ComponentInfo.KEY_DYNAMIC, PBoolean.TRUE);
-                cmp.property(ComponentInfo.KEY_COMPONENT_TYPE, ComponentType.of("audio:output"));
+                cmp.attribute(ComponentInfo.KEY_DYNAMIC, PBoolean.TRUE);
+                cmp.attribute(ComponentInfo.KEY_COMPONENT_TYPE, ComponentType.of("audio:output"));
                 cmp.control("channels", c -> c.property().input(a -> a
                         .number().min(1).max(MAX_CHANNELS)
-                        .property(PNumber.KEY_IS_INTEGER, PBoolean.TRUE)
+                        .attribute(PNumber.KEY_IS_INTEGER, PBoolean.TRUE)
                 ).defaultValue(PNumber.of(2)));
                 for (int i = 0; i < channelCount; i++) {
                     cmp.port(Port.IN + "-" + (i + 1), p -> p.input(AudioPort.class));

--- a/praxiscore-audio-components/src/main/java/org/praxislive/audio/impl/components/DefaultAudioRoot.java
+++ b/praxiscore-audio-components/src/main/java/org/praxislive/audio/impl/components/DefaultAudioRoot.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  * 
- * Copyright 2025 Neil C Smith.
+ * Copyright 2026 Neil C Smith.
  * 
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3 only, as
@@ -139,13 +139,13 @@ public class DefaultAudioRoot extends AbstractRootContainer {
                     .defaultValue(PNumber.of(DEFAULT_SAMPLERATE))
                     .input(a -> a.number()
                         .min(MIN_SAMPLERATE).max(MAX_SAMPLERATE)
-                    .property(PNumber.KEY_IS_INTEGER, PBoolean.TRUE)
+                    .attribute(PNumber.KEY_IS_INTEGER, PBoolean.TRUE)
                 ))
                 .control("block-size", c -> c.property()
                     .defaultValue(PNumber.of(DEFAULT_BLOCKSIZE))
                     .input(a -> a.number()
                         .min(1).max(MAX_BLOCKSIZE)
-                    .property(PNumber.KEY_IS_INTEGER, PBoolean.TRUE)
+                    .attribute(PNumber.KEY_IS_INTEGER, PBoolean.TRUE)
                 ))
                 .control("client-name", c -> c.property()
                     .defaultValue(PString.EMPTY)
@@ -160,8 +160,8 @@ public class DefaultAudioRoot extends AbstractRootContainer {
                                 libraries.keySet().stream().sorted())
                                 .toArray(String[]::new))
                 ))
-                .property(ComponentInfo.KEY_DYNAMIC, PBoolean.TRUE)
-                .property(ComponentInfo.KEY_COMPONENT_TYPE, ComponentType.of("root:audio"))
+                .attribute(ComponentInfo.KEY_DYNAMIC, PBoolean.TRUE)
+                .attribute(ComponentInfo.KEY_COMPONENT_TYPE, ComponentType.of("root:audio"))
         );
         info = baseInfo;
 

--- a/praxiscore-base/src/main/java/org/praxislive/base/AbstractComponent.java
+++ b/praxiscore-base/src/main/java/org/praxislive/base/AbstractComponent.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  * 
- * Copyright 2025 Neil C Smith.
+ * Copyright 2026 Neil C Smith.
  * 
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3 only, as
@@ -116,7 +116,7 @@ public abstract class AbstractComponent implements Component {
         if (parent == null) {
             // assume we're a root?!
             type = Optional.ofNullable(getInfo())
-                    .map(info -> info.properties().get(ComponentInfo.KEY_COMPONENT_TYPE))
+                    .map(info -> info.attributes().get(ComponentInfo.KEY_COMPONENT_TYPE))
                     .flatMap(ComponentType::from)
                     .orElse(null);
         } else {

--- a/praxiscore-base/src/main/java/org/praxislive/base/FilteredTypes.java
+++ b/praxiscore-base/src/main/java/org/praxislive/base/FilteredTypes.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright 2024 Neil C Smith.
+ * Copyright 2026 Neil C Smith.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3 only, as
@@ -255,7 +255,7 @@ public class FilteredTypes implements SupportedTypes {
                 c = p;
                 p = c.getParent();
             }
-            var type = c.getInfo().properties().getString(ComponentInfo.KEY_COMPONENT_TYPE, "");
+            var type = c.getInfo().attributes().getString(ComponentInfo.KEY_COMPONENT_TYPE, "");
             if (type.startsWith("root:")) {
                 return type.substring(5);
             } else {

--- a/praxiscore-code/src/main/java/org/praxislive/code/AnnotationUtils.java
+++ b/praxiscore-code/src/main/java/org/praxislive/code/AnnotationUtils.java
@@ -185,16 +185,16 @@ class AnnotationUtils {
         boolean ranged = min > PNumber.MIN_VALUE || max < PNumber.MAX_VALUE;
 
         Info.ValueInfoBuilder builder = Info.argument().type(PNumber.class);
-        builder.property(PNumber.KEY_IS_INTEGER, true);
+        builder.attribute(PNumber.KEY_IS_INTEGER, true);
         if (ranged) {
-            builder.property(PNumber.KEY_MINIMUM, min);
-            builder.property(PNumber.KEY_MAXIMUM, max);
+            builder.attribute(PNumber.KEY_MINIMUM, min);
+            builder.attribute(PNumber.KEY_MAXIMUM, max);
         }
         if (suggested.length > 0) {
             PArray vals = IntStream.of(suggested)
                     .mapToObj(PNumber::of)
                     .collect(PArray.collector());
-            builder.property(ArgumentInfo.KEY_SUGGESTED_VALUES, vals);
+            builder.attribute(ArgumentInfo.KEY_SUGGESTED_VALUES, vals);
         }
 
         ArgumentInfo info = builder.build();
@@ -262,9 +262,9 @@ class AnnotationUtils {
                             .collect(PArray.collector());
             ArgumentInfo info = Info.argument(a -> {
                 Info.ValueInfoBuilder bld = a.type(PResource.class)
-                        .property(PResource.KEY_ALLOW_EMPTY, true);
+                        .attribute(PResource.KEY_ALLOW_EMPTY, true);
                 if (!mimeTypes.isEmpty()) {
-                    bld.property(PResource.KEY_MIME_TYPES, mimeTypes);
+                    bld.attribute(PResource.KEY_MIME_TYPES, mimeTypes);
                 }
                 return bld;
             });

--- a/praxiscore-code/src/main/java/org/praxislive/code/CodeComponent.java
+++ b/praxiscore-code/src/main/java/org/praxislive/code/CodeComponent.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright 2024 Neil C Smith.
+ * Copyright 2026 Neil C Smith.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3 only, as
@@ -128,7 +128,7 @@ public class CodeComponent<D extends CodeDelegate> implements Component {
         if (parent == null) {
             // assume we're a root?!
             type = Optional.ofNullable(getInfo())
-                    .map(info -> info.properties().get(ComponentInfo.KEY_COMPONENT_TYPE))
+                    .map(info -> info.attributes().get(ComponentInfo.KEY_COMPONENT_TYPE))
                     .flatMap(ComponentType::from)
                     .orElse(null);
         } else {

--- a/praxiscore-code/src/main/java/org/praxislive/code/CodeConnector.java
+++ b/praxiscore-code/src/main/java/org/praxislive/code/CodeConnector.java
@@ -293,10 +293,10 @@ public abstract class CodeConnector<D extends CodeDelegate> {
      */
     protected void buildBaseComponentInfo(Info.ComponentInfoBuilder cmp) {
         cmp.merge(ComponentProtocol.API_INFO);
-        cmp.property(ComponentInfo.KEY_DYNAMIC, true);
-        cmp.property(ComponentInfo.KEY_COMPONENT_TYPE, factory.componentType());
+        cmp.attribute(ComponentInfo.KEY_DYNAMIC, true);
+        cmp.attribute(ComponentInfo.KEY_COMPONENT_TYPE, factory.componentType());
         if (!expose.isEmpty()) {
-            cmp.property(ComponentInfo.KEY_EXPOSE,
+            cmp.attribute(ComponentInfo.KEY_EXPOSE,
                     expose.stream()
                             .map(PString::of)
                             .collect(PArray.collector()));

--- a/praxiscore-code/src/main/java/org/praxislive/code/CodeRootContainer.java
+++ b/praxiscore-code/src/main/java/org/praxislive/code/CodeRootContainer.java
@@ -328,7 +328,7 @@ public class CodeRootContainer<D extends CodeRootContainerDelegate> extends Code
             super.buildBaseComponentInfo(cmp);
             cmp.merge(ContainerProtocol.API_INFO);
             if (displayHint != null) {
-                cmp.property(ComponentInfo.KEY_DISPLAY_HINT, displayHint);
+                cmp.attribute(ComponentInfo.KEY_DISPLAY_HINT, displayHint);
             }
         }
 

--- a/praxiscore-code/src/main/java/org/praxislive/code/FunctionDescriptor.java
+++ b/praxiscore-code/src/main/java/org/praxislive/code/FunctionDescriptor.java
@@ -234,7 +234,7 @@ class FunctionDescriptor extends ControlDescriptor<FunctionDescriptor> {
             controlInfo = Info.control().function()
                     .inputs(inputArgInfo)
                     .outputs(outputArgInfo)
-                    .property(Watch.WATCH_KEY, watchInfo)
+                    .attribute(Watch.WATCH_KEY, watchInfo)
                     .build();
         } else {
             controlInfo = Info.control().function()

--- a/praxiscore-code/src/main/java/org/praxislive/code/PropertyControl.java
+++ b/praxiscore-code/src/main/java/org/praxislive/code/PropertyControl.java
@@ -286,7 +286,7 @@ public class PropertyControl extends Property implements Control {
             propertyField = field;
             synthetic = false;
             if (info.controlType() == ControlInfo.Type.ReadOnlyProperty
-                    || info.properties().getBoolean(ControlInfo.KEY_TRANSIENT, false)) {
+                    || info.attributes().getBoolean(ControlInfo.KEY_TRANSIENT, false)) {
                 writable = false;
             } else {
                 writable = true;
@@ -402,7 +402,7 @@ public class PropertyControl extends Property implements Control {
                         binding.getDefaultValue(),
                         buildProperties(field));
             }
-            if (info.properties().getBoolean("preferred", false)) {
+            if (info.attributes().getBoolean("preferred", false)) {
                 connector.exposeForPreferred(id);
             }
             return new Descriptor(id, index, info, binding, propertyField, onChange, onError);

--- a/praxiscore-code/src/main/java/org/praxislive/code/ResourceProperty.java
+++ b/praxiscore-code/src/main/java/org/praxislive/code/ResourceProperty.java
@@ -282,9 +282,9 @@ public final class ResourceProperty<V> extends AbstractAsyncProperty<V> {
             Info.PropertyInfoBuilder infoBld = Info.control().property()
                     .input(a -> {
                         Info.ValueInfoBuilder bld = a.type(PResource.class)
-                                .property(PResource.KEY_ALLOW_EMPTY, true);
+                                .attribute(PResource.KEY_ALLOW_EMPTY, true);
                         if (!mimeTypes.isEmpty()) {
-                            bld.property(PResource.KEY_MIME_TYPES, mimeTypes);
+                            bld.attribute(PResource.KEY_MIME_TYPES, mimeTypes);
                         }
                         return bld;
                     })
@@ -292,7 +292,7 @@ public final class ResourceProperty<V> extends AbstractAsyncProperty<V> {
 
             boolean preferred = field.isAnnotationPresent(Config.Preferred.class);
             if (preferred) {
-                infoBld.property("preferred", true);
+                infoBld.attribute("preferred", true);
             }
             this.info = infoBld.build();
         }

--- a/praxiscore-hub-net/src/test/java/org/praxislive/hub/net/IonCodecTest.java
+++ b/praxiscore-hub-net/src/test/java/org/praxislive/hub/net/IonCodecTest.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright 2023 Neil C Smith.
+ * Copyright 2026 Neil C Smith.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3 only, as
@@ -192,7 +192,7 @@ public class IonCodecTest {
                 .merge(ComponentProtocol.API_INFO)
                 .port("in", Info.port().input(ControlPort.class).build())
                 .port("out", Info.port().output(ControlPort.class).build())
-                .property("custom", customProp)
+                .attribute("custom", customProp)
                 .build();
         var msg = new Message.Reply(matchID, List.of(info));
         var msgList = roundTrip(List.of(msg));
@@ -204,7 +204,7 @@ public class IonCodecTest {
         assertTrue(decodedInfo instanceof ComponentInfo);
         assertEquals(info, decodedInfo);
         var byteProp = ComponentInfo.from(decodedInfo)
-                .flatMap(i -> PMap.from(i.properties().get("custom")))
+                .flatMap(i -> PMap.from(i.attributes().get("custom")))
                 .map(m -> m.get("data"))
                 .orElseThrow();
         assertEquals(bytes, byteProp);

--- a/praxiscore-script/src/main/java/org/praxislive/script/commands/AtCmds.java
+++ b/praxiscore-script/src/main/java/org/praxislive/script/commands/AtCmds.java
@@ -139,7 +139,7 @@ class AtCmds {
                                 .flatMap(v -> ComponentInfo.from(v).stream())
                                 .flatMap(ci -> {
                                     return Optional.ofNullable(
-                                            ci.properties().get(ComponentInfo.KEY_COMPONENT_TYPE))
+                                            ci.attributes().get(ComponentInfo.KEY_COMPONENT_TYPE))
                                             .flatMap(ComponentType::from)
                                             .stream();
                                 }).findFirst().orElse(null);

--- a/praxiscore-script/src/test/java/org/praxislive/script/DefaultScriptServiceTest.java
+++ b/praxiscore-script/src/test/java/org/praxislive/script/DefaultScriptServiceTest.java
@@ -267,7 +267,7 @@ public class DefaultScriptServiceTest {
         var root = new DefaultScriptService();
         try (var hub = new RootHubImpl("script", root)) {
             ComponentInfo info = Info.component()
-                    .property(ComponentInfo.KEY_COMPONENT_TYPE, "test:component")
+                    .attribute(ComponentInfo.KEY_COMPONENT_TYPE, "test:component")
                     .control("value", ci -> ci.property().input(a -> a.string()))
                     .build();
 

--- a/praxiscore-video-components/src/main/java/org/praxislive/video/impl/components/DefaultVideoRoot.java
+++ b/praxiscore-video-components/src/main/java/org/praxislive/video/impl/components/DefaultVideoRoot.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  * 
- * Copyright 2025 Neil C Smith.
+ * Copyright 2026 Neil C Smith.
  * 
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3 only, as
@@ -135,7 +135,7 @@ public class DefaultVideoRoot extends AbstractRootContainer {
                     .defaultValue(PBoolean.TRUE)
                     .input(PBoolean.class)
                 )
-                .property(ComponentInfo.KEY_COMPONENT_TYPE, ComponentType.of("root:video"))
+                .attribute(ComponentInfo.KEY_COMPONENT_TYPE, ComponentType.of("root:video"))
         );
 
         ctxt = new VideoContextImpl();

--- a/praxiscore-video-components/src/main/java/org/praxislive/video/impl/components/VideoOutput.java
+++ b/praxiscore-video-components/src/main/java/org/praxislive/video/impl/components/VideoOutput.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  * 
- * Copyright 2024 Neil C Smith.
+ * Copyright 2026 Neil C Smith.
  * 
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License version 3 only, as
@@ -82,25 +82,25 @@ public class VideoOutput extends AbstractComponent {
                     .defaultValue(PString.EMPTY))
                 .control("device", c -> c.property().input(a -> a
                         .type(Value.class)
-                        .property(ArgumentInfo.KEY_EMPTY_IS_DEFAULT, PBoolean.TRUE)
-                        .property(ArgumentInfo.KEY_SUGGESTED_VALUES,
+                        .attribute(ArgumentInfo.KEY_EMPTY_IS_DEFAULT, PBoolean.TRUE)
+                        .attribute(ArgumentInfo.KEY_SUGGESTED_VALUES,
                                 IntStream.of(0, 1, 2, 3).mapToObj(PNumber::of).collect(PArray.collector())
                         ))
                     .defaultValue(PString.EMPTY))
                 .control("width", c -> c.property().input(a -> a
                         .type(Value.class)
-                        .property(ArgumentInfo.KEY_EMPTY_IS_DEFAULT, PBoolean.TRUE))
+                        .attribute(ArgumentInfo.KEY_EMPTY_IS_DEFAULT, PBoolean.TRUE))
                     .defaultValue(PString.EMPTY)
                 )
                 .control("height", c -> c.property().input(a -> a
                         .type(Value.class)
-                        .property(ArgumentInfo.KEY_EMPTY_IS_DEFAULT, PBoolean.TRUE))
+                        .attribute(ArgumentInfo.KEY_EMPTY_IS_DEFAULT, PBoolean.TRUE))
                     .defaultValue(PString.EMPTY)
                 )
                 .control("rotation", c -> c.property().input(a -> a
                         .type(Value.class)
-                        .property(ArgumentInfo.KEY_EMPTY_IS_DEFAULT, PBoolean.TRUE)
-                        .property(ArgumentInfo.KEY_SUGGESTED_VALUES,
+                        .attribute(ArgumentInfo.KEY_EMPTY_IS_DEFAULT, PBoolean.TRUE)
+                        .attribute(ArgumentInfo.KEY_SUGGESTED_VALUES,
                                 IntStream.of(0, 90, 180, 270).mapToObj(PNumber::of).collect(PArray.collector())
                         ))
                     .defaultValue(PString.EMPTY))
@@ -110,7 +110,7 @@ public class VideoOutput extends AbstractComponent {
                 .control("show-cursor", c -> c.property().input(PBoolean.class).defaultValue(PBoolean.FALSE))
 
                 .port("in", p -> p.input(VideoPort.class))
-                .property(ComponentInfo.KEY_COMPONENT_TYPE, ComponentType.of("video:output"))
+                .attribute(ComponentInfo.KEY_COMPONENT_TYPE, ComponentType.of("video:output"))
         );
 
         device = new IntegerProperty();


### PR DESCRIPTION
Rename properties as attributes on ComponentInfo and related classes to avoid confusion with property controls, etc.

Add attribute methods replacing property methods on info types. Deprecate property methods for removal.