### PR TITLE
Only log delegate not updating time if delegate does not hold lock.

### DIFF
--- a/praxiscore-base/src/main/java/org/praxislive/base/AbstractRoot.java
+++ b/praxiscore-base/src/main/java/org/praxislive/base/AbstractRoot.java
@@ -981,8 +981,8 @@ public abstract class AbstractRoot implements Root {
             if (forceUpdateAfterNS > 0 && delta > forceUpdateAfterNS) {
                 return true;
             }
-            if (Math.abs(delta) > 10_000_000_000L) {
-                LOG.log(System.Logger.Level.ERROR, "Delegate not updating time");
+            if (Math.abs(delta) > 10_000_000_000L && !lock.isLocked()) {
+                LOG.log(System.Logger.Level.WARNING, "Delegate not updating time");
             }
             return false;
         }


### PR DESCRIPTION
Only log delegate not updating time if delegate does not hold lock. Stop log becoming noisy in cases where a dialog is opened on the EDT, etc.